### PR TITLE
Normalize shipping semantics as net shipping

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -871,3 +871,83 @@ Next exact step:
     - `custSampleEntryProductChart`
 - Next exact step:
   - start the Roy bundle/accessory model as the next business-model expansion after the Vevo sample funnel model is now live in the modern dashboard.
+### 2026-04-10 (Roy bundle and accessory model)
+- Added Roy-specific anchor device families and accessory groups to `projects/roy/settings.json` so bundle economics no longer depends on ad-hoc string logic in dashboard code.
+- Added a dedicated Roy bundle/accessory model in `export_orders.py` that computes:
+  - pair-level attach rate
+  - incremental order contribution uplift
+  - anchor device family summary
+  - accessory group summary
+- Exposed the new Roy bundle/accessory payload through the modern dashboard renderer in `dashboard_modern.py`.
+- Added new Roy charts and tables:
+  - `prodBundleAccessoryAttachChart`
+  - `prodBundleAccessoryUpliftChart`
+  - `prodBundleAccessoryFamilyChart`
+  - `prodBundleAccessoryGroupChart`
+- Verified with:
+  - `python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py`
+  - `python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31`
+- Verification outcome:
+  - Roy March 2026 report regenerated successfully
+  - new bundle/accessory charts render in `data\\roy\\report_20260301-20260331.html`
+- Next exact step:
+  - add cohort-normalized CAC / LTV / payback views so global shortcut metrics are complemented by acquisition-cohort recovery curves.
+### 2026-04-10 (Cohort-normalized unit economics)
+- Added cohort-normalized CAC / LTV / payback views in `export_orders.py` for both VEVO and ROY.
+- The cohort model now computes 30/60/90/180-day acquisition-cohort views with:
+  - customers
+  - revenue LTV
+  - contribution LTV
+  - contribution LTV / CAC
+  - recovery percentage
+  - average / median payback days
+- Added cohort-normalized charts to the modern dashboard in `dashboard_modern.py` for both projects:
+  - `custCohortContributionLtvCacChart`
+  - `custCohortPaybackRecoveryChart`
+  - `custCohortCacVsContributionChart`
+- Verified with:
+  - `python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py`
+  - `python export_orders.py --project vevo --from-date 2025-05-03 --to-date 2026-04-09`
+  - `python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-09`
+- Verification outcome:
+  - full-history VEVO and ROY reports regenerate successfully
+  - both reports now contain cohort-normalized unit-economics charts in the customer section / full library
+- Next exact step:
+  - normalize shipping sign semantics so positive values always mean business cost and negative values mean shipping profit, then update labels and formulas consistently across runtime, export and dashboard layers.
+### 2026-04-10 (Shipping net semantics cleanup)
+- Replaced ambiguous `shipping_subsidy_per_order` semantics with canonical `shipping_net_per_order` in the runtime/config layer:
+  - positive value = business shipping cost
+  - negative value = shipping profit / over-recovery
+- Added runtime alias handling in `reporting_core/runtime.py` so existing settings can still load, while new project configs and templates now use:
+  - `shipping_net_per_order`
+- Updated project settings:
+  - `projects/vevo/settings.json` now uses `shipping_net_per_order: 0.2`
+  - `projects/roy/settings.json` now uses `shipping_net_per_order: -0.2`
+  - `templates/reporting-client/settings.template.json` now uses `shipping_net_per_order`
+- Updated export math in `export_orders.py` to use canonical `shipping_net_cost` in:
+  - daily aggregation
+  - total cost
+  - pre-ad contribution
+  - post-ad contribution
+  - geo profitability
+  - financial summaries
+- Preserved backward-compatible aliases where needed so existing consumers do not break, but all key formulas now read `shipping_net_cost` first.
+- Updated downstream readers:
+  - `reporting_core/cfo_kpis.py`
+  - `daily_report_runner.py`
+  - `dashboard_modern.py`
+  - `html_report_generator.py`
+- Dashboard/UI cleanup:
+  - renamed visible labels from `Shipping Subsidy` to `Net shipping`
+  - modern dashboard tiles and charts now explain that positive means cost and negative means shipping profit
+  - legacy/shared generator fallbacks now read `shipping_net_cost` before old subsidy aliases
+- Verified with:
+  - `python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py reporting_core\\runtime.py reporting_core\\cfo_kpis.py daily_report_runner.py`
+  - `python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31`
+  - `python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31`
+- Verification outcome:
+  - VEVO and ROY March 2026 reports regenerate successfully
+  - modern HTML outputs now render `Net shipping` instead of the ambiguous subsidy label
+  - shipping math stays stable while sign semantics are now explicit and consistent
+- Next exact step:
+  - add full QA assertions in pipeline for shell/library parity, campaign arithmetic integrity and normalized-dimension completeness (`day_name`, `anchor_item`, `country`).

--- a/daily_report_runner.py
+++ b/daily_report_runner.py
@@ -336,7 +336,7 @@ def _load_daily_rows(date_csv: Path) -> List[Dict[str, Any]]:
             orders = _to_int(row.get("unique_orders", ""))
             product_costs = _to_float(row.get("product_expense", ""))
             packaging_costs = _to_float(row.get("packaging_cost", ""))
-            shipping_subsidy = _to_float(row.get("shipping_subsidy_cost", ""))
+            shipping_subsidy = _to_float(row.get("shipping_net_cost", row.get("shipping_subsidy_cost", "")))
             facebook_ads = _to_float(row.get("fb_ads_spend", ""))
             google_ads = _to_float(row.get("google_ads_spend", ""))
             total_ads = facebook_ads + google_ads
@@ -359,6 +359,7 @@ def _load_daily_rows(date_csv: Path) -> List[Dict[str, Any]]:
                     "product_costs": product_costs,
                     "packaging_costs": packaging_costs,
                     "shipping_subsidy": shipping_subsidy,
+                    "shipping_net": shipping_subsidy,
                     "facebook_ads": facebook_ads,
                     "google_ads": google_ads,
                     "total_ads": total_ads,

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -97,7 +97,7 @@ def _series(date_agg: pd.DataFrame) -> Dict[str, List[Any]]:
     total_cost = [_num(v) for v in date_agg.get("total_cost", pd.Series([0] * len(date_agg))).tolist()]
     product_cost = [_num(v) for v in date_agg.get("product_expense", pd.Series([0] * len(date_agg))).tolist()]
     packaging = [_num(v) for v in date_agg.get("packaging_cost", pd.Series([0] * len(date_agg))).tolist()]
-    shipping = [_num(v) for v in date_agg.get("shipping_subsidy_cost", pd.Series([0] * len(date_agg))).tolist()]
+    shipping = [_num(v) for v in date_agg.get("shipping_net_cost", date_agg.get("shipping_subsidy_cost", pd.Series([0] * len(date_agg)))).tolist()]
     fixed = [_num(v) for v in date_agg.get("fixed_daily_cost", pd.Series([0] * len(date_agg))).tolist()]
     items = [int(round(_num(v))) for v in date_agg.get("total_items", pd.Series([0] * len(date_agg))).tolist()]
     avg_items = [round((itm / ords) if ords > 0 else 0.0, 4) for itm, ords in zip(items, orders)]
