### PR TITLE
Add attribution QA guardrails to reporting

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -727,3 +727,27 @@ Next exact step:
   - VEVO shell `Google CPO` now shows `N/A`,
   - ROY shell economics cards show real values and keep numeric Google CPO,
   - no remaining `null` hydration symptoms were found in generated HTML for weekday / attach-rate / geo consumer labels during targeted checks.
+- Follow-up hardening completed:
+  - added explicit attribution QA metadata into `source_health.qa.attribution`,
+  - QA now evaluates campaign spend coverage, oversubscription and platform CPA arithmetic mismatches,
+  - `source_health.overall_status` now escalates to `warning` when QA warnings exist even if raw sources loaded cleanly,
+  - modern dashboard now surfaces attribution QA twice:
+    - as a health card in the source health grid,
+    - as a dedicated marketing panel (`Attribution QA guardrails`) with coverage, oversubscription, campaign-row count and CPA mismatch count,
+  - fixed mojibake / bad currency rendering inside the modern marketing section (`&euro;`, ASCII-safe SK copy for reconciliation text),
+  - added CI assertions so regressions fail if:
+    - attribution QA builder is removed from export,
+    - campaign attribution summary disappears,
+    - dashboard stops rendering the attribution QA panel.
+- Verified with:
+  - `python -m py_compile dashboard_modern.py export_orders.py facebook_ads.py scripts\\security_ci.py`
+  - `python scripts\\security_ci.py`
+  - `python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31`
+  - `python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31`
+- Verification outcome:
+  - VEVO `data_quality_20260301-20260331.json` now contains attribution QA metadata with `qa_status=ok`,
+  - ROY `data_quality_20260301-20260331.json` now contains attribution QA metadata with `qa_status=warning`,
+  - VEVO and ROY modern reports render the new QA panel and reconciliation values with proper euro symbols,
+  - ROY now explicitly warns in dashboard that campaign-level Facebook spend coverage is missing while daily spend exists.
+- Next exact step:
+  - add thresholded attribution warning banners to the hero/executive shell so severe coverage or oversubscription issues are visible before the user reaches the marketing section.

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -533,6 +533,19 @@ def generate_modern_dashboard(
         limit=6,
     )
     source_rows = list(((source_health or {}).get("sources") or {}).values())
+    qa_rows = []
+    for key, value in (((source_health or {}).get("qa") or {}).items()):
+        if not isinstance(value, dict):
+            continue
+        qa_rows.append(
+            {
+                "key": key,
+                "label": value.get("label") or key,
+                "status": value.get("status") or "unknown",
+                "healthy": value.get("healthy", value.get("status") == "ok"),
+                "message": value.get("message") or "-",
+            }
+        )
     embedded_period_reports = embedded_period_reports or {}
     customer_top_rows = _top_rows(
         (customer_concentration or {}).get("top_10_customers"),
@@ -1140,10 +1153,11 @@ def generate_modern_dashboard(
         for row in segment_rows
     ) or '<tr><td colspan="5"><span class="lang-en">No email segmentation data available.</span><span class="lang-sk hidden">Email segmentácia nie je dostupná.</span></td></tr>'
 
+    health_cards = source_rows + qa_rows
     health_html = "".join(
-        f'<div class="health-item"><div class="health-title">{escape(str(row.get("label") or row.get("key") or "Source"))}</div><div class="health-status {("good" if row.get("healthy") else ("warn" if row.get("status") == "degraded" else "bad"))}">{escape(str(row.get("status") or "unknown"))}</div><p>{escape(str(row.get("message") or row.get("mode") or "-"))}</p></div>'
-        for row in source_rows
-    ) or '<div class="health-item"><div class="health-title"><span class="lang-en">Source health</span><span class="lang-sk hidden">Stav zdrojov</span></div><div class="health-status good">ok</div><p><span class="lang-en">No source warnings attached to this run.</span><span class="lang-sk hidden">K tomuto behu nie sú pripojené žiadne varovania zdrojov.</span></p></div>'
+        f'<div class="health-item"><div class="health-title">{escape(str(row.get("label") or row.get("key") or "Source"))}</div><div class="health-status {("good" if row.get("healthy") else ("warn" if row.get("status") in {"warning", "degraded"} else "bad"))}">{escape(str(row.get("status") or "unknown"))}</div><p>{escape(str(row.get("message") or row.get("mode") or "-"))}</p></div>'
+        for row in health_cards
+    ) or '<div class="health-item"><div class="health-title"><span class="lang-en">Source health</span><span class="lang-sk hidden">Stav zdrojov</span></div><div class="health-status good">ok</div><p><span class="lang-en">No source warnings attached to this run.</span><span class="lang-sk hidden">K tomuto behu nie su pripojene ziadne varovania zdrojov.</span></p></div>'
 
     period_switcher_html = _period_switcher_html(period_switcher)
     refund_summary = (refunds_analysis or {}).get("summary", {})
