### PR TITLE
Fix Env Check partial-data assertion

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -88,6 +88,7 @@ Bootstrap entrypoints:
 - Standalone CFO HTML output was removed from the artifact contract and daily email flow; CFO KPI logic now lives only inside the main report.
 - Daily SES email now attaches only the main HTML report.
 - Legacy March `__test` artifacts were removed locally; `__test2` remains only as a reference snapshot.
+- Env Check CI baseline now validates partial-data rendering in the active HTML layer (`html_report_generator.py` / `dashboard_test2.py`) instead of the retired daily runner rendering path.
 
 ## 8) Next Exact Step
 
@@ -118,6 +119,15 @@ Bootstrap entrypoints:
 - Verified syntax via python -m py_compile export_orders.py html_report_generator.py.
 - Revised Week-of-Month methodology to remove day-count bias:
   - uses only days 1-28 (4x7 equal windows),
+
+### 2026-04-03
+- Fixed false-positive `Env Check` / `security-baseline` CI failure after promoting the modern dashboard renderer:
+  - `scripts/security_ci.py` no longer expects the `Partial Data` marker inside `daily_report_runner.py`,
+  - CI now validates partial-data rendering in the actual HTML layer (`html_report_generator.py` and `dashboard_test2.py`),
+  - retained a runner-level assertion that the main HTML report artifact is still attached by `daily_report_runner.py`.
+- Verified locally with:
+  - `python scripts/security_ci.py`
+  - `python -m py_compile scripts/security_ci.py`
   - uses full months only (drops partial first/last month for this metric),
   - daily normalization uses calendar_days (includes zero-order days).
 - Added fairness diagnostics in table: `Calendar Days` and `Active Day Rate`.

--- a/scripts/security_ci.py
+++ b/scripts/security_ci.py
@@ -28,6 +28,8 @@ def main() -> int:
         facebook_ads = read("facebook_ads.py")
         export_orders = read("export_orders.py")
         daily_runner = read("daily_report_runner.py")
+        html_report_generator = read("html_report_generator.py")
+        dashboard_test2 = read("dashboard_test2.py")
         http_client = read("http_client.py")
         weather_client = read("weather_client.py")
         read("templates/reporting-client/settings.template.json")
@@ -77,8 +79,13 @@ def main() -> int:
         )
         require(
             daily_runner,
+            "report_html",
+            "daily_report_runner.py must still attach the generated main HTML report artifact.",
+        )
+        require(
+            html_report_generator + dashboard_test2,
             "Partial Data",
-            "daily_report_runner.py must render partial-data status for generated reports.",
+            "HTML rendering layer must expose explicit partial-data status for generated reports.",
         )
         require(
             read(".github/workflows/observability-check.yml"),


### PR DESCRIPTION
## Summary\n- fix the security baseline check after the renderer move to the modern dashboard\n- validate partial-data rendering in the actual HTML layer instead of daily_report_runner.py\n- keep a runner-level assertion that the main HTML artifact is still attached\n\n## Verification\n- python scripts/security_ci.py\n- python -m py_compile scripts/security_ci.py