### PR TITLE
Add cohort-normalized unit economics views

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -101,7 +101,7 @@ Bootstrap entrypoints:
 
 ## 8) Next Exact Step
 
-- Add cohort-normalized CAC / LTV / payback views so marketing efficiency is comparable by acquisition cohort instead of only global aggregate shortcuts.
+- Add geo confidence scoring and low-sample guardrails so country-level reporting does not present tiny samples as strategic market insights.
 
 ## 9) Change Log
 
@@ -179,6 +179,30 @@ Bootstrap entrypoints:
   - daily normalization uses calendar_days (includes zero-order days).
 - Added fairness diagnostics in table: `Calendar Days` and `Active Day Rate`.
 - Added new Day-of-Month analytics (1-31) to reporting pipeline:
+
+### 2026-04-10 (cohort-normalized unit economics)
+- Added cohort-normalized CAC / LTV / payback views into `export_orders.py` so acquisition cohorts can be compared on mature horizons instead of only via global blended shortcuts.
+- New cohort unit economics payload now exports, per acquisition cohort:
+  - blended and FB CAC
+  - 30/60/90/180-day revenue LTV
+  - 30/60/90/180-day contribution LTV
+  - 30/60/90/180-day contribution LTV/CAC
+  - 30/60/90/180-day CAC recovery %
+  - average and median payback days by horizon
+- Added mature weighted summary fields for cohort-normalized contribution LTV/CAC and payback recovery into the advanced DTC summary layer.
+- Wired the new cohort payload into `dashboard_modern.py` and added three customer analytics charts:
+  - `custCohortContributionLtvCacChart`
+  - `custCohortPaybackRecoveryChart`
+  - `custCohortCacVsContributionChart`
+- Added null-safe rendering for immature cohort horizons so missing maturity now renders as gaps instead of fake zeroes.
+- Verified with:
+  - `python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py`
+  - `python export_orders.py --project vevo --from-date 2025-05-03 --to-date 2026-04-09`
+  - `python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-09`
+- Verification outcome:
+  - VEVO full-history report `data\\vevo\\report_20250503-20260409.html` contains all three cohort chart IDs
+  - ROY full-history report `data\\roy\\report_20250924-20260409.html` contains all three cohort chart IDs
+  - both exports complete successfully with the new cohort-normalized views embedded in the modern dashboard.
 
 ### 2026-04-03
 - Promoted the modern dashboard shell (`test2`) to the default production HTML renderer.

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -779,6 +779,33 @@ def generate_modern_dashboard(
     )
     payday_window_rows = _frame_rows((advanced_dtc_metrics or {}).get("payday_window"), ["window", "orders", "revenue", "profit", "avg_daily_revenue", "avg_daily_profit"], limit=20)
     cohort_payback_rows = _frame_rows((advanced_dtc_metrics or {}).get("cohort_payback"), ["cohort_month", "new_customers", "cohort_cac", "recovery_rate_pct", "avg_payback_days", "median_payback_days"], limit=24)