@@ -205,14 +205,14 @@ def _kpis(payload: Optional[dict]) -> Dict[str, Any]:
 
 def _cost_mix(date_agg: pd.DataFrame) -> Dict[str, Any]:
     return {
-        "labels": ["Product", "Packaging", "Shipping", "Facebook Ads", "Google Ads", "Fixed"],
-        "values": [
-            round(_num(date_agg.get("product_expense", pd.Series(dtype=float)).sum()), 2),
-            round(_num(date_agg.get("packaging_cost", pd.Series(dtype=float)).sum()), 2),
-            round(_num(date_agg.get("shipping_subsidy_cost", pd.Series(dtype=float)).sum()), 2),
-            round(_num(date_agg.get("fb_ads_spend", pd.Series(dtype=float)).sum()), 2),
-            round(_num(date_agg.get("google_ads_spend", pd.Series(dtype=float)).sum()), 2),
-            round(_num(date_agg.get("fixed_daily_cost", pd.Series(dtype=float)).sum()), 2),
+            "labels": ["Product", "Packaging", "Net shipping", "Facebook Ads", "Google Ads", "Fixed"],
+            "values": [
+                round(_num(date_agg.get("product_expense", pd.Series(dtype=float)).sum()), 2),
+                round(_num(date_agg.get("packaging_cost", pd.Series(dtype=float)).sum()), 2),
+                round(_num(date_agg.get("shipping_net_cost", date_agg.get("shipping_subsidy_cost", pd.Series(dtype=float))).sum()), 2),
+                round(_num(date_agg.get("fb_ads_spend", pd.Series(dtype=float)).sum()), 2),
+                round(_num(date_agg.get("google_ads_spend", pd.Series(dtype=float)).sum()), 2),
+                round(_num(date_agg.get("fixed_daily_cost", pd.Series(dtype=float)).sum()), 2),
         ],
     }
 
@@ -976,7 +976,7 @@ def generate_modern_dashboard(
     total_ads = round(total_fb_ads + total_google_ads, 2)
     total_product_cost = round(_num(date_agg.get("product_expense", pd.Series(dtype=float)).sum()), 2)
     total_packaging_cost = round(_num(date_agg.get("packaging_cost", pd.Series(dtype=float)).sum()), 2)
-    total_shipping_subsidy = round(_num(date_agg.get("shipping_subsidy_cost", pd.Series(dtype=float)).sum()), 2)
+    total_shipping_subsidy = round(_num(date_agg.get("shipping_net_cost", date_agg.get("shipping_subsidy_cost", pd.Series(dtype=float))).sum()), 2)
     total_fixed_overhead = round(_num(date_agg.get("fixed_daily_cost", pd.Series(dtype=float)).sum()), 2)
     total_costs = round(_num(date_agg.get("total_cost", pd.Series(dtype=float)).sum()), 2)
     total_items = int(round(_num(date_agg.get("total_items", pd.Series(dtype=float)).sum())))
@@ -1031,11 +1031,13 @@ def generate_modern_dashboard(
         ),
     }
 
+    shipping_tone = "positive" if total_shipping_subsidy < 0 else ("neutral" if total_shipping_subsidy == 0 else "negative")
+
     library_tiles = [
         {"en": "Total revenue (net)", "sk": "Celkove trzby (net)", "value": total_revenue, "kind": "currency", "tone": "neutral"},
         {"en": "Product costs", "sk": "Naklady na produkty", "value": total_product_cost, "kind": "currency", "tone": "negative"},
         {"en": "Packaging costs", "sk": "Naklady na balenie", "value": total_packaging_cost, "kind": "currency", "tone": "negative"},
-        {"en": "Shipping subsidy", "sk": "Prispevok na dopravu", "value": total_shipping_subsidy, "kind": "currency", "tone": "negative"},
+        {"en": "Net shipping", "sk": "Ciste shipping", "value": total_shipping_subsidy, "kind": "currency", "tone": shipping_tone, "note_en": "positive = cost, negative = shipping profit", "note_sk": "kladne = naklad, zaporne = shipping zisk"},
         {"en": "Fixed overhead", "sk": "Fixny overhead", "value": total_fixed_overhead, "kind": "currency", "tone": "negative"},
         {"en": "Facebook ads", "sk": "Facebook reklama", "value": total_fb_ads, "kind": "currency", "tone": "negative"},
         {"en": "Google ads", "sk": "Google reklama", "value": total_google_ads, "kind": "currency", "tone": "negative"},
@@ -1713,7 +1715,7 @@ def generate_modern_dashboard(
                             <div class="chart-shell"><canvas id="dailyEconomicsChart"></canvas></div>
                         </div>
                         <div class="panel chart-card">
-                            <div class="card-head"><div><h3><span class="lang-en">Cost component trend</span><span class="lang-sk hidden">Trend zloziek nakladov</span></h3><p><span class="lang-en">Product, packaging, shipping, fixed and ads in one view.</span><span class="lang-sk hidden">Produkt, balenie, doprava, fix a reklama v jednom pohlade.</span></p></div></div>
+                            <div class="card-head"><div><h3><span class="lang-en">Cost component trend</span><span class="lang-sk hidden">Trend zloziek nakladov</span></h3><p><span class="lang-en">Product, packaging, net shipping, fixed and ads in one view.</span><span class="lang-sk hidden">Produkt, balenie, ciste shipping, fix a reklama v jednom pohlade.</span></p></div></div>
                             <div class="chart-shell"><canvas id="costBreakoutChart"></canvas></div>
                         </div>
                     </div>
@@ -2825,7 +2827,7 @@ def generate_modern_dashboard(
                     datasets: [
                         {{ type: 'bar', label: 'Product', data: s.product_cost, backgroundColor: 'rgba(255,138,31,.72)', stack: 'costs', borderRadius: 6 }},
                         {{ type: 'bar', label: 'Packaging', data: s.packaging, backgroundColor: 'rgba(255,177,93,.72)', stack: 'costs', borderRadius: 6 }},
-                        {{ type: 'bar', label: 'Shipping', data: s.shipping, backgroundColor: 'rgba(255,213,157,.9)', stack: 'costs', borderRadius: 6 }},
+                        {{ type: 'bar', label: 'Net shipping', data: s.shipping, backgroundColor: 'rgba(255,213,157,.9)', stack: 'costs', borderRadius: 6 }},
                         {{ type: 'bar', label: 'Fixed', data: s.fixed, backgroundColor: 'rgba(64,56,47,.72)', stack: 'costs', borderRadius: 6 }},
                         {{ type: 'line', label: 'Ads', data: s.total_ads, borderColor: '#4766ff', tension: .28, borderWidth: 2.1, pointRadius: 0, yAxisID: 'y1' }},
                     ],
@@ -3336,7 +3338,7 @@ def generate_modern_dashboard(
                 {{ id: 'econProfitDetailChart', title: {{ en: 'Profit detail', sk: 'Detail zisku' }}, desc: {{ en: 'Profit development isolated from the mixed chart.', sk: 'Vyvoj zisku oddeleny od ostatnych serii.' }} }},
                 {{ id: 'econAovDetailChart', title: {{ en: 'AOV detail', sk: 'Detail AOV' }}, desc: {{ en: 'Basket value trend and 7-day moving average.', sk: 'Trend hodnoty kosika a 7-dnovy priemer.' }} }},
                 {{ id: 'econCostStackDetailChart', title: {{ en: 'Cost stack detail', sk: 'Detail stacku nakladov' }}, desc: {{ en: 'Total cost, product cost and ad spend on one timeline.', sk: 'Total cost, produktovy cost a reklamny spend na jednej osi.' }} }},
-                {{ id: 'econLogisticsDetailChart', title: {{ en: 'Logistics and fixed costs', sk: 'Logistika a fixne naklady' }}, desc: {{ en: 'Packaging, shipping and fixed overhead in one view.', sk: 'Balenie, shipping a fixny overhead v jednom pohlade.' }} }},
+                {{ id: 'econLogisticsDetailChart', title: {{ en: 'Logistics and fixed costs', sk: 'Logistika a fixne naklady' }}, desc: {{ en: 'Packaging, net shipping and fixed overhead in one view.', sk: 'Balenie, ciste shipping a fixny overhead v jednom pohlade.' }} }},
                 {{ id: 'econAverageTrendDetailChart', title: {{ en: 'Running averages', sk: 'Bezace priemery' }}, desc: {{ en: 'Cumulative average revenue and profit for stability reading.', sk: 'Kumulativny priemer trzby a zisku pre citanie stability.' }} }},
                 {{ id: 'econRoiRoasDetailChart', title: {{ en: 'ROI and ROAS detail', sk: 'Detail ROI a ROAS' }}, desc: {{ en: 'Daily ROI against daily blended ROAS.', sk: 'Denne ROI oproti dennemu blended ROAS.' }} }},
                 {{ id: 'econMarginsDetailChart', title: {{ en: 'Margin stack', sk: 'Stack marzi' }}, desc: {{ en: 'Gross, pre-ad and post-ad margins in one line view.', sk: 'Hruba, pre-ad a post-ad marza v jednom pohlade.' }} }},
@@ -3403,7 +3405,7 @@ def generate_modern_dashboard(
                         labels: s.dates,
                         datasets: [
                             {{ type: 'bar', label: 'Packaging', data: s.packaging, backgroundColor: 'rgba(255,177,93,.55)', borderRadius: 8, yAxisID: 'y' }},
-                            {{ type: 'line', label: 'Shipping', data: s.shipping, borderColor: '#4766ff', tension: .30, borderWidth: 2.2, pointRadius: 0, yAxisID: 'y' }},
+                            {{ type: 'line', label: 'Net shipping', data: s.shipping, borderColor: '#4766ff', tension: .30, borderWidth: 2.2, pointRadius: 0, yAxisID: 'y' }},
                             {{ type: 'line', label: 'Fixed', data: s.fixed, borderColor: '#cf5060', tension: .30, borderWidth: 2.0, pointRadius: 0, yAxisID: 'y1' }},
                         ],
                     }},
@@ -4483,7 +4485,7 @@ def generate_modern_dashboard(
                     {{ id: 'econProductCostsStandaloneChart', title: {{ en: 'Product costs', sk: 'Produktove naklady' }}, desc: {{ en: 'Cost of goods sold through time.', sk: 'Naklady na tovar v case.' }} }},
                     {{ id: 'econGrossMarginStandaloneChart', title: {{ en: 'Gross margin', sk: 'Hruba marza' }}, desc: {{ en: 'Daily gross margin with smoothing.', sk: 'Denne hruba marza s vyhladenim.' }} }},
                     {{ id: 'econPackagingStandaloneChart', title: {{ en: 'Packaging costs', sk: 'Naklady na balenie' }}, desc: {{ en: 'Daily packaging cost load.', sk: 'Denne naklady na balenie.' }} }},
-                    {{ id: 'econShippingStandaloneChart', title: {{ en: 'Shipping subsidy', sk: 'Shipping subsidy' }}, desc: {{ en: 'Daily shipping subsidy or shipping profit line.', sk: 'Denn a shipping subsidy resp. shipping zisk.' }} }},
+                    {{ id: 'econShippingStandaloneChart', title: {{ en: 'Net shipping', sk: 'Ciste shipping' }}, desc: {{ en: 'Daily net shipping line: positive = cost, negative = shipping profit.', sk: 'Denna krivka cisteho shippingu: kladne = naklad, zaporne = shipping zisk.' }} }},
                     {{ id: 'econFixedStandaloneChart', title: {{ en: 'Fixed costs', sk: 'Fixne naklady' }}, desc: {{ en: 'Daily allocation of fixed overhead.', sk: 'Denne alokovane fixne naklady.' }} }},
                     {{ id: 'econItemsSoldStandaloneChart', title: {{ en: 'Items sold', sk: 'Predane kusy' }}, desc: {{ en: 'Total item units sold per day.', sk: 'Celkovy pocet predanych kusov za den.' }} }},
                     {{ id: 'econAvgItemsStandaloneChart', title: {{ en: 'Average items per order', sk: 'Priemer poloziek na objednavku' }}, desc: {{ en: 'Basket depth by number of sold items.', sk: 'Hl bka kosika podla poctu poloziek.' }} }},
@@ -4556,7 +4558,7 @@ def generate_modern_dashboard(
                     type: 'line',
                     data: {{
                         labels: s.dates,
-                        datasets: [{{ label: 'Shipping', data: s.shipping, borderColor: '#4766ff', tension: .32, borderWidth: 2.3, pointRadius: 0 }}],
+                        datasets: [{{ label: 'Net shipping', data: s.shipping, borderColor: '#4766ff', tension: .32, borderWidth: 2.3, pointRadius: 0 }}],
                     }},
                     options: baseOptions(),
                 }});

--- a/export_orders.py
+++ b/export_orders.py
@@ -102,7 +102,8 @@ GRAPHQL_TIMEOUT_SEC = int(
 
 # Fixed costs
 PACKAGING_COST_PER_ORDER = 0.3  # EUR per order
-SHIPPING_SUBSIDY_PER_ORDER = 0.2  # EUR per order (shipping subsidy)
+SHIPPING_SUBSIDY_PER_ORDER = 0.2  # legacy alias; use SHIPPING_NET_PER_ORDER semantics below
+SHIPPING_NET_PER_ORDER = SHIPPING_SUBSIDY_PER_ORDER  # positive = business cost, negative = shipping profit
 FIXED_MONTHLY_COST = 0  # EUR per month (Marek, Uctovnictvo)
 ZERO_MARGIN_BRANDS: List[str] = []  # Optional list of brands that should always run at 0 product margin
 ZERO_COST_BRANDS: List[str] = []  # Optional list of brands that should always run at 0 product cost
@@ -2743,21 +2744,22 @@ class BizniWebExporter:
         date_agg['google_ads_spend'] = date_agg['google_ads_spend'].fillna(0)
 
         # Add variable per-order logistics costs
-        # Packaging + shipping subsidy both scale with number of orders.
+        # Packaging and net shipping both scale with number of orders.
         date_agg['packaging_cost'] = date_agg['unique_orders'] * PACKAGING_COST_PER_ORDER
-        date_agg['shipping_subsidy_cost'] = date_agg['unique_orders'] * SHIPPING_SUBSIDY_PER_ORDER
+        date_agg['shipping_net_cost'] = date_agg['unique_orders'] * SHIPPING_NET_PER_ORDER
+        date_agg['shipping_subsidy_cost'] = date_agg['shipping_net_cost']  # backward-compatible alias
 
         # Add daily fixed cost based on the date
         date_agg['fixed_daily_cost'] = date_agg['date'].apply(lambda d: round(self.get_daily_fixed_cost(pd.Timestamp(d)), 2))
 
         # Company-level cost (includes fixed overhead)
-        # Total cost = product expense + ads + packaging + shipping subsidy + fixed daily cost
+        # Total cost = product expense + ads + packaging + net shipping + fixed daily cost
         date_agg['total_cost'] = (
             date_agg['product_expense']
             + date_agg['fb_ads_spend']
             + date_agg['google_ads_spend']
             + date_agg['packaging_cost']
-            + date_agg['shipping_subsidy_cost']
+            + date_agg['shipping_net_cost']
             + date_agg['fixed_daily_cost']
         )
 
@@ -2768,7 +2770,7 @@ class BizniWebExporter:
         date_agg['pre_ad_contribution_cost'] = (
             date_agg['product_expense']
             + date_agg['packaging_cost']
-            + date_agg['shipping_subsidy_cost']
+            + date_agg['shipping_net_cost']
         )
         date_agg['pre_ad_contribution_profit'] = date_agg['total_revenue'] - date_agg['pre_ad_contribution_cost']
         date_agg['pre_ad_contribution_margin_pct'] = date_agg.apply(
@@ -2784,7 +2786,7 @@ class BizniWebExporter:
         date_agg['contribution_cost'] = (
             date_agg['product_expense']
             + date_agg['packaging_cost']
-            + date_agg['shipping_subsidy_cost']
+            + date_agg['shipping_net_cost']
             + date_agg['fb_ads_spend']
             + date_agg['google_ads_spend']
         )
@@ -2983,7 +2985,7 @@ class BizniWebExporter:
                 
                 print("\n" + "="*220)
                 print(f"DAILY SUMMARY FOR {month_str.upper()}")
-                print("Fixed Costs = Packaging + Shipping Subsidy + Fixed Daily Cost | AOV = Avg Order Value | FB/Order = Avg FB Cost per Order")
+                print("Fixed Costs = Packaging + Net Shipping + Fixed Daily Cost | AOV = Avg Order Value | FB/Order = Avg FB Cost per Order")
                 print("="*220)
                 
                 print(f"\n{'Date':<12} {'Orders':>8} {'Items':>8} {'Revenue (â‚¬)':>12} {'AOV (â‚¬)':>8} {'Product (â‚¬)':>12} {'Fixed Costs (â‚¬)':>14} {'FB Ads (â‚¬)':>12} {'Google Ads (â‚¬)':>14} {'Total Cost (â‚¬)':>14} {'Profit (â‚¬)':>12} {'ROI %':>8}")
@@ -3002,7 +3004,7 @@ class BizniWebExporter:
                 
                 for _, row in month_data.iterrows():
                     date_str = str(row['date'])
-                    fixed_costs = row['packaging_cost'] + row.get('shipping_subsidy_cost', 0) + row['fixed_daily_cost']
+                    fixed_costs = row['packaging_cost'] + row.get('shipping_net_cost', row.get('shipping_subsidy_cost', 0)) + row['fixed_daily_cost']
                     aov = row['total_revenue'] / row['unique_orders'] if row['unique_orders'] > 0 else 0
                     fb_per_order = row['fb_ads_spend'] / row['unique_orders'] if row['unique_orders'] > 0 else 0
                     google_ads = row.get('google_ads_spend', 0)
@@ -3015,7 +3017,7 @@ class BizniWebExporter:
                     month_revenue += row['total_revenue']
                     month_product_expense += row['product_expense']
                     month_packaging += row['packaging_cost']
-                    month_shipping += row.get('shipping_subsidy_cost', 0)
+                    month_shipping += row.get('shipping_net_cost', row.get('shipping_subsidy_cost', 0))
                     month_fixed += row['fixed_daily_cost']
                     month_fb_ads += row['fb_ads_spend']
                     month_google_ads += google_ads
@@ -3055,7 +3057,7 @@ class BizniWebExporter:
             
             for _, row in month_agg.iterrows():
                 month_str = str(row['month'])
-                fixed_costs = row['packaging_cost'] + row.get('shipping_subsidy_cost', 0) + row['fixed_daily_cost']
+                fixed_costs = row['packaging_cost'] + row.get('shipping_net_cost', row.get('shipping_subsidy_cost', 0)) + row['fixed_daily_cost']
                 aov = row['total_revenue'] / row['unique_orders'] if row['unique_orders'] > 0 else 0
                 fb_per_order = row['fb_ads_spend'] / row['unique_orders'] if row['unique_orders'] > 0 else 0
                 google_ads = row.get('google_ads_spend', 0)
@@ -3069,7 +3071,7 @@ class BizniWebExporter:
                 month_total_revenue += row['total_revenue']
                 month_total_product_expense += row['product_expense']
                 month_total_packaging += row['packaging_cost']
-                month_total_shipping += row.get('shipping_subsidy_cost', 0)
+                month_total_shipping += row.get('shipping_net_cost', row.get('shipping_subsidy_cost', 0))
                 month_total_fixed += row['fixed_daily_cost']
                 month_total_fb_ads += row['fb_ads_spend']
                 month_total_google_ads += google_ads
@@ -4955,9 +4957,10 @@ class BizniWebExporter:
         product_cost_by_order = df.groupby('order_num')['total_expense'].sum()
         orders_df['product_cost'] = orders_df['order_num'].map(product_cost_by_order).fillna(0)
         orders_df['packaging_cost'] = PACKAGING_COST_PER_ORDER
-        orders_df['shipping_subsidy_cost'] = SHIPPING_SUBSIDY_PER_ORDER
+        orders_df['shipping_net_cost'] = SHIPPING_NET_PER_ORDER
+        orders_df['shipping_subsidy_cost'] = orders_df['shipping_net_cost']
         orders_df['pre_ad_contribution'] = (
-            orders_df[revenue_col] - orders_df['product_cost'] - orders_df['packaging_cost'] - orders_df['shipping_subsidy_cost']
+            orders_df[revenue_col] - orders_df['product_cost'] - orders_df['packaging_cost'] - orders_df['shipping_net_cost']
         )
 
         # Mark first vs repeat orders
@@ -5208,7 +5211,7 @@ class BizniWebExporter:
             lambda row: (row['item_total_without_tax'] / row['order_item_revenue']) if row['order_item_revenue'] > 0 else 0,
             axis=1
         )
-        overhead_per_order = PACKAGING_COST_PER_ORDER + SHIPPING_SUBSIDY_PER_ORDER
+        overhead_per_order = PACKAGING_COST_PER_ORDER + SHIPPING_NET_PER_ORDER
         item_df['allocated_overhead'] = item_df['item_rev_share'] * overhead_per_order
         item_df['pre_ad_contribution'] = item_df['item_total_without_tax'] - item_df['total_expense'] - item_df['allocated_overhead']
 
@@ -5539,7 +5542,8 @@ class BizniWebExporter:
         geo.columns = ['country', 'orders', 'revenue', 'product_cost']
 
         geo['packaging_cost'] = geo['orders'] * PACKAGING_COST_PER_ORDER
-        geo['shipping_subsidy_cost'] = geo['orders'] * SHIPPING_SUBSIDY_PER_ORDER
+        geo['shipping_net_cost'] = geo['orders'] * SHIPPING_NET_PER_ORDER
+        geo['shipping_subsidy_cost'] = geo['shipping_net_cost']
 
         fb_spend_by_country = {'sk': 0.0, 'cz': 0.0, 'hu': 0.0}
         fb_spend_unattributed = 0.0
@@ -5563,7 +5567,7 @@ class BizniWebExporter:
                 fb_spend_unattributed += spend
 
         geo['fb_ads_spend'] = geo['country'].map(fb_spend_by_country).fillna(0)
-        geo['contribution_cost'] = geo['product_cost'] + geo['packaging_cost'] + geo['shipping_subsidy_cost'] + geo['fb_ads_spend']
+        geo['contribution_cost'] = geo['product_cost'] + geo['packaging_cost'] + geo['shipping_net_cost'] + geo['fb_ads_spend']
         geo['contribution_profit'] = geo['revenue'] - geo['contribution_cost']
         geo['contribution_margin_pct'] = geo.apply(
             lambda row: round((row['contribution_profit'] / row['revenue'] * 100) if row['revenue'] > 0 else 0, 2),
@@ -5783,15 +5787,19 @@ class BizniWebExporter:
         total_ad_spend = total_fb_spend + total_google_spend
         total_product_cost = date_agg['product_expense'].sum() if 'product_expense' in date_agg.columns else df['total_expense'].sum()
         total_packaging_cost = date_agg['packaging_cost'].sum() if 'packaging_cost' in date_agg.columns else 0
-        total_shipping_subsidy = date_agg['shipping_subsidy_cost'].sum() if 'shipping_subsidy_cost' in date_agg.columns else 0
+        total_shipping_net = (
+            date_agg['shipping_net_cost'].sum()
+            if 'shipping_net_cost' in date_agg.columns
+            else (date_agg['shipping_subsidy_cost'].sum() if 'shipping_subsidy_cost' in date_agg.columns else 0)
+        )
         total_fixed_overhead = date_agg['fixed_daily_cost'].sum() if 'fixed_daily_cost' in date_agg.columns else 0
-        total_company_cost = date_agg['total_cost'].sum() if 'total_cost' in date_agg.columns else (total_product_cost + total_ad_spend + total_packaging_cost + total_shipping_subsidy + total_fixed_overhead)
+        total_company_cost = date_agg['total_cost'].sum() if 'total_cost' in date_agg.columns else (total_product_cost + total_ad_spend + total_packaging_cost + total_shipping_net + total_fixed_overhead)
         total_company_profit = date_agg['net_profit'].sum() if 'net_profit' in date_agg.columns else (df['profit_before_ads'].sum() - total_fb_spend - total_google_spend)
-        total_contribution_cost = date_agg['contribution_cost'].sum() if 'contribution_cost' in date_agg.columns else (total_product_cost + total_packaging_cost + total_shipping_subsidy + total_ad_spend)
+        total_contribution_cost = date_agg['contribution_cost'].sum() if 'contribution_cost' in date_agg.columns else (total_product_cost + total_packaging_cost + total_shipping_net + total_ad_spend)
         total_contribution_profit = date_agg['contribution_profit'].sum() if 'contribution_profit' in date_agg.columns else (total_revenue - total_contribution_cost)
         # Break-even CAC is based on contribution before ad spend:
-        # Revenue - Product Cost - Packaging - Shipping subsidy (fixed overhead excluded by design).
-        total_pre_ad_contribution = total_revenue - total_product_cost - total_packaging_cost - total_shipping_subsidy
+        # Revenue - Product Cost - Packaging - Net shipping (fixed overhead excluded by design).
+        total_pre_ad_contribution = total_revenue - total_product_cost - total_packaging_cost - total_shipping_net
         pre_ad_contribution_per_order = (total_pre_ad_contribution / total_orders) if total_orders > 0 else 0
         pre_ad_contribution_per_customer = (total_pre_ad_contribution / total_customers) if total_customers > 0 else 0
 
@@ -5910,7 +5918,9 @@ class BizniWebExporter:
             'total_ad_spend': round(total_ad_spend, 2),
             'total_revenue': round(total_revenue, 2),
             'total_packaging_cost': round(total_packaging_cost, 2),
-            'total_shipping_subsidy': round(total_shipping_subsidy, 2),
+            'total_shipping_subsidy': round(total_shipping_net, 2),  # backward-compatible key
+            'total_shipping_net': round(total_shipping_net, 2),
+            'shipping_net_semantics': 'positive_cost_negative_profit',
             'total_fixed_overhead': round(total_fixed_overhead, 2),
             'total_new_customers': int(total_new_customers),
             'total_orders': total_orders,
@@ -7005,4 +7015,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/html_report_generator.py
+++ b/html_report_generator.py
@@ -176,7 +176,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
         if 'pre_ad_contribution_profit_per_order' in date_agg.columns
         else [
             (
-                (row['total_revenue'] - row['product_expense'] - row['packaging_cost'] - row.get('shipping_subsidy_cost', 0))
+                (row['total_revenue'] - row['product_expense'] - row['packaging_cost'] - row.get('shipping_net_cost', row.get('shipping_subsidy_cost', 0)))
                 / row['unique_orders']
                 if row['unique_orders'] > 0 else 0
             )
@@ -198,7 +198,11 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
     # Calculate total costs for each day (for the all metrics chart)
     total_costs_data = date_agg['total_cost'].tolist()
     packaging_costs_data = date_agg['packaging_cost'].tolist()
-    shipping_subsidy_data = date_agg['shipping_subsidy_cost'].tolist() if 'shipping_subsidy_cost' in date_agg.columns else [0] * len(dates)
+    shipping_subsidy_data = (
+        date_agg['shipping_net_cost'].tolist()
+        if 'shipping_net_cost' in date_agg.columns
+        else (date_agg['shipping_subsidy_cost'].tolist() if 'shipping_subsidy_cost' in date_agg.columns else [0] * len(dates))
+    )
     fixed_daily_costs_data = date_agg['fixed_daily_cost'].tolist()
     items_data = date_agg['total_items'].tolist()
 
@@ -220,7 +224,11 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
     total_revenue = date_agg['total_revenue'].sum()
     total_product_expense = date_agg['product_expense'].sum()
     total_packaging = date_agg['packaging_cost'].sum()
-    total_shipping_subsidy = date_agg['shipping_subsidy_cost'].sum() if 'shipping_subsidy_cost' in date_agg.columns else 0
+    total_shipping_subsidy = (
+        date_agg['shipping_net_cost'].sum()
+        if 'shipping_net_cost' in date_agg.columns
+        else (date_agg['shipping_subsidy_cost'].sum() if 'shipping_subsidy_cost' in date_agg.columns else 0)
+    )
     total_fixed = date_agg['fixed_daily_cost'].sum()
     total_fixed_costs = total_packaging + total_shipping_subsidy + total_fixed
     total_fb_ads = date_agg['fb_ads_spend'].sum()
@@ -1700,7 +1708,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                 <div class="card-value cost">&#8364;{total_packaging:,.2f}</div>
             </div>
             <div class="card">
-                <div class="card-title">Shipping Subsidy</div>
+                <div class="card-title">Net Shipping</div>
                 <div class="card-value cost">&#8364;{total_shipping_subsidy:,.2f}</div>
             </div>
             <div class="card">
@@ -2025,7 +2033,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
         
         <div class="chart-container">
             <h2 class="chart-title">Daily Revenue vs Costs</h2>
-            <p class="chart-explanation">Revenue = net sales income (without VAT) | Product Costs = cost of goods sold | FB Ads = Facebook advertising spend | Google Ads = Google advertising spend | Packaging = per-order packaging cost | Shipping Subsidy = per-order postal subsidy | Fixed Overhead = daily fixed operational cost | Net Profit = Revenue - (Product + Packaging + Shipping Subsidy + Fixed + Ads) | AOV = Average Order Value (Revenue / Orders)</p>
+            <p class="chart-explanation">Revenue = net sales income (without VAT) | Product Costs = cost of goods sold | FB Ads = Facebook advertising spend | Google Ads = Google advertising spend | Packaging = per-order packaging cost | Net Shipping = positive cost to the business, negative shipping profit | Fixed Overhead = daily fixed operational cost | Net Profit = Revenue - (Product + Packaging + Net Shipping + Fixed + Ads) | AOV = Average Order Value (Revenue / Orders)</p>
             <canvas id="revenueChart"></canvas>
         </div>
 
@@ -2049,14 +2057,14 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
 
         <div class="chart-container">
             <h2 class="chart-title">All Metrics Overview</h2>
-            <p class="chart-explanation">Comprehensive view of all daily metrics: Revenue, Total Costs (all expenses combined), Product Costs, Facebook Ads, Google Ads, Packaging Costs, Shipping Subsidy, Fixed Daily Costs, Net Profit, AOV (Average Order Value), and ROI % (Return on Investment percentage)</p>
+            <p class="chart-explanation">Comprehensive view of all daily metrics: Revenue, Total Costs (all expenses combined), Product Costs, Facebook Ads, Google Ads, Packaging Costs, Net Shipping, Fixed Daily Costs, Net Profit, AOV (Average Order Value), and ROI % (Return on Investment percentage)</p>
             <canvas id="allMetricsChart"></canvas>
         </div>
         
         <div class="chart-grid">
             <div class="chart-container">
                 <h2 class="chart-title">Daily Profit</h2>
-                <p class="chart-explanation">Net Profit = Revenue - Total Costs (includes all product, fixed, packaging, shipping subsidy, and advertising costs)</p>
+            <p class="chart-explanation">Net Profit = Revenue - Total Costs (includes all product, fixed, packaging, net shipping, and advertising costs)</p>
                 <canvas id="profitChart"></canvas>
             </div>
             <div class="chart-container">
@@ -2069,7 +2077,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
         <div class="chart-grid">
             <div class="chart-container">
                 <h2 class="chart-title">Cost Breakdown</h2>
-                <p class="chart-explanation">Distribution of total costs across categories: Product Costs (COGS), Packaging Costs, Shipping Subsidy, Fixed Overhead, Facebook Ads, and Google Ads</p>
+            <p class="chart-explanation">Distribution of total costs across categories: Product Costs (COGS), Packaging Costs, Net Shipping, Fixed Overhead, Facebook Ads, and Google Ads</p>
                 <canvas id="costPieChart"></canvas>
             </div>
             <div class="chart-container">
@@ -2089,7 +2097,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
             </div>
             <div class="chart-container">
                 <h2 class="chart-title">Daily Total Costs</h2>
-                <p class="chart-explanation">Sum of all expenses: Product Costs + Packaging + Shipping Subsidy + Fixed Overhead + Facebook Ads + Google Ads</p>
+            <p class="chart-explanation">Sum of all expenses: Product Costs + Packaging + Net Shipping + Fixed Overhead + Facebook Ads + Google Ads</p>
                 <canvas id="totalCostsChart"></canvas>
             </div>
         </div>
@@ -2102,7 +2110,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
             </div>
             <div class="chart-container">
                 <h2 class="chart-title">Daily Product Gross Margin %</h2>
-                <p class="chart-explanation">Gross margin on products only = (Revenue - Product Costs) / Revenue. Excludes packaging, shipping subsidy, ads, and fixed overhead.</p>
+            <p class="chart-explanation">Gross margin on products only = (Revenue - Product Costs) / Revenue. Excludes packaging, net shipping, ads, and fixed overhead.</p>
                 <canvas id="productGrossMarginChart"></canvas>
             </div>
             <div class="chart-container">
@@ -2132,7 +2140,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                 <canvas id="packagingCostsChart"></canvas>
             </div>
             <div class="chart-container">
-                <h2 class="chart-title">Daily Shipping Subsidy</h2>
+            <h2 class="chart-title">Daily Net Shipping</h2>
                 <p class="chart-explanation">Postal subsidy paid per order (configured as fixed amount per order)</p>
                 <canvas id="shippingSubsidyChart"></canvas>
             </div>
@@ -2164,7 +2172,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
 
         <div class="chart-container">
             <h2 class="chart-title">Daily Contribution per Order (Pre-Ad vs Post-Ad)</h2>
-            <p class="chart-explanation">Pre-Ad contribution/order = (Revenue - Product Costs - Packaging - Shipping Subsidy) / Orders. Post-Ad contribution/order additionally subtracts Ads. Fixed overhead excluded in both.</p>
+            <p class="chart-explanation">Pre-Ad contribution/order = (Revenue - Product Costs - Packaging - Net Shipping) / Orders. Post-Ad contribution/order additionally subtracts Ads. Fixed overhead excluded in both.</p>
             <canvas id="contributionPerOrderChart"></canvas>
         </div>
 
@@ -3886,7 +3894,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
     # Add daily rows
     for _, row in date_agg.iterrows():
         profit_class = "profit-positive" if row['net_profit'] > 0 else "profit-negative"
-        fixed_costs = row['packaging_cost'] + row.get('shipping_subsidy_cost', 0) + row['fixed_daily_cost']
+        fixed_costs = row['packaging_cost'] + row.get('shipping_net_cost', row.get('shipping_subsidy_cost', 0)) + row['fixed_daily_cost']
         aov = row['total_revenue'] / row['unique_orders'] if row['unique_orders'] > 0 else 0
         avg_items_per_order = row['total_items'] / row['unique_orders'] if row['unique_orders'] > 0 else 0
         fb_per_order = row['fb_ads_spend'] / row['unique_orders'] if row['unique_orders'] > 0 else 0
@@ -4781,7 +4789,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
 
         <div class="chart-container">
             <h2 class="chart-title">SK/CZ/HU Profitability (Post-Ad Contribution + FB CPO)</h2>
-            <p class="chart-explanation">Country-level post-ad contribution view using net revenue, product costs, packaging, shipping subsidy, and estimated FB spend by campaign naming (fixed overhead excluded). Unattributed FB spend (not mapped to SK/CZ/HU): &#8364;{unattributed_fb:,.2f}.</p>
+            <p class="chart-explanation">Country-level post-ad contribution view using net revenue, product costs, packaging, net shipping, and estimated FB spend by campaign naming (fixed overhead excluded). Unattributed FB spend (not mapped to SK/CZ/HU): &#8364;{unattributed_fb:,.2f}.</p>
             <canvas id="geoProfitabilityChart"></canvas>
         </div>
 
@@ -4799,7 +4807,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                         <th class="number">Revenue</th>
                         <th class="number">Product Cost</th>
                         <th class="number">Packaging</th>
-                        <th class="number">Shipping Subsidy</th>
+                        <th class="number">Net Shipping</th>
                         <th class="number">FB Spend</th>
                         <th class="number">Post-Ad Contribution Profit</th>
                         <th class="number">Post-Ad Contribution Margin %</th>
@@ -4816,7 +4824,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                         <td class="number">&#8364;{row.get('revenue', 0):,.2f}</td>
                         <td class="number">&#8364;{row.get('product_cost', 0):,.2f}</td>
                         <td class="number">&#8364;{row.get('packaging_cost', 0):,.2f}</td>
-                        <td class="number">&#8364;{row.get('shipping_subsidy_cost', 0):,.2f}</td>
+                        <td class="number">&#8364;{row.get('shipping_net_cost', row.get('shipping_subsidy_cost', 0)):,.2f}</td>
                         <td class="number">&#8364;{row.get('fb_ads_spend', 0):,.2f}</td>
                         <td class="number {'profit-positive' if row.get('contribution_profit', 0) >= 0 else 'profit-negative'}">&#8364;{row.get('contribution_profit', 0):,.2f}</td>
                         <td class="number {'profit-positive' if row.get('contribution_margin_pct', 0) >= 0 else 'profit-negative'}">{row.get('contribution_margin_pct', 0):.2f}%</td>
@@ -5203,7 +5211,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
         <div class="chart-grid">
             <div class="chart-container">
                 <h2 class="chart-title">Total Cost vs Revenue Correlation</h2>
-                <p class="chart-explanation">Scatter plot showing relationship between daily total costs (product + packaging + shipping subsidy + ads + fixed) and revenue. Higher correlation indicates predictable cost-revenue relationship.</p>
+            <p class="chart-explanation">Scatter plot showing relationship between daily total costs (product + packaging + net shipping + ads + fixed) and revenue. Higher correlation indicates predictable cost-revenue relationship.</p>
                 <canvas id="costRevenueChart"></canvas>
             </div>
         </div>
@@ -5601,7 +5609,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
             "Total Revenue (Net)": "Celkovy obrat (bez DPH)",
             "Product Costs": "Naklady na produkty",
             "Packaging Costs": "Naklady na balenie",
-            "Shipping Subsidy": "Prispevok na dopravu",
+        "Net Shipping": "Ciste shipping",
             "Fixed Overhead": "Fixne naklady",
             "Facebook Ads": "Facebook reklama",
             "Google Ads": "Google reklama",
@@ -5659,7 +5667,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
             "Daily Facebook Ads": "Denne Facebook Ads",
             "Daily Google Ads": "Denne Google Ads",
             "Daily Packaging Costs": "Denne naklady na balenie",
-            "Daily Shipping Subsidy": "Denny prispevok na dopravu",
+        "Daily Net Shipping": "Denny cisty shipping",
             "Daily Fixed Costs": "Denne fixne naklady",
             "Daily Average Order Value": "Denna priemerna hodnota objednavky",
             "Daily Items Sold": "Denny pocet predanych poloziek",
@@ -6271,7 +6279,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                         tension: 0.4
                     }},
                     {{
-                        label: 'Shipping Subsidy',
+                label: 'Net Shipping',
                         data: {json.dumps(shipping_subsidy_data)},
                         borderColor: '#f97316',
                         backgroundColor: 'rgba(249, 115, 22, 0.1)',
@@ -6618,7 +6626,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                         hidden: false
                     }},
                     {{
-                        label: 'Shipping Subsidy',
+                label: 'Net Shipping',
                         data: {json.dumps(shipping_subsidy_data)},
                         borderColor: '#f97316',
                         backgroundColor: 'rgba(249, 115, 22, 0.1)',
@@ -6841,7 +6849,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
         new Chart(costPieCtx, {{
             type: 'doughnut',
             data: {{
-                labels: ['Product Costs', 'Packaging Costs', 'Shipping Subsidy', 'Fixed Overhead', 'Facebook Ads', 'Google Ads'],
+                labels: ['Product Costs', 'Packaging Costs', 'Net Shipping', 'Fixed Overhead', 'Facebook Ads', 'Google Ads'],
                 datasets: [{{
                     data: [{total_product_expense:.2f}, {total_packaging:.2f}, {total_shipping_subsidy:.2f}, {total_fixed:.2f}, {total_fb_ads:.2f}, {total_google_ads:.2f}],
                     backgroundColor: ['#ed8936', '#f6ad55', '#f97316', '#48bb78', '#4299e1', '#34D399'],
@@ -7274,14 +7282,14 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
             }}
         }});
 
-        // Shipping Subsidy Chart
+        // Net Shipping Chart
         const shippingSubsidyCtx = document.getElementById('shippingSubsidyChart').getContext('2d');
         new Chart(shippingSubsidyCtx, {{
             type: 'bar',
             data: {{
                 labels: {json.dumps(dates)},
                 datasets: [{{
-                    label: 'Shipping Subsidy',
+                    label: 'Net Shipping',
                     data: {json.dumps(shipping_subsidy_data)},
                     backgroundColor: '#f97316',
                     borderRadius: 5
@@ -7296,7 +7304,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                     tooltip: {{
                         callbacks: {{
                             label: function(context) {{
-                                return 'Shipping Subsidy: &#8364;' + context.parsed.y.toFixed(2);
+                                    return 'Net Shipping: &#8364;' + context.parsed.y.toFixed(2);
                             }}
                         }}
                     }}

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -5,7 +5,7 @@
   "enable_email_strategy_report": false,
   "report_from_date": "2025-09-24",
   "packaging_cost_per_order": 0.05,
-  "shipping_subsidy_per_order": -0.2,
+  "shipping_net_per_order": -0.2,
   "fixed_monthly_cost": 4900,
   "weather": {
     "enabled": true,

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -6,7 +6,7 @@
   "enable_email_strategy_report": true,
   "report_from_date": "2025-05-03",
   "packaging_cost_per_order": 0.3,
-  "shipping_subsidy_per_order": 0.2,
+  "shipping_net_per_order": 0.2,
   "fixed_monthly_cost": 0,
   "weather": {
     "enabled": true,

--- a/reporting_core/cfo_kpis.py
+++ b/reporting_core/cfo_kpis.py
@@ -136,7 +136,7 @@ def _build_daily_rows_from_date_agg(date_agg: pd.DataFrame) -> List[Dict[str, An
         orders = int(float(row.get("unique_orders", 0) or 0))
         product_costs = float(row.get("product_expense", 0) or 0)
         packaging_costs = float(row.get("packaging_cost", 0) or 0)
-        shipping_subsidy = float(row.get("shipping_subsidy_cost", 0) or 0)
+        shipping_subsidy = float(row.get("shipping_net_cost", row.get("shipping_subsidy_cost", 0)) or 0)
         facebook_ads = float(row.get("fb_ads_spend", 0) or 0)
         google_ads = float(row.get("google_ads_spend", 0) or 0)
         total_ads = facebook_ads + google_ads
@@ -159,6 +159,7 @@ def _build_daily_rows_from_date_agg(date_agg: pd.DataFrame) -> List[Dict[str, An
                 "product_costs": product_costs,
                 "packaging_costs": packaging_costs,
                 "shipping_subsidy": shipping_subsidy,
+                "shipping_net": shipping_subsidy,
                 "facebook_ads": facebook_ads,
                 "google_ads": google_ads,
                 "total_ads": total_ads,

--- a/reporting_core/runtime.py
+++ b/reporting_core/runtime.py
@@ -36,6 +36,15 @@ class ProjectRuntime:
     weather: Dict[str, Any]
     reporting_defaults: Dict[str, Any]
 
+    @property
+    def shipping_net_per_order(self) -> float:
+        """Canonical shipping semantics.
+
+        Positive value = net shipping cost to the business.
+        Negative value = shipping profit / shipping margin retained by the business.
+        """
+        return float(self.shipping_subsidy_per_order)
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "project_name": self.project_name,
@@ -43,6 +52,7 @@ class ProjectRuntime:
             "api_token": self.api_token,
             "packaging_cost_per_order": self.packaging_cost_per_order,
             "shipping_subsidy_per_order": self.shipping_subsidy_per_order,
+            "shipping_net_per_order": self.shipping_net_per_order,
             "fixed_monthly_cost": self.fixed_monthly_cost,
             "currency_rates_to_eur": dict(self.currency_rates_to_eur),
             "product_expenses": dict(self.product_expenses),
@@ -102,7 +112,12 @@ def load_project_runtime(
         api_url=resolve_biznisweb_api_url(project_name, settings),
         api_token=os.getenv("BIZNISWEB_API_TOKEN", ""),
         packaging_cost_per_order=float(settings.get("packaging_cost_per_order", default_packaging_cost_per_order)),
-        shipping_subsidy_per_order=float(settings.get("shipping_subsidy_per_order", default_shipping_subsidy_per_order)),
+        shipping_subsidy_per_order=float(
+            settings.get(
+                "shipping_net_per_order",
+                settings.get("shipping_subsidy_per_order", default_shipping_subsidy_per_order),
+            )
+        ),
         fixed_monthly_cost=float(settings.get("fixed_monthly_cost", default_fixed_monthly_cost)),
         currency_rates_to_eur={
             str(k).upper(): float(v)
@@ -135,6 +150,7 @@ def load_project_runtime(
 def apply_project_runtime(runtime: ProjectRuntime, target_globals: Dict[str, Any]) -> None:
     target_globals["PACKAGING_COST_PER_ORDER"] = float(runtime.packaging_cost_per_order)
     target_globals["SHIPPING_SUBSIDY_PER_ORDER"] = float(runtime.shipping_subsidy_per_order)
+    target_globals["SHIPPING_NET_PER_ORDER"] = float(runtime.shipping_net_per_order)
     target_globals["FIXED_MONTHLY_COST"] = float(runtime.fixed_monthly_cost)
     target_globals["CURRENCY_RATES_TO_EUR"] = dict(runtime.currency_rates_to_eur)
     target_globals["PRODUCT_EXPENSES"] = dict(runtime.product_expenses)

--- a/templates/reporting-client/settings.template.json
+++ b/templates/reporting-client/settings.template.json
@@ -5,7 +5,7 @@
   "enable_email_strategy_report": false,
   "report_from_date": "2026-01-01",
   "packaging_cost_per_order": 0.3,
-  "shipping_subsidy_per_order": 0.0,
+  "shipping_net_per_order": 0.0,
   "fixed_monthly_cost": 0,
   "weather": {
     "enabled": false,


### PR DESCRIPTION
## Summary\n- replace ambiguous shipping subsidy semantics with canonical net shipping semantics\n- update runtime/config, export math, dashboard labels and legacy fallbacks\n- verify VEVO and ROY March 2026 exports after the change\n\n## Verification\n- python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py reporting_core/runtime.py reporting_core/cfo_kpis.py daily_report_runner.py\n- python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31\n- python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31