@@ -1153,6 +1167,12 @@ def generate_modern_dashboard(
     avg_days_between = _maybe_num(cohort_summary.get("avg_days_between_orders"))
     top_10_share = _num((customer_concentration or {}).get("top_10_pct_revenue_share"))
     top_20_share = _num((customer_concentration or {}).get("top_20_pct_revenue_share"))
+    attribution_qa = (((source_health or {}).get("qa") or {}).get("attribution") or {})
+    attribution_warnings = [str(item) for item in list(attribution_qa.get("warnings") or []) if str(item).strip()]
+    attribution_warning_items_html = "".join(
+        f"<li>{escape(item)}</li>"
+        for item in attribution_warnings
+    ) or '<li><span class="lang-en">Attribution QA passed for this period.</span><span class="lang-sk hidden">Attribution QA pre toto obdobie presla bez warningov.</span></li>'
 
     html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -1270,6 +1290,8 @@ def generate_modern_dashboard(
         .health-status.good {{ color:#11633f; background: rgba(31,157,102,.12); }}
         .health-status.warn {{ color:#a75300; background: rgba(255,138,31,.12); }}
         .health-status.bad {{ color:#a22d40; background: rgba(207,80,96,.12); }}
+        .warning-list {{ margin: 16px 0 0; padding-left: 18px; }}
+        .warning-list li {{ margin: 8px 0; color: var(--muted); }}
         table {{ width:100%; border-collapse: collapse; }}
         th, td {{ text-align:left; padding: 11px 8px; border-bottom: 1px solid rgba(234,223,206,.85); font-size: 13px; }}
         th {{ color: var(--muted); font-size: 11px; font-weight: 800; text-transform: uppercase; letter-spacing:.08em; }}
@@ -1513,17 +1535,28 @@ def generate_modern_dashboard(
                             </table>
                         </div>
                         <div class="panel table-card">
-                            <div class="card-head"><div><h3><span class="lang-en">FB spend reconciliation</span><span class="lang-sk hidden">FB spend reconciliation</span></h3><p><span class="lang-en">Daily-source spend versus campaign-source spend from the original reconciliation check.</span><span class="lang-sk hidden">Denný source spend oproti campaign source spendu z povodnej reconciliation kontroly.</span></p></div></div>
+                            <div class="card-head"><div><h3><span class="lang-en">FB spend reconciliation</span><span class="lang-sk hidden">FB spend reconciliation</span></h3><p><span class="lang-en">Daily-source spend versus campaign-source spend from the original reconciliation check.</span><span class="lang-sk hidden">Denny source spend oproti campaign source spendu z povodnej reconciliation kontroly.</span></p></div></div>
                             <table>
                                 <thead><tr><th><span class="lang-en">Metric</span><span class="lang-sk hidden">Metrika</span></th><th><span class="lang-en">Value</span><span class="lang-sk hidden">Hodnota</span></th></tr></thead>
                                 <tbody>
-                                    <tr><td><span class="lang-en">Daily source spend</span><span class="lang-sk hidden">Daily source spend</span></td><td>â‚¬{_num(((cost_per_order or {}).get('fb_spend_reconciliation') or {}).get('daily_source_spend')):,.2f}</td></tr>
-                                    <tr><td><span class="lang-en">Campaign source spend</span><span class="lang-sk hidden">Campaign source spend</span></td><td>â‚¬{_num(((cost_per_order or {}).get('fb_spend_reconciliation') or {}).get('campaign_source_spend')):,.2f}</td></tr>
-                                    <tr><td><span class="lang-en">Difference</span><span class="lang-sk hidden">Rozdiel</span></td><td>â‚¬{_num(((cost_per_order or {}).get('fb_spend_reconciliation') or {}).get('difference')):,.2f}</td></tr>
+                                    <tr><td><span class="lang-en">Daily source spend</span><span class="lang-sk hidden">Denny source spend</span></td><td>&euro;{_num(((cost_per_order or {}).get('fb_spend_reconciliation') or {}).get('daily_source_spend')):,.2f}</td></tr>
+                                    <tr><td><span class="lang-en">Campaign source spend</span><span class="lang-sk hidden">Campaign source spend</span></td><td>&euro;{_num(((cost_per_order or {}).get('fb_spend_reconciliation') or {}).get('campaign_source_spend')):,.2f}</td></tr>
+                                    <tr><td><span class="lang-en">Difference</span><span class="lang-sk hidden">Rozdiel</span></td><td>&euro;{_num(((cost_per_order or {}).get('fb_spend_reconciliation') or {}).get('difference')):,.2f}</td></tr>
                                     <tr><td><span class="lang-en">Difference %</span><span class="lang-sk hidden">Rozdiel %</span></td><td>{_num(((cost_per_order or {}).get('fb_spend_reconciliation') or {}).get('difference_pct')):.2f}%</td></tr>
                                 </tbody>
                             </table>
                         </div>
+                    </div>
+
+                    <div class="panel table-card" style="margin-top:18px;">
+                        <div class="card-head"><div><h3><span class="lang-en">Attribution QA guardrails</span><span class="lang-sk hidden">Attribution QA guardrails</span></h3><p><span class="lang-en">Coverage and oversubscription checks that catch attribution fallback problems early.</span><span class="lang-sk hidden">Kontroly coverage a oversubscription, ktore skoro zachytia problemy s attribution fallbackom.</span></p></div></div>
+                        <div class="mini-grid">
+                            <div class="mini-card"><small><span class="lang-en">Coverage ratio</span><span class="lang-sk hidden">Coverage ratio</span></small><strong>{_format_mini_value_html(attribution_qa.get("coverage_ratio"), kind="multiple")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Oversubscription</span><span class="lang-sk hidden">Oversubscription</span></small><strong>{_format_mini_value_html(attribution_qa.get("oversubscription_ratio"), kind="multiple")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Campaign rows</span><span class="lang-sk hidden">Pocet kampani</span></small><strong>{int(round(_num(attribution_qa.get("campaign_rows"))))}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">CPA mismatches</span><span class="lang-sk hidden">CPA nezrovnalosti</span></small><strong>{int(round(_num(attribution_qa.get("platform_cost_mismatch_count"))))}</strong></div>
+                        </div>
+                        <ul class="warning-list">{attribution_warning_items_html}</ul>
                     </div>
 
                     <div class="grid-2" style="margin-top:18px;">

--- a/export_orders.py
+++ b/export_orders.py
@@ -614,17 +614,134 @@ class BizniWebExporter:
         return entry
 
     @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        try:
+            if pd.isna(value):
+                return None
+        except TypeError:
+            pass
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _build_attribution_qa(
+        cls,
+        *,
+        cost_per_order: Optional[Dict[str, Any]],
+        fb_campaigns: Optional[List[Dict[str, Any]]],
+        total_orders: int,
+    ) -> Dict[str, Any]:
+        reconciliation = ((cost_per_order or {}).get("fb_spend_reconciliation") or {})
+        summary = ((cost_per_order or {}).get("campaign_attribution_summary") or {})
+        campaign_rows = list((cost_per_order or {}).get("campaign_attribution") or [])
+        daily_source_spend = cls._safe_float(summary.get("daily_source_spend"))
+        if daily_source_spend is None:
+            daily_source_spend = cls._safe_float(reconciliation.get("daily_source_spend"))
+        campaign_source_spend = cls._safe_float(summary.get("campaign_source_spend"))
+        if campaign_source_spend is None:
+            campaign_source_spend = cls._safe_float(reconciliation.get("campaign_source_spend"))
+        coverage_ratio = cls._safe_float(summary.get("coverage_ratio"))
+        if coverage_ratio is None:
+            coverage_ratio = cls._safe_float(reconciliation.get("coverage_ratio"))
+        estimated_orders_total = cls._safe_float(summary.get("estimated_orders_total"))
+        oversubscription_ratio = cls._safe_float(summary.get("oversubscription_ratio"))
+        warnings: List[str] = []
+
+        if (daily_source_spend or 0) > 0 and (campaign_source_spend is None or campaign_source_spend <= 0):
+            warnings.append("Campaign-level Facebook spend is missing while daily Facebook spend exists.")
+        elif coverage_ratio is None and (daily_source_spend or 0) > 0:
+            warnings.append("Campaign spend coverage ratio is unavailable for a period with Facebook spend.")
+        elif coverage_ratio is not None and (coverage_ratio < 0.90 or coverage_ratio > 1.10):
+            warnings.append(
+                f"Campaign spend coverage ratio is {coverage_ratio:.2f}x. Expected range is 0.90x-1.10x."
+            )
+
+        if total_orders > 0 and not campaign_rows and (daily_source_spend or 0) > 0:
+            warnings.append("Campaign attribution table is empty although Facebook daily spend exists.")
+        if oversubscription_ratio is not None and oversubscription_ratio > 1.05:
+            warnings.append(
+                f"Attributed campaign orders sum to {oversubscription_ratio:.2f}x of total orders. Attribution fallback is likely overstating campaign output."
+            )
+
+        platform_rows_checked = 0
+        platform_cost_mismatch_count = 0
+        for row in fb_campaigns or []:
+            spend = cls._safe_float(row.get("spend"))
+            platform_conversions = cls._safe_float(row.get("platform_conversions", row.get("conversions")))
+            platform_cpa = cls._safe_float(
+                row.get("cost_per_platform_conversion", row.get("cost_per_conversion"))
+            )
+            if spend is None:
+                continue
+            if platform_conversions is None or platform_conversions <= 0:
+                continue
+            platform_rows_checked += 1
+            expected_cpa = spend / platform_conversions
+            if platform_cpa is None or abs(expected_cpa - platform_cpa) > 0.05:
+                platform_cost_mismatch_count += 1
+
+        if platform_cost_mismatch_count > 0:
+            warnings.append(
+                f"{platform_cost_mismatch_count} campaign row(s) have platform CPA that does not match spend/platform conversions."
+            )
+
+        status = "warning" if warnings else "ok"
+        message = (
+            "Campaign attribution QA passed: coverage, attribution totals, and platform CPA are within tolerance."
+            if not warnings
+            else warnings[0]
+        )
+        return {
+            "key": "attribution",
+            "label": "Campaign Attribution QA",
+            "status": status,
+            "healthy": not warnings,
+            "message": message,
+            "warnings": warnings,
+            "coverage_ratio": round(coverage_ratio, 4) if coverage_ratio is not None else None,
+            "oversubscription_ratio": round(oversubscription_ratio, 4) if oversubscription_ratio is not None else None,
+            "daily_source_spend": round(daily_source_spend, 2) if daily_source_spend is not None else None,
+            "campaign_source_spend": round(campaign_source_spend, 2) if campaign_source_spend is not None else None,
+            "estimated_orders_total": round(estimated_orders_total, 1) if estimated_orders_total is not None else None,
+            "total_orders": int(total_orders),
+            "campaign_rows": len(campaign_rows),
+            "platform_rows_checked": platform_rows_checked,
+            "platform_cost_mismatch_count": platform_cost_mismatch_count,
+            "attribution_method": summary.get("attribution_method") or "unknown",
+        }
+
+    @staticmethod
     def _finalize_source_health(source_health: Dict[str, Any]) -> Dict[str, Any]:
         sources = list((source_health.get("sources") or {}).values())
         degraded = [source["label"] for source in sources if source.get("status") in {"warning", "error"}]
-        source_health["overall_status"] = "partial" if degraded else "full"
+        qa_checks = list((source_health.get("qa") or {}).values())
+        qa_warnings = [check.get("label") or check.get("key") or "QA" for check in qa_checks if check.get("status") == "warning"]
+        if degraded:
+            overall_status = "partial"
+        elif qa_warnings:
+            overall_status = "warning"
+        else:
+            overall_status = "full"
+        source_health["overall_status"] = overall_status
         source_health["is_partial"] = bool(degraded)
         source_health["partial_sources"] = degraded
+        source_health["qa_status"] = "warning" if qa_warnings else "ok"
+        source_health["qa_warnings"] = qa_warnings
         if degraded:
             source_health["summary"] = (
                 "Partial data: "
                 + ", ".join(degraded)
                 + " did not load cleanly in this run. Metrics depending on these sources may be incomplete or zero-filled."
+            )
+        elif qa_warnings:
+            source_health["summary"] = (
+                "Data sources loaded, but QA warnings were raised for "
+                + ", ".join(qa_warnings)
+                + ". Treat attribution-style metrics with caution."
             )
         else:
             source_health["summary"] = "All enabled external sources loaded successfully for this run."
@@ -2075,7 +2192,6 @@ class BizniWebExporter:
                 message="Weather enrichment is not configured for this project/runtime.",
                 healthy=True,
             )
-        source_health = self._finalize_source_health(source_health)
 
         # Calculate financial metrics
         financial_metrics = self.calculate_financial_metrics(df, date_agg, clv_return_time_analysis)
@@ -2093,6 +2209,12 @@ class BizniWebExporter:
             fb_campaigns,
             reference_total_revenue=financial_metrics.get('total_revenue')
         )
+        source_health.setdefault("qa", {})["attribution"] = self._build_attribution_qa(
+            cost_per_order=cost_per_order,
+            fb_campaigns=fb_campaigns,
+            total_orders=int(df["order_num"].nunique()) if "order_num" in df.columns else len(orders),
+        )
+        source_health = self._finalize_source_health(source_health)
 
         # Display aggregated data
         self.display_aggregated_data(date_product_agg, date_agg, month_agg)

--- a/scripts/security_ci.py
+++ b/scripts/security_ci.py
@@ -74,6 +74,16 @@ def main() -> int:
         )
         require(
             export_orders,
+            "_build_attribution_qa",
+            "export_orders.py must build attribution QA guardrails before report export.",
+        )
+        require(
+            export_orders,
+            "campaign_attribution_summary",
+            "export_orders.py must keep campaign attribution summary metadata.",
+        )
+        require(
+            export_orders,
             "\"is_partial\"",
             "export_orders.py must persist partial-data state in source health metadata.",
         )
@@ -86,6 +96,11 @@ def main() -> int:
             html_report_generator + dashboard_modern,
             "Partial Data",
             "HTML rendering layer must expose explicit partial-data status for generated reports.",
+        )
+        require(
+            dashboard_modern,
+            "Attribution QA guardrails",
+            "Modern dashboard must surface attribution QA warnings explicitly.",
         )
         require(
             read(".github/workflows/observability-check.yml"),


### PR DESCRIPTION
## Summary\n- add attribution QA metadata to source health and escalate report health to warning when coverage checks fail\n- surface attribution QA directly in the modern dashboard marketing section and source health grid\n- add CI assertions for attribution QA presence and dashboard rendering\n\n## Verification\n- python -m py_compile dashboard_modern.py export_orders.py facebook_ads.py scripts/security_ci.py\n- python scripts/security_ci.py\n- python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31\n- python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31