### PR TITLE
Upgrade GitHub Actions workflow pins to v6

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5.1.1
+        uses: aws-actions/configure-aws-credentials@v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/env-check.yml
+++ b/.github/workflows/env-check.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Validate required env keys against template
         run: |
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Baseline security assertions
         run: |

--- a/.github/workflows/observability-check.yml
+++ b/.github/workflows/observability-check.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -687,3 +687,10 @@ Next exact step:
 - This uses GitHub's documented opt-in path so JavaScript actions execute on Node 24 now, instead of waiting for the future runner default switch.
 - Next exact step:
   - push the branch, run/observe the next workflow execution, and confirm the deprecation annotation is gone.
+### 2026-04-08 (GitHub Actions v6 action pins)
+- After validating the GitHub release feeds, upgraded workflow pins further to the current major releases:
+  - `actions/checkout@v6.0.2`
+  - `aws-actions/configure-aws-credentials@v6.1.0`
+- Kept the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workflow env override in place as an additional safety measure during the Node 24 transition window.
+- Next exact step:
+  - push the branch, merge it, and verify on the next `Build and Push ECR` run that the old Node 20 deprecation annotation no longer appears.


### PR DESCRIPTION
## Summary\n- upgrade workflow action pins to the current major releases\n- move actions/checkout to v6.0.2 everywhere\n- move aws-actions/configure-aws-credentials to v6.1.0 in the ECR workflow\n- keep the Node 24 opt-in override in place during the transition window\n- update PROJECT_STATE.md\n\n## Verification\n- verified latest release tags via GitHub releases\n- reviewed workflow diffs for all affected files\n- next GitHub Actions run will confirm the old Node 20 deprecation annotation is gone\n