### PR TITLE
Add Roy bundle/accessory model

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -101,7 +101,7 @@ Bootstrap entrypoints:
 
 ## 8) Next Exact Step
 
-- Add explicit attribution QA guardrails into the pipeline and surface campaign-attribution coverage / oversubscription warnings directly in the dashboard.
+- Add cohort-normalized CAC / LTV / payback views so marketing efficiency is comparable by acquisition cohort instead of only global aggregate shortcuts.
 
 ## 9) Change Log
 
@@ -118,6 +118,12 @@ Bootstrap entrypoints:
   - added `reporting_core.runtime` with `ProjectRuntime` and reusable runtime application/loading helpers,
   - added `reporting_core.contracts` with `ReportingArtifactSet` + canonical output artifact builder,
   - switched `export_orders.py`, `daily_report_runner.py`, and `generate_invoices.py` to import from `reporting_core`,
+
+### 2026-04-10
+- Added Roy bundle/accessory model as a first-class advanced DTC metric using project-configured anchor device families and accessory groups.
+- Bundle/accessory outputs now include pair-level attach rate and contribution uplift, device family summary, and accessory group quality summary.
+- Modern dashboard now renders Roy bundle/accessory charts in the Products/Operations library without changing the current production shell.
+- Verified with real Roy March 2026 export: HTML report generated successfully and new bundle/accessory chart IDs are present in the rendered output.
   - updated daily runner to consume the shared artifact contract instead of rebuilding output paths ad hoc,
   - verified syntax with `python -m py_compile export_orders.py daily_report_runner.py generate_invoices.py project_config.py reporting_core\\__init__.py reporting_core\\config.py reporting_core\\runtime.py reporting_core\\contracts.py`,
   - verified ROY smoke export on `2026-03-01..2026-03-02`,

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -766,6 +766,7 @@ def generate_modern_dashboard(
     )
 
     advanced_summary = (advanced_dtc_metrics or {}).get("summary", {}) if advanced_dtc_metrics else {}