+    cohort_unit_economics_rows = _frame_rows(
+        (advanced_dtc_metrics or {}).get("cohort_unit_economics"),
+        [
+            "cohort_month",
+            "new_customers",
+            "cohort_age_days",
+            "cohort_paid_spend",
+            "cohort_blended_cac",
+            "revenue_ltv_30d",
+            "revenue_ltv_60d",
+            "revenue_ltv_90d",
+            "revenue_ltv_180d",
+            "contribution_ltv_30d",
+            "contribution_ltv_60d",
+            "contribution_ltv_90d",
+            "contribution_ltv_180d",
+            "contribution_ltv_cac_30d",
+            "contribution_ltv_cac_60d",
+            "contribution_ltv_cac_90d",
+            "contribution_ltv_cac_180d",
+            "payback_recovery_30d_pct",
+            "payback_recovery_60d_pct",
+            "payback_recovery_90d_pct",
+            "payback_recovery_180d_pct",
+        ],
+        limit=24,
+    )
     bundle_accessory_pair_rows = _frame_rows(
         (bundle_accessory_model or {}).get("pair_rows"),
         [
@@ -1092,6 +1119,7 @@ def generate_modern_dashboard(
         "daily_margin_rows": daily_margin_rows,
         "payday_window_rows": payday_window_rows,
         "cohort_payback_rows": cohort_payback_rows,
+        "cohort_unit_economics_rows": cohort_unit_economics_rows,
         "advanced_summary": {k: _maybe_num(v) for k, v in advanced_summary.items()},
         "heatmap_rows": heatmap_rows,
         "b2b_rows": b2b_rows,
@@ -2284,6 +2312,7 @@ def generate_modern_dashboard(
         function fmtInt(v) {{ if (v === null || v === undefined || Number.isNaN(Number(v))) return 'N/A'; return new Intl.NumberFormat('en-US', {{ maximumFractionDigits: 0 }}).format(Number(v)); }}
         function fmtPercent(v) {{ if (v === null || v === undefined || Number.isNaN(Number(v))) return 'N/A'; return `${{Number(v).toFixed(1)}}%`; }}
         function fmtMultiple(v) {{ if (v === null || v === undefined || Number.isNaN(Number(v))) return 'N/A'; return `${{Number(v).toFixed(2)}}x`; }}
+        function nullableNumber(v) {{ return (v === null || v === undefined || Number.isNaN(Number(v))) ? null : Number(v); }}
         function fmtMetric(key, value) {{
             const type = KPI_TYPES[key] || 'text';
             if (type === 'currency') return fmtCurrency(value);
@@ -3566,6 +3595,13 @@ def generate_modern_dashboard(
                     {{ id: 'custCumulativeClvCacChart', title: {{ en: 'Cumulative CLV vs CAC', sk: 'Kumulativne CLV vs CAC' }}, desc: {{ en: 'Cumulative average CLV compared with cumulative CAC.', sk: 'Kumulativne priemerne CLV oproti kumulativnemu CAC.' }} }},
                 );
             }}
+            if (hasRows(DATA.cohort_unit_economics_rows)) {{
+                customerItems.push(
+                    {{ id: 'custCohortContributionLtvCacChart', title: {{ en: 'Cohort contribution LTV/CAC', sk: 'Kohortne contribution LTV/CAC' }}, desc: {{ en: '30/60/90/180-day contribution LTV/CAC by acquisition cohort.', sk: '30/60/90/180-dnove contribution LTV/CAC podla akvizicnej kohorty.' }} }},
+                    {{ id: 'custCohortPaybackRecoveryChart', title: {{ en: 'Cohort payback recovery', sk: 'Kohortna payback recovery' }}, desc: {{ en: 'Share of customers that recover blended CAC within each horizon.', sk: 'Podiel zakaznikov, ktori vratia blended CAC v danom horizonte.' }} }},
+                    {{ id: 'custCohortCacVsContributionChart', title: {{ en: 'Cohort CAC vs contribution LTV', sk: 'Kohortny CAC vs contribution LTV' }}, desc: {{ en: 'Blended CAC versus mature contribution LTV by cohort.', sk: 'Blended CAC oproti zrelemu contribution LTV podla kohorty.' }} }},
+                );
+            }}
             if (hasSeries(DATA.order_size.labels)) {{
                 customerItems.push({{ id: 'custOrderSizeMixDetailChart', title: {{ en: 'Order size mix', sk: 'Mix velkosti objednavok' }}, desc: {{ en: 'Daily order size distribution by basket size.', sk: 'Denny mix velkosti objednavok podla poctu poloziek.' }} }});
             }}
@@ -3667,6 +3703,53 @@ def generate_modern_dashboard(
                         ],
                     }},
                     options: cumOpts,
+                }});
+            }}
+            if (document.getElementById('custCohortContributionLtvCacChart')) {{
+                const cohortRows = DATA.cohort_unit_economics_rows;
+                new Chart(document.getElementById('custCohortContributionLtvCacChart'), {{
+                    type: 'line',
+                    data: {{
+                        labels: cohortRows.map(x => x.cohort_month || '-'),
+                        datasets: [
+                            {{ label: '30d', data: cohortRows.map(x => nullableNumber(x.contribution_ltv_cac_30d)), borderColor: '#ffb96d', tension: .30, borderWidth: 2.0, pointRadius: 2, spanGaps: true }},
+                            {{ label: '60d', data: cohortRows.map(x => nullableNumber(x.contribution_ltv_cac_60d)), borderColor: '#ff8a1f', tension: .30, borderWidth: 2.2, pointRadius: 2, spanGaps: true }},
+                            {{ label: '90d', data: cohortRows.map(x => nullableNumber(x.contribution_ltv_cac_90d)), borderColor: '#4766ff', tension: .30, borderWidth: 2.2, pointRadius: 2, spanGaps: true }},
+                            {{ label: '180d', data: cohortRows.map(x => nullableNumber(x.contribution_ltv_cac_180d)), borderColor: '#1f9d66', tension: .30, borderWidth: 2.4, pointRadius: 2, spanGaps: true }},
+                        ],
+                    }},
+                    options: baseOptions(),
+                }});
+            }}
+            if (document.getElementById('custCohortPaybackRecoveryChart')) {{
+                const cohortRows = DATA.cohort_unit_economics_rows;
+                new Chart(document.getElementById('custCohortPaybackRecoveryChart'), {{
+                    type: 'bar',
+                    data: {{
+                        labels: cohortRows.map(x => x.cohort_month || '-'),
+                        datasets: [
+                            {{ label: '30d recovery %', data: cohortRows.map(x => nullableNumber(x.payback_recovery_30d_pct)), backgroundColor: 'rgba(255,185,109,.70)', borderRadius: 6 }},
+                            {{ label: '60d recovery %', data: cohortRows.map(x => nullableNumber(x.payback_recovery_60d_pct)), backgroundColor: 'rgba(255,138,31,.68)', borderRadius: 6 }},
+                            {{ label: '90d recovery %', data: cohortRows.map(x => nullableNumber(x.payback_recovery_90d_pct)), backgroundColor: 'rgba(71,102,255,.62)', borderRadius: 6 }},
+                            {{ label: '180d recovery %', data: cohortRows.map(x => nullableNumber(x.payback_recovery_180d_pct)), backgroundColor: 'rgba(31,157,102,.62)', borderRadius: 6 }},
+                        ],
+                    }},
+                    options: baseOptions(),
+                }});
+            }}
+            if (document.getElementById('custCohortCacVsContributionChart')) {{
+                const cohortRows = DATA.cohort_unit_economics_rows;
+                const cohortOpts = dualAxisOptions();
+                new Chart(document.getElementById('custCohortCacVsContributionChart'), {{
+                    data: {{
+                        labels: cohortRows.map(x => x.cohort_month || '-'),
+                        datasets: [
+                            {{ type: 'bar', label: 'Blended CAC', data: cohortRows.map(x => nullableNumber(x.cohort_blended_cac)), backgroundColor: 'rgba(207,80,96,.52)', borderRadius: 8, yAxisID: 'y' }},
+                            {{ type: 'line', label: '90d contribution LTV', data: cohortRows.map(x => nullableNumber(x.contribution_ltv_90d)), borderColor: '#4766ff', tension: .30, borderWidth: 2.2, pointRadius: 2, yAxisID: 'y1', spanGaps: true }},
+                            {{ type: 'line', label: '180d contribution LTV', data: cohortRows.map(x => nullableNumber(x.contribution_ltv_180d)), borderColor: '#1f9d66', tension: .30, borderWidth: 2.4, pointRadius: 2, yAxisID: 'y1', spanGaps: true }},
+                        ],
+                    }},
+                    options: cohortOpts,
                 }});
             }}
             if (document.getElementById('custOrderSizeMixDetailChart')) {{

--- a/export_orders.py
+++ b/export_orders.py
@@ -4893,12 +4893,17 @@ class BizniWebExporter:
         # Cohort CAC is estimated as monthly FB spend / new customers acquired in that month.
         daily_spend_df = (
             df.assign(_d=pd.to_datetime(df['purchase_date']).dt.normalize())
-            .groupby('_d')[['fb_ads_daily_spend']]
+            .groupby('_d')[['fb_ads_daily_spend', 'google_ads_daily_spend']]
             .first()
             .reset_index()
         )
         daily_spend_df['cohort_month'] = daily_spend_df['_d'].dt.to_period('M').astype(str)
         monthly_fb_spend = daily_spend_df.groupby('cohort_month')['fb_ads_daily_spend'].sum().to_dict()
+        monthly_google_spend = daily_spend_df.groupby('cohort_month')['google_ads_daily_spend'].sum().to_dict()
+        monthly_paid_spend = {
+            month: float(monthly_fb_spend.get(month, 0.0)) + float(monthly_google_spend.get(month, 0.0))
+            for month in set(monthly_fb_spend.keys()) | set(monthly_google_spend.keys())
+        }
 
         first_order_map = (
             orders_df.sort_values(['customer_email', 'purchase_datetime'])
@@ -4914,6 +4919,7 @@ class BizniWebExporter:
         customer_orders['days_since_first'] = (
             customer_orders['purchase_datetime'] - customer_orders['first_purchase_datetime']
         ).dt.days
+        analysis_end = customer_orders['purchase_datetime'].max().normalize()
 
         cohort_rows = []
         for cohort_month, group in first_order_map.groupby('cohort_month'):
@@ -4949,6 +4955,109 @@ class BizniWebExporter:
             })
 
         cohort_payback = pd.DataFrame(cohort_rows).sort_values('cohort_month') if cohort_rows else pd.DataFrame()
+
+        # ---- 4b) cohort-normalized CAC / LTV / payback by horizon
+        cohort_unit_rows = []
+        cohort_horizons = (30, 60, 90, 180)
+        for cohort_month, group in first_order_map.groupby('cohort_month'):
+            cohort_customers = group.index.tolist()
+            cohort_new_customers = len(cohort_customers)
+            if cohort_new_customers == 0:
+                continue
+
+            cohort_fb_spend = float(monthly_fb_spend.get(cohort_month, 0.0))
+            cohort_google_spend = float(monthly_google_spend.get(cohort_month, 0.0))
+            cohort_paid_spend = float(monthly_paid_spend.get(cohort_month, 0.0))
+            cohort_fb_cac = (cohort_fb_spend / cohort_new_customers) if cohort_new_customers > 0 else 0.0
+            cohort_blended_cac = (cohort_paid_spend / cohort_new_customers) if cohort_new_customers > 0 else 0.0
+
+            cohort_first_dates = group['first_purchase_datetime'].sort_values()
+            cohort_start_date = cohort_first_dates.min().normalize()
+            cohort_latest_first_date = cohort_first_dates.max().normalize()
+            cohort_age_days = int((analysis_end - cohort_latest_first_date).days)
+            cohort_customer_orders = customer_orders[
+                customer_orders['customer_email'].isin(cohort_customers)
+            ].copy()
+
+            row = {
+                'cohort_month': cohort_month,
+                'new_customers': cohort_new_customers,
+                'cohort_start_date': cohort_start_date.strftime('%Y-%m-%d'),
+                'cohort_latest_first_date': cohort_latest_first_date.strftime('%Y-%m-%d'),
+                'cohort_age_days': cohort_age_days,
+                'cohort_fb_spend': round(cohort_fb_spend, 2),
+                'cohort_google_spend': round(cohort_google_spend, 2),
+                'cohort_paid_spend': round(cohort_paid_spend, 2),
+                'cohort_fb_cac': round(cohort_fb_cac, 2),
+                'cohort_blended_cac': round(cohort_blended_cac, 2),
+            }
+
+            for horizon in cohort_horizons:
+                mature = cohort_age_days >= horizon
+                horizon_orders = cohort_customer_orders[cohort_customer_orders['days_since_first'] <= horizon].copy()
+                revenue_ltv = (float(horizon_orders[revenue_col].sum()) / cohort_new_customers) if mature else np.nan
+                contribution_ltv_h = (float(horizon_orders['pre_ad_contribution'].sum()) / cohort_new_customers) if mature else np.nan
+
+                revenue_ltv_cac_h = np.nan
+                contribution_ltv_cac_h = np.nan
+                if mature and cohort_blended_cac > 0:
+                    revenue_ltv_cac_h = revenue_ltv / cohort_blended_cac
+                    contribution_ltv_cac_h = contribution_ltv_h / cohort_blended_cac
+
+                payback_days_list = []
+                if mature and cohort_blended_cac > 0:
+                    for customer in cohort_customers:
+                        c_orders = horizon_orders[horizon_orders['customer_email'] == customer].sort_values('purchase_datetime')
+                        if c_orders.empty:
+                            continue
+                        c_orders = c_orders[['days_since_first', 'pre_ad_contribution']].copy()
+                        c_orders['cum_contribution'] = c_orders['pre_ad_contribution'].cumsum()
+                        reached = c_orders[c_orders['cum_contribution'] >= cohort_blended_cac]
+                        if not reached.empty:
+                            payback_days_list.append(int(reached.iloc[0]['days_since_first']))
+
+                recovered_customers_h = len(payback_days_list) if mature and cohort_blended_cac > 0 else np.nan
+                recovery_rate_h = (
+                    recovered_customers_h / cohort_new_customers * 100
+                    if mature and cohort_blended_cac > 0 else np.nan
+                )
+
+                row.update({
+                    f'revenue_ltv_{horizon}d': round(revenue_ltv, 2) if pd.notna(revenue_ltv) else np.nan,
+                    f'contribution_ltv_{horizon}d': round(contribution_ltv_h, 2) if pd.notna(contribution_ltv_h) else np.nan,
+                    f'revenue_ltv_cac_{horizon}d': round(revenue_ltv_cac_h, 2) if pd.notna(revenue_ltv_cac_h) else np.nan,
+                    f'contribution_ltv_cac_{horizon}d': round(contribution_ltv_cac_h, 2) if pd.notna(contribution_ltv_cac_h) else np.nan,
+                    f'payback_recovered_{horizon}d': int(recovered_customers_h) if pd.notna(recovered_customers_h) else np.nan,
+                    f'payback_recovery_{horizon}d_pct': round(recovery_rate_h, 1) if pd.notna(recovery_rate_h) else np.nan,
+                    f'avg_payback_{horizon}d_days': round(float(np.mean(payback_days_list)), 1) if payback_days_list else np.nan,
+                    f'median_payback_{horizon}d_days': round(float(np.median(payback_days_list)), 1) if payback_days_list else np.nan,
+                })
+
+            cohort_unit_rows.append(row)
+
+        cohort_unit_economics = (
+            pd.DataFrame(cohort_unit_rows).sort_values('cohort_month').reset_index(drop=True)
+            if cohort_unit_rows else pd.DataFrame()
+        )
+
+        mature_weighted_summary = {}
+        if not cohort_unit_economics.empty:
+            weight_col = cohort_unit_economics['new_customers'].fillna(0)
+            for horizon in cohort_horizons:
+                ratio_col = f'contribution_ltv_cac_{horizon}d'
+                recovery_col = f'payback_recovery_{horizon}d_pct'
+                valid_ratio = cohort_unit_economics[ratio_col].notna()
+                valid_recovery = cohort_unit_economics[recovery_col].notna()
+                if valid_ratio.any():
+                    mature_weighted_summary[f'mature_{horizon}d_contribution_ltv_cac'] = round(
+                        float((cohort_unit_economics.loc[valid_ratio, ratio_col] * weight_col.loc[valid_ratio]).sum() / weight_col.loc[valid_ratio].sum()),
+                        2,
+                    )
+                if valid_recovery.any():
+                    mature_weighted_summary[f'mature_{horizon}d_payback_recovery_pct'] = round(
+                        float((cohort_unit_economics.loc[valid_recovery, recovery_col] * weight_col.loc[valid_recovery]).sum() / weight_col.loc[valid_recovery].sum()),
+                        1,
+                    )
 
         # ---- 7) contribution by basket size
         def basket_bucket(items_count):
@@ -5165,8 +5274,10 @@ class BizniWebExporter:
                 'margin_stability_index': round(margin_stability_index, 1),
                 'sku_pareto_80_count': sku_pareto_80_count,
                 'sku_total_count': int(len(sku_pareto)),
+                **mature_weighted_summary,
             },
             'cohort_payback': cohort_payback,
+            'cohort_unit_economics': cohort_unit_economics,
             'basket_contribution': basket_contrib,
             'sku_pareto': sku_pareto,
             'attach_rate': attach_rate,


### PR DESCRIPTION
## Summary\n- add cohort-normalized CAC/LTV/payback views for VEVO and ROY\n- render new cohort charts in the modern dashboard\n- update PROJECT_STATE with verification and next exact step\n\n## Verification\n- python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py\n- python export_orders.py --project vevo --from-date 2025-05-03 --to-date 2026-04-09\n- python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-09