+    bundle_accessory_model = (advanced_dtc_metrics or {}).get("bundle_accessory_model", {}) if advanced_dtc_metrics else {}
     basket_contribution_rows = _frame_rows((advanced_dtc_metrics or {}).get("basket_contribution"), ["basket_size", "orders", "revenue", "pre_ad_contribution", "contribution_per_order", "contribution_margin_pct"], limit=10)
     sku_pareto_rows = _normalize_sku_pareto_rows(
         _frame_rows((advanced_dtc_metrics or {}).get("sku_pareto"), ["sku", "product", "orders", "revenue", "pre_ad_contribution", "cum_contribution_pct", "cum_contribution_share_pct"], limit=12)
@@ -778,6 +779,50 @@ def generate_modern_dashboard(
     )
     payday_window_rows = _frame_rows((advanced_dtc_metrics or {}).get("payday_window"), ["window", "orders", "revenue", "profit", "avg_daily_revenue", "avg_daily_profit"], limit=20)
     cohort_payback_rows = _frame_rows((advanced_dtc_metrics or {}).get("cohort_payback"), ["cohort_month", "new_customers", "cohort_cac", "recovery_rate_pct", "avg_payback_days", "median_payback_days"], limit=24)
+    bundle_accessory_pair_rows = _frame_rows(
+        (bundle_accessory_model or {}).get("pair_rows"),
+        [
+            "anchor_group_label",
+            "accessory_group_label",
+            "anchor_orders",
+            "attached_orders",
+            "attach_rate_pct",
+            "avg_order_value_with_accessory",
+            "avg_order_value_without_accessory",
+            "avg_pre_ad_contribution_with_accessory",
+            "avg_pre_ad_contribution_without_accessory",
+            "revenue_uplift_per_order",
+            "contribution_uplift_per_order",
+        ],
+        limit=18,
+    )
+    bundle_accessory_device_rows = _frame_rows(
+        (bundle_accessory_model or {}).get("device_family_rows"),
+        [
+            "anchor_group_label",
+            "anchor_orders",
+            "anchor_avg_order_value",
+            "anchor_avg_pre_ad_contribution",
+            "best_accessory_group_label",
+            "best_attach_rate_pct",
+            "best_contribution_uplift_per_order",
+            "best_revenue_uplift_per_order",
+        ],
+        limit=12,
+    )
+    bundle_accessory_group_rows = _frame_rows(
+        (bundle_accessory_model or {}).get("accessory_group_rows"),
+        [
+            "accessory_group_label",
+            "covered_anchor_groups",
+            "pair_rows",
+            "attached_orders_total",
+            "weighted_attach_rate_pct",
+            "avg_contribution_uplift_per_order",
+            "best_anchor_group_label",
+        ],
+        limit=10,
+    )
 
     heatmap_rows = _frame_rows(day_hour_heatmap, ["day_name", "hour", "orders"], limit=None)
     b2b_rows = _frame_rows(b2b_analysis, ["customer_type", "orders", "revenue", "profit", "unique_customers", "aov", "orders_pct", "revenue_pct"], limit=10)
@@ -1038,6 +1083,12 @@ def generate_modern_dashboard(
         "basket_contribution_rows": basket_contribution_rows,
         "sku_pareto_rows": sku_pareto_rows,
         "attach_rate_rows": attach_rate_rows,
+        "bundle_accessory": {
+            "summary": {k: _maybe_num(v) if isinstance(v, (int, float)) else _json_safe(v) for k, v in ((bundle_accessory_model or {}).get("summary") or {}).items()},
+            "pair_rows": bundle_accessory_pair_rows,
+            "device_rows": bundle_accessory_device_rows,
+            "group_rows": bundle_accessory_group_rows,
+        },
         "daily_margin_rows": daily_margin_rows,
         "payday_window_rows": payday_window_rows,
         "cohort_payback_rows": cohort_payback_rows,
@@ -3931,6 +3982,10 @@ def generate_modern_dashboard(
             if (hasRows(DATA.daily_margin_rows)) productItems.push({{ id: 'prodMarginStabilityChart', title: {{ en: 'Daily margin stability', sk: 'Stabilita denneho marginu' }}, desc: {{ en: 'Pre-ad contribution margin through time.', sk: 'Pre-ad contribution margin v case.' }} }});
             if (hasRows(DATA.sku_pareto_rows)) productItems.push({{ id: 'prodParetoLibraryChart', title: {{ en: 'SKU Pareto', sk: 'SKU Pareto' }}, desc: {{ en: 'Contribution concentration across top SKUs.', sk: 'Koncentracia kontribucie napriec top SKU.' }} }});
             if (hasRows(DATA.attach_rate_rows)) productItems.push({{ id: 'prodAttachRateLibraryChart', title: {{ en: 'Attach rate', sk: 'Attach rate' }}, desc: {{ en: 'Most common anchor -> attached item pairs.', sk: 'Najcastejsie dvojice anchor -> attached item.' }} }});
+            if (hasRows(DATA.bundle_accessory.pair_rows)) productItems.push({{ id: 'prodBundleAccessoryAttachChart', title: {{ en: 'Device -> accessory attach rate', sk: 'Attach rate zariadenie -> doplnok' }}, desc: {{ en: 'Config-driven Roy device family attach-rate by accessory group.', sk: 'Konfigurovany Roy attach-rate podla device family a accessory group.' }} }});
+            if (hasRows(DATA.bundle_accessory.pair_rows)) productItems.push({{ id: 'prodBundleAccessoryUpliftChart', title: {{ en: 'Accessory contribution uplift', sk: 'Contribution uplift doplnkov' }}, desc: {{ en: 'Incremental pre-ad contribution per order when the accessory is present.', sk: 'Inkrementalna pre-ad contribution na objednavku pri pritomnosti doplnku.' }} }});
+            if (hasRows(DATA.bundle_accessory.device_rows)) productItems.push({{ id: 'prodBundleAccessoryFamilyChart', title: {{ en: 'Device family summary', sk: 'Sumar device family' }}, desc: {{ en: 'Best accessory group per device family by uplift and attach rate.', sk: 'Najlepsi accessory group pre device family podla upliftu a attach rate.' }} }});
+            if (hasRows(DATA.bundle_accessory.group_rows)) productItems.push({{ id: 'prodBundleAccessoryGroupChart', title: {{ en: 'Accessory group quality', sk: 'Kvalita accessory groups' }}, desc: {{ en: 'Weighted attach-rate and uplift by accessory category.', sk: 'Vazeny attach-rate a uplift podla kategorie doplnkov.' }} }});
             if (hasRows(DATA.b2b_rows)) productItems.push({{ id: 'opsB2bRevenueProfitChart', title: {{ en: 'B2B vs B2C economics', sk: 'Ekonomika B2B vs B2C' }}, desc: {{ en: 'Revenue, profit and AOV by customer type.', sk: 'Trzba, zisk a AOV podla typu zakaznika.' }} }});
             if (hasRows(DATA.order_status_rows)) productItems.push({{ id: 'opsStatusRevenueChart', title: {{ en: 'Order status mix', sk: 'Mix stavov objednavok' }}, desc: {{ en: 'Orders and revenue by final order status.', sk: 'Objednavky a trzba podla finalneho statusu.' }} }});
             if (hasRows(DATA.segment_rows)) productItems.push({{ id: 'opsSegmentPriorityChart', title: {{ en: 'Email segment volume', sk: 'Objem email segmentov' }}, desc: {{ en: 'Size and priority of lifecycle email segments.', sk: 'Velkost a priorita lifecycle email segmentov.' }} }});
@@ -4009,6 +4064,54 @@ def generate_modern_dashboard(
                         datasets: [{{ label: 'Attach rate %', data: DATA.attach_rate_rows.map(x => Number(x.attach_rate_pct || 0)), backgroundColor: 'rgba(71,102,255,.72)', borderRadius: 8 }}],
                     }},
                     options: horizontalBarOptions(),
+                }});
+            }}
+            if (document.getElementById('prodBundleAccessoryAttachChart')) {{
+                new Chart(document.getElementById('prodBundleAccessoryAttachChart'), {{
+                    type: 'bar',
+                    data: {{
+                        labels: DATA.bundle_accessory.pair_rows.map(x => `${{(x.anchor_group_label || '').slice(0, 18)}} -> ${{(x.accessory_group_label || '').slice(0, 16)}}`),
+                        datasets: [{{ label: 'Attach rate %', data: DATA.bundle_accessory.pair_rows.map(x => Number(x.attach_rate_pct || 0)), backgroundColor: 'rgba(255,138,31,.72)', borderRadius: 8 }}],
+                    }},
+                    options: horizontalBarOptions(),
+                }});
+            }}
+            if (document.getElementById('prodBundleAccessoryUpliftChart')) {{
+                new Chart(document.getElementById('prodBundleAccessoryUpliftChart'), {{
+                    type: 'bar',
+                    data: {{
+                        labels: DATA.bundle_accessory.pair_rows.map(x => `${{(x.anchor_group_label || '').slice(0, 18)}} -> ${{(x.accessory_group_label || '').slice(0, 16)}}`),
+                        datasets: [{{ label: 'Contribution uplift / order', data: DATA.bundle_accessory.pair_rows.map(x => Number(x.contribution_uplift_per_order || 0)), backgroundColor: 'rgba(31,157,102,.72)', borderRadius: 8 }}],
+                    }},
+                    options: horizontalBarOptions(),
+                }});
+            }}
+            if (document.getElementById('prodBundleAccessoryFamilyChart')) {{
+                const familyOpts = dualAxisOptions();
+                new Chart(document.getElementById('prodBundleAccessoryFamilyChart'), {{
+                    data: {{
+                        labels: DATA.bundle_accessory.device_rows.map(x => x.anchor_group_label || '-'),
+                        datasets: [
+                            {{ type: 'bar', label: 'Anchor orders', data: DATA.bundle_accessory.device_rows.map(x => Number(x.anchor_orders || 0)), backgroundColor: 'rgba(71,102,255,.56)', borderRadius: 8, yAxisID: 'y' }},
+                            {{ type: 'line', label: 'Best attach rate %', data: DATA.bundle_accessory.device_rows.map(x => Number(x.best_attach_rate_pct || 0)), borderColor: '#ff8a1f', tension: .30, borderWidth: 2.2, pointRadius: 3, yAxisID: 'y1' }},
+                            {{ type: 'line', label: 'Best uplift / order', data: DATA.bundle_accessory.device_rows.map(x => Number(x.best_contribution_uplift_per_order || 0)), borderColor: '#1f9d66', tension: .30, borderWidth: 2.0, pointRadius: 3, yAxisID: 'y1' }},
+                        ],
+                    }},
+                    options: familyOpts,
+                }});
+            }}
+            if (document.getElementById('prodBundleAccessoryGroupChart')) {{
+                const groupOpts = dualAxisOptions();
+                new Chart(document.getElementById('prodBundleAccessoryGroupChart'), {{
+                    data: {{
+                        labels: DATA.bundle_accessory.group_rows.map(x => x.accessory_group_label || '-'),
+                        datasets: [
+                            {{ type: 'bar', label: 'Attached orders', data: DATA.bundle_accessory.group_rows.map(x => Number(x.attached_orders_total || 0)), backgroundColor: 'rgba(71,102,255,.56)', borderRadius: 8, yAxisID: 'y' }},
+                            {{ type: 'line', label: 'Weighted attach rate %', data: DATA.bundle_accessory.group_rows.map(x => Number(x.weighted_attach_rate_pct || 0)), borderColor: '#ff8a1f', tension: .30, borderWidth: 2.2, pointRadius: 3, yAxisID: 'y1' }},
+                            {{ type: 'line', label: 'Avg uplift / order', data: DATA.bundle_accessory.group_rows.map(x => Number(x.avg_contribution_uplift_per_order || 0)), borderColor: '#1f9d66', tension: .30, borderWidth: 2.0, pointRadius: 3, yAxisID: 'y1' }},
+                        ],
+                    }},
+                    options: groupOpts,
                 }});
             }}
             if (document.getElementById('opsB2bRevenueProfitChart')) {{

--- a/export_orders.py
+++ b/export_orders.py
@@ -358,7 +358,8 @@ class BizniWebExporter:
         normalized_subdir = str(artifact_subdir or "").strip().strip("/\\")
         self.artifact_subdir = normalized_subdir
         self.enable_period_bundle = enable_period_bundle
-        self.reporting_defaults = resolve_reporting_defaults(project_name, load_project_settings(project_name))
+        self.project_settings = load_project_settings(project_name)
+        self.reporting_defaults = resolve_reporting_defaults(project_name, self.project_settings)
         self.project_root_dir = Path("data") / project_name
         self.data_dir = self.project_root_dir / normalized_subdir if normalized_subdir else self.project_root_dir
         self.data_dir.mkdir(parents=True, exist_ok=True)
@@ -820,6 +821,229 @@ class BizniWebExporter:
             if normalized_pattern and normalized_pattern in normalized_label:
                 return True
         return False
+
+    def _bundle_accessory_config(self) -> Dict[str, Any]:
+        config = self.project_settings.get("bundle_accessory_model") or {}
+        return config if isinstance(config, dict) else {}
+
+    def _match_named_group(self, label: Any, groups: List[Dict[str, Any]]) -> Tuple[Optional[str], Optional[str]]:
+        for group in groups or []:
+            if self._matches_patterns(str(label or ""), group.get("patterns") or []):
+                group_key = str(group.get("key") or "").strip()
+                group_label = str(group.get("label") or group_key).strip()
+                if group_key:
+                    return group_key, group_label
+        return None, None
+
+    def analyze_bundle_accessory_model(
+        self,
+        orders_df: pd.DataFrame,
+        item_df: pd.DataFrame,
+        revenue_col: str,
+    ) -> dict:
+        config = self._bundle_accessory_config()
+        if not config.get("enabled"):
+            return {
+                "summary": {},
+                "pair_rows": pd.DataFrame(),
+                "device_family_rows": pd.DataFrame(),
+                "accessory_group_rows": pd.DataFrame(),
+            }
+
+        anchor_groups = config.get("anchor_groups") or []
+        accessory_groups = config.get("accessory_groups") or []
+        if not anchor_groups or not accessory_groups or orders_df.empty or item_df.empty:
+            return {
+                "summary": {},
+                "pair_rows": pd.DataFrame(),
+                "device_family_rows": pd.DataFrame(),
+                "accessory_group_rows": pd.DataFrame(),
+            }
+
+        classified_rows = []
+        for row in item_df[["order_num", "item_label", "product_sku"]].itertuples(index=False):
+            anchor_key, anchor_label = self._match_named_group(row.item_label, anchor_groups)
+            accessory_key, accessory_label = self._match_named_group(row.item_label, accessory_groups)
+            if not anchor_key and not accessory_key:
+                continue
+            classified_rows.append(
+                {
+                    "order_num": row.order_num,
+                    "item_label": row.item_label,
+                    "product_sku": row.product_sku,
+                    "anchor_group_key": anchor_key,
+                    "anchor_group_label": anchor_label,
+                    "accessory_group_key": accessory_key,
+                    "accessory_group_label": accessory_label,
+                }
+            )
+
+        classified = pd.DataFrame(classified_rows)
+        if classified.empty:
+            return {
+                "summary": {},
+                "pair_rows": pd.DataFrame(),
+                "device_family_rows": pd.DataFrame(),
+                "accessory_group_rows": pd.DataFrame(),
+            }
+
+        anchor_matches = classified[classified["anchor_group_key"].notna()][
+            ["order_num", "anchor_group_key", "anchor_group_label"]
+        ].drop_duplicates()
+        accessory_matches = classified[classified["accessory_group_key"].notna()][
+            ["order_num", "accessory_group_key", "accessory_group_label"]
+        ].drop_duplicates()
+        if anchor_matches.empty or accessory_matches.empty:
+            return {
+                "summary": {
+                    "anchor_group_count": int(anchor_matches["anchor_group_key"].nunique()) if not anchor_matches.empty else 0,
+                    "accessory_group_count": int(accessory_matches["accessory_group_key"].nunique()) if not accessory_matches.empty else 0,
+                },
+                "pair_rows": pd.DataFrame(),
+                "device_family_rows": pd.DataFrame(),
+                "accessory_group_rows": pd.DataFrame(),
+            }
+
+        orders_lookup = orders_df[["order_num", revenue_col, "pre_ad_contribution"]].drop_duplicates(subset=["order_num"]).copy()
+        orders_lookup[revenue_col] = pd.to_numeric(orders_lookup[revenue_col], errors="coerce").fillna(0.0)
+        orders_lookup["pre_ad_contribution"] = pd.to_numeric(orders_lookup["pre_ad_contribution"], errors="coerce").fillna(0.0)
+
+        pair_matches = anchor_matches.merge(accessory_matches, on="order_num", how="inner")
+        pair_rows = []
+        for (anchor_key, anchor_label), anchor_group_df in anchor_matches.groupby(["anchor_group_key", "anchor_group_label"]):
+            anchor_order_nums = set(anchor_group_df["order_num"].astype(str))
+            anchor_orders_df = orders_lookup[orders_lookup["order_num"].astype(str).isin(anchor_order_nums)].copy()
+            anchor_orders = len(anchor_order_nums)
+            if anchor_orders == 0 or anchor_orders_df.empty:
+                continue
+
+            anchor_avg_aov = float(anchor_orders_df[revenue_col].mean())
+            anchor_avg_contribution = float(anchor_orders_df["pre_ad_contribution"].mean())
+            anchor_pairs = pair_matches[pair_matches["anchor_group_key"] == anchor_key]
+            if anchor_pairs.empty:
+                continue
+
+            for (accessory_key, accessory_label), pair_df in anchor_pairs.groupby(["accessory_group_key", "accessory_group_label"]):
+                attached_order_nums = set(pair_df["order_num"].astype(str))
+                attached_orders_df = anchor_orders_df[anchor_orders_df["order_num"].astype(str).isin(attached_order_nums)].copy()
+                without_orders_df = anchor_orders_df[~anchor_orders_df["order_num"].astype(str).isin(attached_order_nums)].copy()
+                attached_orders = len(attached_order_nums)
+                if attached_orders == 0 or attached_orders_df.empty:
+                    continue
+
+                avg_order_value_with = float(attached_orders_df[revenue_col].mean())
+                avg_contribution_with = float(attached_orders_df["pre_ad_contribution"].mean())
+                avg_order_value_without = float(without_orders_df[revenue_col].mean()) if not without_orders_df.empty else np.nan
+                avg_contribution_without = float(without_orders_df["pre_ad_contribution"].mean()) if not without_orders_df.empty else np.nan
+
+                pair_rows.append(
+                    {
+                        "anchor_group_key": anchor_key,
+                        "anchor_group_label": anchor_label,
+                        "accessory_group_key": accessory_key,
+                        "accessory_group_label": accessory_label,
+                        "anchor_orders": int(anchor_orders),
+                        "attached_orders": int(attached_orders),
+                        "attach_rate_pct": round((attached_orders / anchor_orders * 100), 1),
+                        "anchor_avg_order_value": round(anchor_avg_aov, 2),
+                        "anchor_avg_pre_ad_contribution": round(anchor_avg_contribution, 2),
+                        "avg_order_value_with_accessory": round(avg_order_value_with, 2),
+                        "avg_order_value_without_accessory": round(avg_order_value_without, 2) if pd.notna(avg_order_value_without) else np.nan,
+                        "avg_pre_ad_contribution_with_accessory": round(avg_contribution_with, 2),
+                        "avg_pre_ad_contribution_without_accessory": round(avg_contribution_without, 2) if pd.notna(avg_contribution_without) else np.nan,
+                        "revenue_uplift_per_order": round(avg_order_value_with - avg_order_value_without, 2) if pd.notna(avg_order_value_without) else np.nan,
+                        "contribution_uplift_per_order": round(avg_contribution_with - avg_contribution_without, 2) if pd.notna(avg_contribution_without) else np.nan,
+                    }
+                )
+
+        pair_rows_df = pd.DataFrame(pair_rows)
+        if pair_rows_df.empty:
+            return {
+                "summary": {
+                    "anchor_group_count": int(anchor_matches["anchor_group_key"].nunique()),
+                    "accessory_group_count": int(accessory_matches["accessory_group_key"].nunique()),
+                    "anchor_orders_total": int(anchor_matches["order_num"].nunique()),
+                    "device_family_count": int(anchor_matches["anchor_group_key"].nunique()),
+                },
+                "pair_rows": pd.DataFrame(),
+                "device_family_rows": pd.DataFrame(),
+                "accessory_group_rows": pd.DataFrame(),
+            }
+
+        pair_rows_df = pair_rows_df.sort_values(
+            ["anchor_orders", "attach_rate_pct", "contribution_uplift_per_order"],
+            ascending=[False, False, False],
+        ).reset_index(drop=True)
+
+        device_family_rows = []
+        for (anchor_key, anchor_label), anchor_df in pair_rows_df.groupby(["anchor_group_key", "anchor_group_label"]):
+            ranked = anchor_df.sort_values(
+                ["contribution_uplift_per_order", "attach_rate_pct", "attached_orders"],
+                ascending=[False, False, False],
+                na_position="last",
+            )
+            best_row = ranked.iloc[0]
+            device_family_rows.append(
+                {
+                    "anchor_group_key": anchor_key,
+                    "anchor_group_label": anchor_label,
+                    "anchor_orders": int(anchor_df["anchor_orders"].max()),
+                    "anchor_avg_order_value": round(float(anchor_df["anchor_avg_order_value"].max()), 2),
+                    "anchor_avg_pre_ad_contribution": round(float(anchor_df["anchor_avg_pre_ad_contribution"].max()), 2),
+                    "best_accessory_group_key": best_row["accessory_group_key"],
+                    "best_accessory_group_label": best_row["accessory_group_label"],
+                    "best_attach_rate_pct": round(float(best_row["attach_rate_pct"]), 1),
+                    "best_contribution_uplift_per_order": round(float(best_row["contribution_uplift_per_order"]), 2)
+                    if pd.notna(best_row["contribution_uplift_per_order"]) else np.nan,
+                    "best_revenue_uplift_per_order": round(float(best_row["revenue_uplift_per_order"]), 2)
+                    if pd.notna(best_row["revenue_uplift_per_order"]) else np.nan,
+                }
+            )
+        device_family_rows_df = pd.DataFrame(device_family_rows).sort_values("anchor_orders", ascending=False)
+
+        accessory_group_rows = []
+        for (accessory_key, accessory_label), accessory_df in pair_rows_df.groupby(["accessory_group_key", "accessory_group_label"]):
+            weighted_attach = np.average(
+                accessory_df["attach_rate_pct"],
+                weights=accessory_df["anchor_orders"].clip(lower=1),
+            ) if not accessory_df.empty else np.nan
+            best_anchor = accessory_df.sort_values(
+                ["contribution_uplift_per_order", "attach_rate_pct", "attached_orders"],
+                ascending=[False, False, False],
+                na_position="last",
+            ).iloc[0]
+            accessory_group_rows.append(
+                {
+                    "accessory_group_key": accessory_key,
+                    "accessory_group_label": accessory_label,
+                    "covered_anchor_groups": int(accessory_df["anchor_group_key"].nunique()),
+                    "pair_rows": int(len(accessory_df)),
+                    "attached_orders_total": int(accessory_df["attached_orders"].sum()),
+                    "weighted_attach_rate_pct": round(float(weighted_attach), 1) if pd.notna(weighted_attach) else np.nan,
+                    "avg_contribution_uplift_per_order": round(float(accessory_df["contribution_uplift_per_order"].dropna().mean()), 2)
+                    if accessory_df["contribution_uplift_per_order"].notna().any() else np.nan,
+                    "best_anchor_group_label": best_anchor["anchor_group_label"],
+                }
+            )
+        accessory_group_rows_df = pd.DataFrame(accessory_group_rows).sort_values("attached_orders_total", ascending=False)
+
+        summary = {
+            "anchor_group_count": int(anchor_matches["anchor_group_key"].nunique()),
+            "accessory_group_count": int(accessory_matches["accessory_group_key"].nunique()),
+            "anchor_orders_total": int(anchor_matches["order_num"].nunique()),
+            "device_family_count": int(device_family_rows_df["anchor_group_key"].nunique()) if not device_family_rows_df.empty else 0,
+            "pair_row_count": int(len(pair_rows_df)),
+            "best_attach_rate_pct": round(float(pair_rows_df["attach_rate_pct"].max()), 1) if not pair_rows_df.empty else np.nan,
+            "best_contribution_uplift_per_order": round(float(pair_rows_df["contribution_uplift_per_order"].max()), 2)
+            if pair_rows_df["contribution_uplift_per_order"].notna().any() else np.nan,
+        }
+
+        return {
+            "summary": summary,
+            "pair_rows": pair_rows_df,
+            "device_family_rows": device_family_rows_df,
+            "accessory_group_rows": accessory_group_rows_df,
+        }
 
     @staticmethod
     def _distribute_total_spend(total: float, date_from: datetime, date_to: datetime) -> Dict[str, float]:
@@ -4830,6 +5054,9 @@ class BizniWebExporter:
             attach_rate['anchor_orders'] = attach_rate['key_orders']
             attach_rate['attached_item'] = attach_rate['attached_product']
 
+        # ---- Roy bundle/accessory model (config-driven, optional per project)
+        bundle_accessory_model = self.analyze_bundle_accessory_model(orders_df, item_df, revenue_col)
+
         # ---- 10) margin stability index (daily pre-ad margin volatility)
         daily_margin = orders_df.groupby('purchase_date_only').agg({
             revenue_col: 'sum',
@@ -4943,6 +5170,7 @@ class BizniWebExporter:
             'basket_contribution': basket_contrib,
             'sku_pareto': sku_pareto,
             'attach_rate': attach_rate,
+            'bundle_accessory_model': bundle_accessory_model,
             'daily_margin': daily_margin,
             'payday_window': payday_window,
         }

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -120,6 +120,86 @@
     "Pasca na potkany z bukového dreva"
   ],
   "product_expenses_file": "product_expenses.json",
+  "bundle_accessory_model": {
+    "enabled": true,
+    "anchor_groups": [
+      {
+        "key": "discovery",
+        "label": "Wachman Discovery",
+        "patterns": ["Wachman Discovery 4G", "Discovery 4G"]
+      },
+      {
+        "key": "hc800",
+        "label": "Wachman HC800",
+        "patterns": ["Wachman HC800", "HC800"]
+      },
+      {
+        "key": "rio",
+        "label": "Wachman Rio",
+        "patterns": ["Fotopasca Wachman Rio", "Wachman Rio", "Rio Solar 4G"]
+      },
+      {
+        "key": "alfa",
+        "label": "Wachman Alfa",
+        "patterns": ["Wachman Alfa Live 4G", "Wachman Alfa"]
+      },
+      {
+        "key": "aldo",
+        "label": "Wachman Aldo",
+        "patterns": ["Wachman Aldo", "Aldo"]
+      },
+      {
+        "key": "solar",
+        "label": "Wachman Solar",
+        "patterns": ["Fotopasca Wachman Solar Pro", "Wachman Solar Pro", "Wachman Solar Lite"]
+      },
+      {
+        "key": "spider",
+        "label": "Wachman Spider",
+        "patterns": ["Wachman Spider"]
+      },
+      {
+        "key": "slim",
+        "label": "Wachman Slim",
+        "patterns": ["Wachman Slim 4K WIFI", "Wachman Slim"]
+      }
+    ],
+    "accessory_groups": [
+      {
+        "key": "sd_card",
+        "label": "SD card",
+        "patterns": ["Micro SD KARTA", "Micro SD CARD", "MicroSDXC", "SD karta", "SD card"]
+      },
+      {
+        "key": "batteries_power",
+        "label": "Batteries & power",
+        "patterns": [
+          "Baterky pre fotopascu",
+          "Baterky AA pre fotopascu",
+          "Baterie do fotopasti",
+          "Externe napajanie pre fotopascu",
+          "Napajaci kabel pre fotopasce",
+          "Napajaci kabel",
+          "Univerzalne solarne napajanie"
+        ]
+      },
+      {
+        "key": "metal_box",
+        "label": "Metal box",
+        "patterns": ["Ochranny kovovy box", "Ochranny box", "Box na Wachman", "Box na fotopascu"]
+      },
+      {
+        "key": "insurance",
+        "label": "Insurance",
+        "patterns": ["Poistenie balika proti strate a rozbitiu", "Poistenie balika"]
+      },
+      {
+        "key": "mounting_security",
+        "label": "Mounting & security",
+        "patterns": ["Popruh na fotopascu", "Univerzalni popruh", "Zamok na fotopascu", "MasterLock Python", "Drziak na fotopascu"]
+      }
+    ]
+  },
   "currency_rates_to_eur": {
     "EUR": 1.0,
     "CZK": 0.04,


### PR DESCRIPTION
## Summary
- add Roy bundle/accessory configuration for anchor device families and accessory groups
- compute attach-rate and contribution uplift summaries in advanced DTC metrics
- render Roy bundle/accessory charts in the modern dashboard
- update PROJECT_STATE.md with verification and next step

## Verification
- python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py
- python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31
- verified new bundle/accessory chart ids in rendered HTML
