### PR TITLE
Add acquisition source family cube

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1003,3 +1003,27 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - consistency checks remain green after CM taxonomy exposure
 - Next exact step:
   - add acquisition-source x product-family cube for ROY and VEVO so channel efficiency can be evaluated by product family instead of only globally.
+### 2026-04-11 (Acquisition-source x product-family cube)
+- Added order-level ad spend hydration into the advanced DTC pipeline so first-order source proxies can be derived consistently from the first purchase day.
+- Wired the existing `analyze_acquisition_source_product_family_cube(...)` model into `analyze_advanced_dtc_metrics(...)` and exposed it in the exported advanced metrics payload as:
+  - `acquisition_product_family_cube`
+- Extended the modern dashboard payload in `dashboard_modern.py` with:
+  - `acquisition_family.cube_rows`
+  - `acquisition_family.source_rows`
+  - `acquisition_family.family_rows`
+  - `acquisition_family.summary`
+- Added three new marketing library charts to the modern dashboard for both VEVO and ROY:
+  - `Source proxy x product family`
+  - `90d contribution by source proxy x family`
+  - `Source proxy summary`
+- The new view is explicitly proxy-based, using paid-day presence (`facebook_paid_day`, `google_paid_day`, `mixed_paid_day`, `organic_unknown_day`) rather than pretending to be exact order-level attribution.
+- Verified with:
+  - `python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py`
+  - `python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31`
+  - `python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31`
+- Verification outcome:
+  - VEVO and ROY March 2026 reports regenerate successfully
+  - both rendered HTML reports contain the new acquisition-family charts and chart bindings
+  - no regression in existing advanced DTC or marketing sections
+- Next exact step:
+  - add Vevo cohort refill model so refill timing is measured by first-item cohort and horizon, not only by generic repeat-purchase logic.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -98,10 +98,12 @@ Bootstrap entrypoints:
 - Env Check CI baseline now validates partial-data rendering in the active HTML layer (`html_report_generator.py` / `dashboard_modern.py`) instead of the retired daily runner rendering path.
 - Production dashboard now keeps `Executive KPI deck` on its own `Daily / Weekly / Monthly` switch while the rest of the report uses a separate global analytics window switcher in the sidebar.
 - Period bundle generation is enabled for plain production reports, so the sidebar analytics switch now works outside of test-tag exports too.
+- Shipping semantics are now normalized to net shipping in runtime config and dashboard labels, but CM taxonomy naming is still mixed between legacy labels and CM1/CM2/CM3 terms in some views.
+- Full QA assertions are now computed into `data_quality` sidecars and surfaced in dashboard/email/CloudWatch, but the next business-model layer (Vevo refill cohorts) is still missing.
 
 ## 8) Next Exact Step
 
-- Normalize shipping sign convention across both projects so `shipping` / `shipping_subsidy` has one clear meaning in export, dashboard labels, and profitability math.
+- Implement Vevo cohort refill model (sample/full-size first-order cohorts, refill windows, and cohort refill timing charts) on top of the now-verified QA assertion layer.
 
 ## 9) Change Log
 
@@ -218,6 +220,28 @@ Bootstrap entrypoints:
   - Geo confidence guardrails panel
   - confidence badges for country rows
   - guarded geo profitability chart/table values (`N/A` on low-sample markets)
+
+### 2026-04-11 (QA assertions + shipping semantics)
+- Verified shared QA assertion layer end-to-end on real March 2026 VEVO and ROY exports.
+- Export layer now computes `qa.assertions` with:
+  - shell/library parity checks for critical economics metrics,
+  - refund binding presence,
+  - platform/attributed CPA arithmetic mismatch detection,
+  - attributed orders tolerance checks,
+  - missing dimension counts (`day_name`, `anchor_item`, `attached_item`, `anchor_orders`, `country`),
+  - `null_label_rate_pct`, `qa_failure_count`, `qa_warning_count`.
+- Daily runner now includes data-quality summary in email body and publishes CloudWatch QA metrics:
+  - `ReportQaWarnings`
+  - `ReportQaFailures`
+  - `ReportQaCritical`
+  - `ReportPartialData`
+- Modern dashboard now renders both failure and warning assertion blocks plus richer geo confidence share cards.
+- Shipping terminology was normalized from subsidy-style wording to `Net shipping` / `shipping_net_cost` in config, export, and dashboard labels.
+- Verified locally with:
+  - `python -m py_compile export_orders.py dashboard_modern.py daily_report_runner.py scripts\\security_ci.py`
+  - `python scripts\\security_ci.py`
+  - `python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31`
+  - `python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31`
 - Added CI guardrails so geo QA metadata and the dashboard geo-confidence panel cannot disappear silently.
 - Verification target:
   - `python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py scripts\\security_ci.py`
@@ -979,4 +1003,3 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - consistency checks remain green after CM taxonomy exposure
 - Next exact step:
   - add acquisition-source x product-family cube for ROY and VEVO so channel efficiency can be evaluated by product family instead of only globally.
-

--- a/daily_report_runner.py
+++ b/daily_report_runner.py
@@ -180,6 +180,33 @@ def load_data_quality(path: Optional[Path]) -> Dict[str, Any]:
         }
 
 
+def build_data_quality_summary(data_quality: Dict[str, Any]) -> str:
+    overall_status = str(data_quality.get("overall_status") or "unknown").upper()
+    qa_status = str(data_quality.get("qa_status") or "unknown").upper()
+    summary = str(data_quality.get("summary") or "No data quality summary is available.")
+    qa_failure_count = int(data_quality.get("qa_failure_count") or 0)
+    qa_warning_count = int(data_quality.get("qa_warning_count") or 0)
+    partial_sources = list(data_quality.get("partial_sources") or [])
+    qa_errors = list(data_quality.get("qa_errors") or [])
+    qa_warnings = list(data_quality.get("qa_warnings") or [])
+
+    lines = [
+        "DATA QUALITY",
+        f"- Overall status: {overall_status}",
+        f"- QA status: {qa_status}",
+        f"- QA failures: {qa_failure_count}",
+        f"- QA warnings: {qa_warning_count}",
+        f"- Summary: {summary}",
+    ]
+    if partial_sources:
+        lines.append(f"- Partial sources: {', '.join(map(str, partial_sources[:5]))}")
+    if qa_errors:
+        lines.append(f"- Critical QA checks: {', '.join(map(str, qa_errors[:5]))}")
+    if qa_warnings:
+        lines.append(f"- Warning QA checks: {', '.join(map(str, qa_warnings[:5]))}")
+    return "\n".join(lines)
+
+
 def s3_upload_outputs(project: str, paths: Dict[str, Path]) -> Dict[str, str]:
     bucket = os.getenv("REPORT_S3_BUCKET", "").strip()
     prefix = os.getenv("REPORT_S3_PREFIX", "").strip().strip("/")
@@ -843,14 +870,22 @@ def build_report_summary(file_paths: Dict[str, Path]) -> str:
     ])
 
 
-def build_email_body(from_date: str, to_date: str, summary_text: str, reporting_defaults: Dict[str, Any]) -> str:
+def build_email_body(
+    from_date: str,
+    to_date: str,
+    summary_text: str,
+    reporting_defaults: Dict[str, Any],
+    data_quality: Optional[Dict[str, Any]] = None,
+) -> str:
     display_name = reporting_defaults["display_name"]
     reporting_system_name = reporting_defaults["reporting_system_name"]
+    data_quality_block = build_data_quality_summary(data_quality or {})
     return (
         "Dobry den,\n\n"
         f"v prilohe posielam denny {display_name} report v HTML formate.\n"
         f"Sledovane obdobie: {from_date} az {to_date}.\n\n"
         f"{summary_text}\n\n"
+        f"{data_quality_block}\n\n"
         f"Tento email bol odoslany automaticky zo systemu {reporting_system_name}.\n"
     )
 
@@ -1001,6 +1036,21 @@ def main() -> None:
         raise FileNotFoundError(f"Expected output files not found: {missing}")
 
     s3_upload_outputs(project, output_paths)
+    data_quality = load_data_quality(output_paths.get("data_quality_json"))
+    put_metric("ReportQaWarnings", int(data_quality.get("qa_warning_count") or 0), project, reporting_defaults)
+    put_metric("ReportQaFailures", int(data_quality.get("qa_failure_count") or 0), project, reporting_defaults)
+    put_metric(
+        "ReportQaCritical",
+        1 if str(data_quality.get("qa_status") or "").lower() == "critical" else 0,
+        project,
+        reporting_defaults,
+    )
+    put_metric(
+        "ReportPartialData",
+        1 if bool(data_quality.get("is_partial")) else 0,
+        project,
+        reporting_defaults,
+    )
 
     if args.skip_email:
         print("Email sending skipped by flag.")
@@ -1008,7 +1058,7 @@ def main() -> None:
 
     subject = build_email_subject(reporting_defaults)
     summary_text = build_report_summary(output_paths)
-    body_text = build_email_body(from_date, to_date, summary_text, reporting_defaults)
+    body_text = build_email_body(from_date, to_date, summary_text, reporting_defaults, data_quality)
     message_id = send_email_ses(
         subject=subject,
         body_text=body_text,

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -894,6 +894,53 @@ def generate_modern_dashboard(
         ],
         limit=10,
     )
+    acquisition_family_cube = (advanced_dtc_metrics or {}).get("acquisition_product_family_cube", {}) if advanced_dtc_metrics else {}
+    acquisition_family_cube_rows = _frame_rows(
+        (acquisition_family_cube or {}).get("cube_rows"),
+        [
+            "source_proxy_key",
+            "source_proxy_label",
+            "product_family_key",
+            "product_family_label",
+            "new_customers",
+            "first_order_revenue",
+            "first_order_contribution",
+            "first_order_aov",
+            "first_order_contribution_per_order",
+            "repeat_60d_rate_pct",
+            "repeat_90d_rate_pct",
+            "revenue_ltv_90d",
+            "contribution_ltv_90d",
+            "revenue_ltv_90d_per_customer",
+            "contribution_ltv_90d_per_customer",
+        ],
+        limit=40,
+    )
+    acquisition_family_source_rows = _frame_rows(
+        (acquisition_family_cube or {}).get("source_rows"),
+        [
+            "source_proxy_key",
+            "source_proxy_label",
+            "new_customers",
+            "revenue_ltv_90d",
+            "contribution_ltv_90d",
+            "contribution_ltv_90d_per_customer",
+        ],
+        limit=10,
+    )
+    acquisition_family_family_rows = _frame_rows(
+        (acquisition_family_cube or {}).get("family_rows"),
+        [
+            "product_family_key",
+            "product_family_label",
+            "new_customers",
+            "first_order_revenue",
+            "contribution_ltv_90d",
+            "repeat_90d_rate_pct",
+            "contribution_ltv_90d_per_customer",
+        ],
+        limit=20,
+    )
 
     heatmap_rows = _frame_rows(day_hour_heatmap, ["day_name", "hour", "orders"], limit=None)
     b2b_rows = _frame_rows(b2b_analysis, ["customer_type", "orders", "revenue", "profit", "unique_customers", "aov", "orders_pct", "revenue_pct"], limit=10)
@@ -1182,6 +1229,12 @@ def generate_modern_dashboard(
             "pair_rows": bundle_accessory_pair_rows,
             "device_rows": bundle_accessory_device_rows,
             "group_rows": bundle_accessory_group_rows,
+        },
+        "acquisition_family": {
+            "summary": {k: _maybe_num(v) if isinstance(v, (int, float)) else _json_safe(v) for k, v in ((acquisition_family_cube or {}).get("summary") or {}).items()},
+            "cube_rows": acquisition_family_cube_rows,
+            "source_rows": acquisition_family_source_rows,
+            "family_rows": acquisition_family_family_rows,
         },
         "daily_margin_rows": daily_margin_rows,
         "payday_window_rows": payday_window_rows,
@@ -3560,6 +3613,13 @@ def generate_modern_dashboard(
                 );
             }}
             if (hasRows(DATA.dow_effectiveness_rows)) marketingItems.push({{ id: 'mktDowRevenueSpendChart', title: {{ en: 'Weekday revenue and spend', sk: 'Trzba a spend podla dna' }}, desc: {{ en: 'Average weekday business output versus FB spend.', sk: 'Priemerny vykon dna oproti FB spendu.' }} }});
+            if (hasRows(DATA.acquisition_family.cube_rows)) {{
+                marketingItems.push(
+                    {{ id: 'mktSourceFamilyMixChart', title: {{ en: 'Source proxy x product family', sk: 'Source proxy x produktova family' }}, desc: {{ en: 'New-customer mix by paid-day source proxy and dominant first-order family.', sk: 'Mix novych zakaznikov podla paid-day source proxy a dominantnej family prveho nakupu.' }} }},
+                    {{ id: 'mktSourceFamilyContributionChart', title: {{ en: '90d contribution by source proxy x family', sk: '90d contribution podla source proxy x family' }}, desc: {{ en: 'Downstream 90d contribution quality by source proxy and first-order family.', sk: 'Kvalita downstream 90d contribution podla source proxy a family prveho nakupu.' }} }},
+                );
+            }}
+            if (hasRows(DATA.acquisition_family.source_rows)) marketingItems.push({{ id: 'mktSourceProxySummaryChart', title: {{ en: 'Source proxy summary', sk: 'Sumar source proxy' }}, desc: {{ en: 'New-customer volume and contribution LTV per customer by source proxy.', sk: 'Objem novych zakaznikov a contribution LTV na zakaznika podla source proxy.' }} }});
             renderGalleryCards('libraryMarketing', marketingItems);
 
             if (document.getElementById('mktDailyCpoRoasChart')) {{
@@ -3733,6 +3793,66 @@ def generate_modern_dashboard(
                         ],
                     }},
                     options: dowSpendOpts,
+                }});
+            }}
+            if (document.getElementById('mktSourceFamilyMixChart')) {{
+                const cubeRows = DATA.acquisition_family.cube_rows || [];
+                const familyLabels = [...new Set(cubeRows.map(x => x.product_family_label || 'Other / unclassified'))];
+                const sourceLabels = [...new Set(cubeRows.map(x => x.source_proxy_label || 'Unknown source'))];
+                const colorMap = {{
+                    'Facebook-paid day': 'rgba(255,138,31,.72)',
+                    'Google-paid day': 'rgba(71,102,255,.68)',
+                    'Mixed paid day': 'rgba(31,157,102,.68)',
+                    'Organic / unknown day': 'rgba(143,130,120,.62)',
+                }};
+                const mixOpts = baseOptions();
+                mixOpts.scales.x.stacked = true;
+                mixOpts.scales.y.stacked = true;
+                new Chart(document.getElementById('mktSourceFamilyMixChart'), {{
+                    type: 'bar',
+                    data: {{
+                        labels: familyLabels,
+                        datasets: sourceLabels.map(source => ({{
+                            label: source,
+                            data: familyLabels.map(family => {{
+                                const row = cubeRows.find(x => (x.source_proxy_label || 'Unknown source') === source && (x.product_family_label || 'Other / unclassified') === family);
+                                return Number((row && row.new_customers) || 0);
+                            }}),
+                            backgroundColor: colorMap[source] || 'rgba(255,138,31,.55)',
+                            borderRadius: 8,
+                        }})),
+                    }},
+                    options: mixOpts,
+                }});
+            }}
+            if (document.getElementById('mktSourceFamilyContributionChart')) {{
+                const rows = [...(DATA.acquisition_family.cube_rows || [])]
+                    .sort((a, b) => Number(b.contribution_ltv_90d_per_customer || 0) - Number(a.contribution_ltv_90d_per_customer || 0))
+                    .slice(0, 12);
+                const familyContributionOpts = dualAxisOptions();
+                new Chart(document.getElementById('mktSourceFamilyContributionChart'), {{
+                    data: {{
+                        labels: rows.map(x => `${{x.source_proxy_label || 'Unknown'}} • ${{x.product_family_label || 'Other'}}`.slice(0, 32)),
+                        datasets: [
+                            {{ type: 'bar', label: 'Contribution LTV 90d / customer', data: rows.map(x => Number(x.contribution_ltv_90d_per_customer || 0)), backgroundColor: 'rgba(31,157,102,.68)', borderRadius: 8, yAxisID: 'y' }},
+                            {{ type: 'line', label: 'Repeat 90d %', data: rows.map(x => Number(x.repeat_90d_rate_pct || 0)), borderColor: '#cf5060', tension: .30, borderWidth: 2.2, pointRadius: 3, yAxisID: 'y1' }},
+                        ],
+                    }},
+                    options: familyContributionOpts,
+                }});
+            }}
+            if (document.getElementById('mktSourceProxySummaryChart')) {{
+                const rows = DATA.acquisition_family.source_rows || [];
+                const sourceSummaryOpts = dualAxisOptions();
+                new Chart(document.getElementById('mktSourceProxySummaryChart'), {{
+                    data: {{
+                        labels: rows.map(x => x.source_proxy_label || 'Unknown'),
+                        datasets: [
+                            {{ type: 'bar', label: 'New customers', data: rows.map(x => Number(x.new_customers || 0)), backgroundColor: 'rgba(255,138,31,.66)', borderRadius: 8, yAxisID: 'y' }},
+                            {{ type: 'line', label: 'Contribution LTV 90d / customer', data: rows.map(x => Number(x.contribution_ltv_90d_per_customer || 0)), borderColor: '#4766ff', tension: .30, borderWidth: 2.2, pointRadius: 3, yAxisID: 'y1' }},
+                        ],
+                    }},
+                    options: sourceSummaryOpts,
                 }});
             }}
         }}

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1249,12 +1249,19 @@ def generate_modern_dashboard(
         else '<p class="muted-note"><span class="lang-en">No low-sample geo warnings for the current report window.</span><span class="lang-sk hidden">V aktualnom okne nie su ziadne geo warningy pre malu vzorku.</span></p>'
     )
     data_assertion_warning_items = list(data_assertions_qa.get("warnings") or [])
+    data_assertion_failure_items = list(data_assertions_qa.get("failures") or [])
     data_assertion_warning_items_html = "".join(f"<li>{escape(str(item))}</li>" for item in data_assertion_warning_items)
+    data_assertion_failure_items_html = "".join(f"<li>{escape(str(item))}</li>" for item in data_assertion_failure_items)
     data_assertion_warning_block_html = (
-        f'<ul class="warning-list">{data_assertion_warning_items_html}</ul>'
-        if data_assertion_warning_items_html
-        else '<p class="muted-note"><span class="lang-en">Data assertions passed for the current report window.</span><span class="lang-sk hidden">Datove assertions pre aktualne okno presli bez warningov.</span></p>'
-    )
+        (
+            f'<div class="warning-block"><p class="muted-note"><span class="lang-en">Critical QA failures</span><span class="lang-sk hidden">Kriticke QA chyby</span></p><ul class="warning-list">{data_assertion_failure_items_html}</ul></div>'
+            if data_assertion_failure_items_html else ""
+        )
+        + (
+            f'<div class="warning-block"><p class="muted-note"><span class="lang-en">Warnings</span><span class="lang-sk hidden">Warningy</span></p><ul class="warning-list">{data_assertion_warning_items_html}</ul></div>'
+            if data_assertion_warning_items_html else ""
+        )
+    ) or '<p class="muted-note"><span class="lang-en">Data assertions passed for the current report window.</span><span class="lang-sk hidden">Datove assertions pre aktualne okno presli bez warningov.</span></p>'
     margin_stability_warning_items = list(margin_stability_qa.get("warnings") or [])
     margin_stability_warning_items_html = "".join(f"<li>{escape(str(item))}</li>" for item in margin_stability_warning_items)
     margin_stability_warning_block_html = (
@@ -2214,15 +2221,21 @@ def generate_modern_dashboard(
                             <div class="mini-card"><small><span class="lang-en">Observe countries</span><span class="lang-sk hidden">Sledovane krajiny</span></small><strong>{int(round(_num(geo_qa.get("observe_count"))))}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">Ignore countries</span><span class="lang-sk hidden">Ignorovane krajiny</span></small><strong>{int(round(_num(geo_qa.get("ignore_count"))))}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">Unknown country rate</span><span class="lang-sk hidden">Podiel neznamej krajiny</span></small><strong>{_format_mini_value_html(geo_qa.get("unknown_country_rate"), kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Low-conf. order share</span><span class="lang-sk hidden">Podiel objednavok s nizkou istotou</span></small><strong>{_format_mini_value_html(geo_qa.get("low_confidence_order_share_pct"), kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Low-conf. revenue share</span><span class="lang-sk hidden">Podiel trzby s nizkou istotou</span></small><strong>{_format_mini_value_html(geo_qa.get("low_confidence_revenue_share_pct"), kind="percent")}</strong></div>
                         </div>
                         {geo_warning_block_html}
                     </div>
                     <div class="panel table-card" style="margin-top:18px;">
                         <div class="card-head"><div><h3><span class="lang-en">Data assertions</span><span class="lang-sk hidden">Datove assertions</span></h3><p><span class="lang-en">Pipeline-level parity, arithmetic and dimension completeness checks.</span><span class="lang-sk hidden">Kontroly parity, aritmetiky a uplnosti dimenzii priamo v pipeline.</span></p></div></div>
                         <div class="mini-grid">
+                            <div class="mini-card"><small><span class="lang-en">Critical failures</span><span class="lang-sk hidden">Kriticke chyby</span></small><strong>{int(round(_num(data_assertions_qa.get("failure_count"))))}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Warnings</span><span class="lang-sk hidden">Warningy</span></small><strong>{int(round(_num(data_assertions_qa.get("warning_count"))))}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">Shell parity failures</span><span class="lang-sk hidden">Shell parity chyby</span></small><strong>{int(round(_num(data_assertions_qa.get("shell_parity_failures"))))}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">Platform CPA mismatches</span><span class="lang-sk hidden">Platform CPA nezrovnalosti</span></small><strong>{int(round(_num(data_assertions_qa.get("platform_cpa_mismatches"))))}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">Attributed CPA mismatches</span><span class="lang-sk hidden">Attributed CPA nezrovnalosti</span></small><strong>{int(round(_num(data_assertions_qa.get("attributed_cpa_mismatches"))))}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Null label rate</span><span class="lang-sk hidden">Podiel null labelov</span></small><strong>{_format_mini_value_html(data_assertions_qa.get("null_label_rate_pct"), kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Attributed orders ratio</span><span class="lang-sk hidden">Pomer attributed objednavok</span></small><strong>{_format_mini_value_html(_num(data_assertions_qa.get("attributed_orders_ratio")) * 100 if data_assertions_qa.get("attributed_orders_ratio") is not None else None, kind="percent")}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">Missing country labels</span><span class="lang-sk hidden">Chybajuce country labely</span></small><strong>{int(round(_num(data_assertions_qa.get("country_missing"))))}</strong></div>
                         </div>
                         {data_assertion_warning_block_html}

--- a/export_orders.py
+++ b/export_orders.py
@@ -1231,6 +1231,10 @@ class BizniWebExporter:
         config = self.project_settings.get("bundle_accessory_model") or {}
         return config if isinstance(config, dict) else {}
 
+    def _product_family_groups_config(self) -> List[Dict[str, Any]]:
+        groups = self.project_settings.get("product_family_groups") or []
+        return groups if isinstance(groups, list) else []
+
     def _match_named_group(self, label: Any, groups: List[Dict[str, Any]]) -> Tuple[Optional[str], Optional[str]]:
         for group in groups or []:
             if self._matches_patterns(str(label or ""), group.get("patterns") or []):
@@ -1239,6 +1243,238 @@ class BizniWebExporter:
                 if group_key:
                     return group_key, group_label
         return None, None
+
+    @staticmethod
+    def _source_proxy_from_spend(fb_spend: Any, google_spend: Any) -> Tuple[str, str]:
+        fb_value = float(fb_spend or 0.0)
+        google_value = float(google_spend or 0.0)
+        if fb_value > 0 and google_value > 0:
+            return "mixed_paid_day", "Mixed paid day"
+        if fb_value > 0:
+            return "facebook_paid_day", "Facebook-paid day"
+        if google_value > 0:
+            return "google_paid_day", "Google-paid day"
+        return "organic_unknown_day", "Organic / unknown day"
+
+    def analyze_acquisition_source_product_family_cube(
+        self,
+        orders_df: pd.DataFrame,
+        item_df: pd.DataFrame,
+        customer_orders: pd.DataFrame,
+        revenue_col: str,
+    ) -> dict:
+        family_groups = self._product_family_groups_config()
+        if not family_groups or orders_df.empty or item_df.empty or customer_orders.empty:
+            return {
+                "summary": {},
+                "cube_rows": pd.DataFrame(),
+                "source_rows": pd.DataFrame(),
+                "family_rows": pd.DataFrame(),
+            }
+
+        required_item_columns = {"order_num", "item_label", "item_total_without_tax"}
+        if not required_item_columns.issubset(item_df.columns):
+            return {
+                "summary": {},
+                "cube_rows": pd.DataFrame(),
+                "source_rows": pd.DataFrame(),
+                "family_rows": pd.DataFrame(),
+            }
+
+        classified_rows = []
+        for row in item_df[["order_num", "item_label", "item_total_without_tax"]].itertuples(index=False):
+            family_key, family_label = self._match_named_group(row.item_label, family_groups)
+            if not family_key:
+                continue
+            classified_rows.append(
+                {
+                    "order_num": row.order_num,
+                    "product_family_key": family_key,
+                    "product_family_label": family_label,
+                    "item_total_without_tax": float(row.item_total_without_tax or 0.0),
+                }
+            )
+
+        if not classified_rows:
+            return {
+                "summary": {},
+                "cube_rows": pd.DataFrame(),
+                "source_rows": pd.DataFrame(),
+                "family_rows": pd.DataFrame(),
+            }
+
+        classified_df = pd.DataFrame(classified_rows)
+        family_by_order = (
+            classified_df.groupby(["order_num", "product_family_key", "product_family_label"], as_index=False)
+            .agg(order_family_revenue=("item_total_without_tax", "sum"))
+            .sort_values(["order_num", "order_family_revenue"], ascending=[True, False])
+            .drop_duplicates(subset=["order_num"])
+        )
+        order_family_map = family_by_order.set_index("order_num")[["product_family_key", "product_family_label"]]
+
+        order_source_frame = orders_df[
+            [
+                "order_num",
+                "customer_email",
+                "purchase_datetime",
+                revenue_col,
+                "pre_ad_contribution",
+                "fb_ads_daily_spend",
+                "google_ads_daily_spend",
+            ]
+        ].drop_duplicates(subset=["order_num"]).copy()
+        order_source_frame = order_source_frame.merge(order_family_map, left_on="order_num", right_index=True, how="left")
+        order_source_frame["product_family_key"] = order_source_frame["product_family_key"].fillna("other_unclassified")
+        order_source_frame["product_family_label"] = order_source_frame["product_family_label"].fillna("Other / unclassified")
+        proxy_pairs = order_source_frame.apply(
+            lambda row: self._source_proxy_from_spend(row.get("fb_ads_daily_spend"), row.get("google_ads_daily_spend")),
+            axis=1,
+        )
+        order_source_frame["source_proxy_key"] = proxy_pairs.apply(lambda value: value[0])
+        order_source_frame["source_proxy_label"] = proxy_pairs.apply(lambda value: value[1])
+
+        first_orders = (
+            order_source_frame.sort_values(["customer_email", "purchase_datetime"])
+            .drop_duplicates(subset=["customer_email"], keep="first")
+            .copy()
+        )
+        first_orders["first_order_revenue"] = first_orders[revenue_col]
+        first_orders["first_order_contribution"] = first_orders["pre_ad_contribution"]
+
+        customer_enriched = customer_orders.merge(
+            first_orders[
+                [
+                    "customer_email",
+                    "source_proxy_key",
+                    "source_proxy_label",
+                    "product_family_key",
+                    "product_family_label",
+                ]
+            ],
+            on="customer_email",
+            how="left",
+        )
+
+        def _repeat_within_days(group: pd.DataFrame, days: int) -> int:
+            return int(((group["days_since_first"] > 0) & (group["days_since_first"] <= days)).any())
+
+        customer_level_rows = []
+        for customer_email, group in customer_enriched.groupby("customer_email"):
+            first_row = group.sort_values("purchase_datetime").iloc[0]
+            window_90 = group[group["days_since_first"] <= 90].copy()
+            customer_level_rows.append(
+                {
+                    "customer_email": customer_email,
+                    "source_proxy_key": first_row.get("source_proxy_key"),
+                    "source_proxy_label": first_row.get("source_proxy_label"),
+                    "product_family_key": first_row.get("product_family_key"),
+                    "product_family_label": first_row.get("product_family_label"),
+                    "first_order_revenue": float(first_row.get("first_order_revenue") or 0.0),
+                    "first_order_contribution": float(first_row.get("first_order_contribution") or 0.0),
+                    "orders_total": int(group["order_num"].nunique()),
+                    "repeat_60d_flag": _repeat_within_days(group, 60),
+                    "repeat_90d_flag": _repeat_within_days(group, 90),
+                    "revenue_ltv_90d": float(window_90[revenue_col].sum()),
+                    "contribution_ltv_90d": float(window_90["pre_ad_contribution"].sum()),
+                }
+            )
+
+        customer_level = pd.DataFrame(customer_level_rows)
+        if customer_level.empty:
+            return {
+                "summary": {},
+                "cube_rows": pd.DataFrame(),
+                "source_rows": pd.DataFrame(),
+                "family_rows": pd.DataFrame(),
+            }
+
+        cube_rows = (
+            customer_level.groupby(
+                ["source_proxy_key", "source_proxy_label", "product_family_key", "product_family_label"],
+                as_index=False,
+            )
+            .agg(
+                new_customers=("customer_email", "nunique"),
+                first_order_revenue=("first_order_revenue", "sum"),
+                first_order_contribution=("first_order_contribution", "sum"),
+                repeat_60d_customers=("repeat_60d_flag", "sum"),
+                repeat_90d_customers=("repeat_90d_flag", "sum"),
+                revenue_ltv_90d=("revenue_ltv_90d", "sum"),
+                contribution_ltv_90d=("contribution_ltv_90d", "sum"),
+            )
+        )
+        cube_rows["first_order_aov"] = cube_rows.apply(
+            lambda row: (row["first_order_revenue"] / row["new_customers"]) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+        cube_rows["first_order_contribution_per_order"] = cube_rows.apply(
+            lambda row: (row["first_order_contribution"] / row["new_customers"]) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+        cube_rows["repeat_60d_rate_pct"] = cube_rows.apply(
+            lambda row: (row["repeat_60d_customers"] / row["new_customers"] * 100) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+        cube_rows["repeat_90d_rate_pct"] = cube_rows.apply(
+            lambda row: (row["repeat_90d_customers"] / row["new_customers"] * 100) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+        cube_rows["revenue_ltv_90d_per_customer"] = cube_rows.apply(
+            lambda row: (row["revenue_ltv_90d"] / row["new_customers"]) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+        cube_rows["contribution_ltv_90d_per_customer"] = cube_rows.apply(
+            lambda row: (row["contribution_ltv_90d"] / row["new_customers"]) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+        cube_rows = cube_rows.sort_values(
+            ["new_customers", "contribution_ltv_90d_per_customer", "repeat_90d_rate_pct"],
+            ascending=[False, False, False],
+        ).reset_index(drop=True)
+
+        source_rows = (
+            cube_rows.groupby(["source_proxy_key", "source_proxy_label"], as_index=False)
+            .agg(
+                new_customers=("new_customers", "sum"),
+                revenue_ltv_90d=("revenue_ltv_90d", "sum"),
+                contribution_ltv_90d=("contribution_ltv_90d", "sum"),
+            )
+        )
+        source_rows["contribution_ltv_90d_per_customer"] = source_rows.apply(
+            lambda row: (row["contribution_ltv_90d"] / row["new_customers"]) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+
+        family_rows = (
+            cube_rows.groupby(["product_family_key", "product_family_label"], as_index=False)
+            .agg(
+                new_customers=("new_customers", "sum"),
+                first_order_revenue=("first_order_revenue", "sum"),
+                contribution_ltv_90d=("contribution_ltv_90d", "sum"),
+                repeat_90d_customers=("repeat_90d_customers", "sum"),
+            )
+        )
+        family_rows["repeat_90d_rate_pct"] = family_rows.apply(
+            lambda row: (row["repeat_90d_customers"] / row["new_customers"] * 100) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+        family_rows["contribution_ltv_90d_per_customer"] = family_rows.apply(
+            lambda row: (row["contribution_ltv_90d"] / row["new_customers"]) if row["new_customers"] > 0 else 0.0,
+            axis=1,
+        )
+
+        return {
+            "summary": {
+                "proxy_method": "first_order_day_paid_spend_presence",
+                "source_count": int(source_rows["source_proxy_key"].nunique()) if not source_rows.empty else 0,
+                "family_count": int(family_rows["product_family_key"].nunique()) if not family_rows.empty else 0,
+                "cube_rows": int(len(cube_rows)),
+                "new_customers_covered": int(cube_rows["new_customers"].sum()) if not cube_rows.empty else 0,
+            },
+            "cube_rows": cube_rows,
+            "source_rows": source_rows.sort_values("new_customers", ascending=False).reset_index(drop=True),
+            "family_rows": family_rows.sort_values("new_customers", ascending=False).reset_index(drop=True),
+        }
 
     def analyze_bundle_accessory_model(
         self,

--- a/export_orders.py
+++ b/export_orders.py
@@ -730,8 +730,13 @@ class BizniWebExporter:
         degraded = [source["label"] for source in sources if source.get("status") in {"warning", "error"}]
         qa_checks = list((source_health.get("qa") or {}).values())
         qa_warnings = [check.get("label") or check.get("key") or "QA" for check in qa_checks if check.get("status") == "warning"]
+        qa_errors = [check.get("label") or check.get("key") or "QA" for check in qa_checks if check.get("status") in {"error", "critical"}]
+        qa_failure_count = int(sum(int(check.get("failure_count") or 0) for check in qa_checks))
+        qa_warning_count = int(sum(int(check.get("warning_count") or 0) for check in qa_checks))
         if degraded:
             overall_status = "partial"
+        elif qa_errors:
+            overall_status = "critical"
         elif qa_warnings:
             overall_status = "warning"
         else:
@@ -739,13 +744,23 @@ class BizniWebExporter:
         source_health["overall_status"] = overall_status
         source_health["is_partial"] = bool(degraded)
         source_health["partial_sources"] = degraded
-        source_health["qa_status"] = "warning" if qa_warnings else "ok"
+        source_health["qa_status"] = "critical" if qa_errors else ("warning" if qa_warnings else "ok")
         source_health["qa_warnings"] = qa_warnings
+        source_health["qa_errors"] = qa_errors
+        source_health["qa_failure_count"] = qa_failure_count
+        source_health["qa_warning_count"] = qa_warning_count
+        source_health["qa_check_count"] = len(qa_checks)
         if degraded:
             source_health["summary"] = (
                 "Partial data: "
                 + ", ".join(degraded)
                 + " did not load cleanly in this run. Metrics depending on these sources may be incomplete or zero-filled."
+            )
+        elif qa_errors:
+            source_health["summary"] = (
+                "Critical data QA issues were raised for "
+                + ", ".join(qa_errors)
+                + ". Treat affected metrics as unsafe for decision-making until the assertions are resolved."
             )
         elif qa_warnings:
             source_health["summary"] = (
@@ -833,11 +848,27 @@ class BizniWebExporter:
         ignore_count = 0
         observe_count = 0
         ready_count = 0
+        ignore_orders = 0.0
+        observe_orders = 0.0
+        ignore_revenue = 0.0
+        observe_revenue = 0.0
+        total_orders = 0.0
+        total_revenue = 0.0
 
         if not geo_df.empty and "confidence_status" in geo_df.columns:
+            if "orders" in geo_df.columns:
+                total_orders = float(pd.to_numeric(geo_df["orders"], errors="coerce").fillna(0).sum())
+            if "revenue" in geo_df.columns:
+                total_revenue = float(pd.to_numeric(geo_df["revenue"], errors="coerce").fillna(0).sum())
             ignore_count = int((geo_df["confidence_status"] == "ignore").sum())
             observe_count = int((geo_df["confidence_status"] == "observe").sum())
             ready_count = int((geo_df["confidence_status"] == "ready").sum())
+            if total_orders > 0 and "orders" in geo_df.columns:
+                ignore_orders = float(pd.to_numeric(geo_df.loc[geo_df["confidence_status"] == "ignore", "orders"], errors="coerce").fillna(0).sum())
+                observe_orders = float(pd.to_numeric(geo_df.loc[geo_df["confidence_status"] == "observe", "orders"], errors="coerce").fillna(0).sum())
+            if total_revenue > 0 and "revenue" in geo_df.columns:
+                ignore_revenue = float(pd.to_numeric(geo_df.loc[geo_df["confidence_status"] == "ignore", "revenue"], errors="coerce").fillna(0).sum())
+                observe_revenue = float(pd.to_numeric(geo_df.loc[geo_df["confidence_status"] == "observe", "revenue"], errors="coerce").fillna(0).sum())
             if ignore_count > 0:
                 warnings.append(
                     f"{ignore_count} country row(s) are below the minimum geo sample threshold and should not be treated as strategic market insight."
@@ -849,11 +880,20 @@ class BizniWebExporter:
 
         unknown_country_rate = None
         if not country_df.empty and "country" in country_df.columns:
-            total_orders = float(country_df["orders"].sum()) if "orders" in country_df.columns else 0.0
-            unknown_orders = float(country_df.loc[country_df["country"].astype(str).str.lower() == "unknown", "orders"].sum()) if total_orders > 0 else 0.0
-            unknown_country_rate = round((unknown_orders / total_orders) * 100, 2) if total_orders > 0 else 0.0
+            total_country_orders = float(country_df["orders"].sum()) if "orders" in country_df.columns else 0.0
+            unknown_orders = float(country_df.loc[country_df["country"].astype(str).str.lower() == "unknown", "orders"].sum()) if total_country_orders > 0 else 0.0
+            unknown_country_rate = round((unknown_orders / total_country_orders) * 100, 2) if total_country_orders > 0 else 0.0
             if unknown_country_rate > 0:
                 warnings.append(f"Unknown country coverage is {unknown_country_rate:.2f}% of orders.")
+
+        ignore_order_share_pct = round((ignore_orders / total_orders) * 100, 2) if total_orders > 0 else 0.0
+        observe_order_share_pct = round((observe_orders / total_orders) * 100, 2) if total_orders > 0 else 0.0
+        ignore_revenue_share_pct = round((ignore_revenue / total_revenue) * 100, 2) if total_revenue > 0 else 0.0
+        observe_revenue_share_pct = round((observe_revenue / total_revenue) * 100, 2) if total_revenue > 0 else 0.0
+        if ignore_order_share_pct >= 10 or ignore_revenue_share_pct >= 10:
+            warnings.append(
+                f"Low-confidence geo rows still represent {ignore_order_share_pct:.2f}% of orders and {ignore_revenue_share_pct:.2f}% of revenue."
+            )
 
         message = (
             "Geo confidence guardrails passed: country sample sizes are large enough for strategic comparison."
@@ -867,10 +907,18 @@ class BizniWebExporter:
             "healthy": not warnings,
             "message": message,
             "warnings": warnings,
+            "warning_count": len(warnings),
+            "failure_count": 0,
             "ignore_count": ignore_count,
             "observe_count": observe_count,
             "ready_count": ready_count,
             "unknown_country_rate": unknown_country_rate,
+            "ignore_order_share_pct": ignore_order_share_pct,
+            "observe_order_share_pct": observe_order_share_pct,
+            "ignore_revenue_share_pct": ignore_revenue_share_pct,
+            "observe_revenue_share_pct": observe_revenue_share_pct,
+            "low_confidence_order_share_pct": round(ignore_order_share_pct + observe_order_share_pct, 2),
+            "low_confidence_revenue_share_pct": round(ignore_revenue_share_pct + observe_revenue_share_pct, 2),
         }
 
     def _build_data_assertions_qa(
@@ -886,6 +934,7 @@ class BizniWebExporter:
         cost_per_order: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
         warnings: List[str] = []
+        failures: List[str] = []
         metrics = financial_metrics or {}
         checks = consistency_checks or {}
         refund_summary = (refunds_analysis or {}).get("summary") or {}
@@ -911,7 +960,7 @@ class BizniWebExporter:
         ]
         missing_financial_keys = [key for key in required_financial_keys if metrics.get(key) is None]
         if missing_financial_keys:
-            warnings.append(
+            failures.append(
                 "Critical economics registry keys are missing: " + ", ".join(missing_financial_keys[:5])
             )
 
@@ -932,24 +981,24 @@ class BizniWebExporter:
         if payback_orders is not None and expected_payback is not None and abs(payback_orders - expected_payback) > 0.05:
             shell_parity_failures += 1
         if shell_parity_failures > 0:
-            warnings.append(
+            failures.append(
                 f"{shell_parity_failures} shell/library economics parity check(s) failed."
             )
 
         if refund_summary.get("refund_orders") and metrics.get("refund_rate_pct") is None:
-            warnings.append("Refund orders exist but refund summary metrics are missing from the registry.")
+            failures.append("Refund orders exist but refund summary metrics are missing from the registry.")
 
         if checks:
             if checks.get("roas_ok") is False:
-                warnings.append(
+                failures.append(
                     f"ROAS consistency delta is {checks.get('roas_delta')}. Reported and derived ROAS do not match."
                 )
             if checks.get("company_margin_ok") is False:
-                warnings.append(
+                failures.append(
                     f"Company margin consistency delta is {checks.get('company_margin_delta_pct')} percentage points."
                 )
             if checks.get("cac_ok") is False:
-                warnings.append(
+                failures.append(
                     f"CAC consistency delta is {checks.get('cac_delta')}. Check spend/new-customer denominator alignment."
                 )
 
@@ -997,11 +1046,11 @@ class BizniWebExporter:
                     attributed_cpa_mismatches += 1
 
         if platform_cpa_mismatches > 0:
-            warnings.append(
+            failures.append(
                 f"{platform_cpa_mismatches} campaign row(s) have platform CPA that does not match spend/platform conversions."
             )
         if attributed_cpa_mismatches > 0:
-            warnings.append(
+            failures.append(
                 f"{attributed_cpa_mismatches} campaign row(s) have cost_per_attributed_order that does not match spend/attributed_orders_est."
             )
 
@@ -1011,22 +1060,31 @@ class BizniWebExporter:
         if attributed_orders_total is not None and total_orders and total_orders > 0:
             attributed_orders_ratio = attributed_orders_total / total_orders
             if attributed_orders_ratio > 1.05:
-                warnings.append(
+                failures.append(
                     f"Attributed campaign orders sum to {attributed_orders_total:.1f}, which exceeds total orders ({total_orders:.0f}) beyond tolerance."
                 )
 
+        label_row_total = len(dow_df.index) + len(attach_df.index) + len(country_df.index) + len(geo_df.index)
+        missing_label_total = day_name_missing + anchor_missing + attached_missing + anchor_orders_missing + country_missing + geo_country_missing
+        null_label_rate_pct = round((missing_label_total / label_row_total) * 100, 2) if label_row_total > 0 else 0.0
+        if null_label_rate_pct > 0:
+            warnings.append(f"Dimension completeness warning: {null_label_rate_pct:.2f}% of labeled QA rows are missing a required label.")
+
         message = (
             "Data assertions passed: economics registry, arithmetic and dimensions are within tolerance."
-            if not warnings
-            else warnings[0]
+            if not (failures or warnings)
+            else (failures + warnings)[0]
         )
         return {
             "key": "data_assertions",
             "label": "Data assertions",
-            "status": "warning" if warnings else "ok",
-            "healthy": not warnings,
+            "status": "critical" if failures else ("warning" if warnings else "ok"),
+            "healthy": not failures,
             "message": message,
             "warnings": warnings,
+            "failures": failures,
+            "warning_count": len(warnings),
+            "failure_count": len(failures),
             "missing_financial_keys": missing_financial_keys,
             "shell_parity_failures": shell_parity_failures,
             "day_name_missing": day_name_missing,
@@ -1035,9 +1093,13 @@ class BizniWebExporter:
             "anchor_orders_missing": anchor_orders_missing,
             "country_missing": country_missing,
             "geo_country_missing": geo_country_missing,
+            "missing_label_total": missing_label_total,
+            "null_label_rate_pct": null_label_rate_pct,
             "platform_cpa_mismatches": platform_cpa_mismatches,
             "attributed_cpa_mismatches": attributed_cpa_mismatches,
             "attributed_orders_ratio": round(attributed_orders_ratio, 4) if attributed_orders_ratio is not None else None,
+            "attributed_orders_tolerance_breached": bool(attributed_orders_ratio is not None and attributed_orders_ratio > 1.05),
+            "label_row_total": label_row_total,
         }
 
     def _build_margin_stability_qa(self, date_agg: Optional[pd.DataFrame]) -> Dict[str, Any]:
@@ -1095,6 +1157,8 @@ class BizniWebExporter:
             "healthy": not warnings,
             "message": message,
             "warnings": warnings,
+            "warning_count": len(warnings),
+            "failure_count": 0,
             "raw_extreme_days": raw_extreme_days,
             "smoothed_extreme_days": smoothed_extreme_days,
             "min_smoothed_margin_pct": round(min_smoothed, 2) if min_smoothed is not None else None,

--- a/export_orders.py
+++ b/export_orders.py
@@ -5529,6 +5529,14 @@ class BizniWebExporter:
 
         # ---- Build robust order-level frame
         orders_df = df[['order_num', 'customer_email', 'purchase_date', revenue_col, 'total_items_in_order']].drop_duplicates(subset=['order_num']).copy()
+        order_spend = (
+            df.groupby('order_num')[['fb_ads_daily_spend', 'google_ads_daily_spend']]
+            .first()
+            .reset_index()
+        )
+        orders_df = orders_df.merge(order_spend, on='order_num', how='left')
+        orders_df['fb_ads_daily_spend'] = pd.to_numeric(orders_df['fb_ads_daily_spend'], errors='coerce').fillna(0.0)
+        orders_df['google_ads_daily_spend'] = pd.to_numeric(orders_df['google_ads_daily_spend'], errors='coerce').fillna(0.0)
         orders_df['purchase_datetime'] = pd.to_datetime(orders_df['purchase_date'])
         orders_df['purchase_date_only'] = orders_df['purchase_datetime'].dt.date
         orders_df['cohort_month'] = orders_df['purchase_datetime'].dt.to_period('M').astype(str)
@@ -5855,6 +5863,12 @@ class BizniWebExporter:
 
         # ---- Roy bundle/accessory model (config-driven, optional per project)
         bundle_accessory_model = self.analyze_bundle_accessory_model(orders_df, item_df, revenue_col)
+        acquisition_product_family_cube = self.analyze_acquisition_source_product_family_cube(
+            orders_df=orders_df,
+            item_df=item_df,
+            customer_orders=customer_orders,
+            revenue_col=revenue_col,
+        )
 
         # ---- 10) margin stability index (daily pre-ad margin volatility)
         daily_margin = orders_df.groupby('purchase_date_only').agg({
@@ -5972,6 +5986,7 @@ class BizniWebExporter:
             'sku_pareto': sku_pareto,
             'attach_rate': attach_rate,
             'bundle_accessory_model': bundle_accessory_model,
+            'acquisition_product_family_cube': acquisition_product_family_cube,
             'daily_margin': daily_margin,
             'payday_window': payday_window,
         }

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -131,6 +131,58 @@
     "ArboBand biele lepové dosky 5 ks na ochranu kvetov",
     "Pasca na potkany z bukového dreva"
   ],
+  "product_family_groups": [
+    {
+      "key": "trail_cameras",
+      "label": "Trail cameras",
+      "patterns": ["Fotopasca", "Wachman", "Welltar", "Suntek", "Braun", "HC800", "Rio", "Discovery", "Alfa", "Spider", "Aldo"]
+    },
+    {
+      "key": "thermal_optics",
+      "label": "Thermal optics",
+      "patterns": ["Pixfra", "Pard Night", "Night Stalker", "Sirius", "Chiron"]
+    },
+    {
+      "key": "night_vision_optics",
+      "label": "Night vision & optics",
+      "patterns": ["NV007", "Dalekohlad", "Walther 2x20", "optika", "kolimator"]
+    },
+    {
+      "key": "memory_storage",
+      "label": "Memory & storage",
+      "patterns": ["Micro SD", "SD card", "SD karta", "MicroSD"]
+    },
+    {
+      "key": "power_accessories",
+      "label": "Power accessories",
+      "patterns": ["Baterky", "Baterie", "Napajaci kabel", "Externe napajanie", "solarne napajanie", "AA"]
+    },
+    {
+      "key": "protection_mounting",
+      "label": "Protection & mounting",
+      "patterns": ["Ochranny box", "kovovy box", "Box na", "Popruh", "Zamok", "Drziak"]
+    },
+    {
+      "key": "insurance_service",
+      "label": "Insurance & service",
+      "patterns": ["Poistenie", "servis", "Reklamacia", "Reklamace", "Warranty claim", "Dobropis"]
+    },
+    {
+      "key": "apparel_outdoor",
+      "label": "Apparel & outdoor",
+      "patterns": ["Bunda", "Mikina", "Tricko", "Tričko", "Nohavice", "Ruksak", "Ladvinka", "Helikon", "Pentagon", "MFH"]
+    },
+    {
+      "key": "knives_axes",
+      "label": "Knives & axes",
+      "patterns": ["Knife", "noz", "nôž", "Axe", "sekera", "Albainox", "Karambit", "Roy Survival Axe", "Roy EDC"]
+    },
+    {
+      "key": "pest_control_misc",
+      "label": "Pest control & misc",
+      "patterns": ["Pasca", "Mucholapka", "ArboBand", "RataStop", "FRUTABAND", "Nanoprotech", "vosk", "farby na tvar"]
+    }
+  ],
   "product_expenses_file": "product_expenses.json",
   "bundle_accessory_model": {
     "enabled": true,

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -32,6 +32,88 @@
       "chart_min_orders": 3
     }
   },
+  "product_family_groups": [
+    {
+      "key": "sample_sets",
+      "label": "Sample sets",
+      "patterns": ["Vzorky", "Sample Set", "Discovery Set"]
+    },
+    {
+      "key": "sample_singles",
+      "label": "Sample singles",
+      "patterns": ["Vzorka 10ml", "10ml)"]
+    },
+    {
+      "key": "fullsize_200",
+      "label": "Full-size 200ml",
+      "patterns": ["(200ml)", "200 ml"]
+    },
+    {
+      "key": "fullsize_500",
+      "label": "Full-size 500ml",
+      "patterns": ["(500ml)", "500 ml"]
+    },
+    {
+      "key": "laundry_gel",
+      "label": "Laundry gel",
+      "patterns": ["Praci gel", "Praci gel", "Laundry gel"]
+    },
+    {
+      "key": "floor_care",
+      "label": "Floor care",
+      "patterns": ["Parfum na podlahy", "podlahy"]
+    },
+    {
+      "key": "cleaning_shot",
+      "label": "Cleaning shot",
+      "patterns": ["Vevo Shot"]
+    },
+    {
+      "key": "accessories",
+      "label": "Accessories",
+      "patterns": ["Odmerka", "Poistenie", "Tringelt"]
+    }
+  ],
+  "vevo_growth_model": {
+    "sample_entry_patterns": ["Vzorky", "Sample Set", "Discovery Set", "Vzorka 10ml"],
+    "sample_set_patterns": ["Vzorky", "Sample Set", "Discovery Set"],
+    "fullsize_200_patterns": ["(200ml)", "200 ml"],
+    "fullsize_500_patterns": ["(500ml)", "500 ml"],
+    "bundle_anchor_patterns": ["Vzorky", "Sample Set", "(200ml)", "(500ml)"],
+    "bundle_attached_patterns": ["Odmerka", "Praci gel", "Laundry gel", "Vevo Shot", "Poistenie"],
+    "scent_patterns": [
+      {
+        "key": "cotton_paradise",
+        "label": "Cotton Paradise",
+        "patterns": ["Cotton Paradise", "No.01"]
+      },
+      {
+        "key": "sweet_paradise",
+        "label": "Sweet Paradise",
+        "patterns": ["Sweet Paradise", "No.02"]
+      },
+      {
+        "key": "royal_cotton",
+        "label": "Royal Cotton",
+        "patterns": ["Royal Cotton", "No.06"]
+      },
+      {
+        "key": "ylang_absolute",
+        "label": "Ylang Absolute",
+        "patterns": ["Ylang Absolute", "No.07"]
+      },
+      {
+        "key": "cotton_dream",
+        "label": "Cotton Dream",
+        "patterns": ["Cotton Dream", "No.08"]
+      },
+      {
+        "key": "pure_garden",
+        "label": "Pure Garden",
+        "patterns": ["Pure Garden", "No.09"]
+      }
+    ]
+  },
   "product_expenses_file": "product_expenses.json",
   "currency_rates_to_eur": {
     "EUR": 1.0,

--- a/scripts/security_ci.py
+++ b/scripts/security_ci.py
@@ -94,6 +94,21 @@ def main() -> int:
         )
         require(
             export_orders,
+            "\"qa_failure_count\"",
+            "export_orders.py must aggregate QA failure counts into source health metadata.",
+        )
+        require(
+            export_orders,
+            "\"qa_warning_count\"",
+            "export_orders.py must aggregate QA warning counts into source health metadata.",
+        )
+        require(
+            export_orders,
+            "\"null_label_rate_pct\"",
+            "export_orders.py must expose null label rate in data assertions QA.",
+        )
+        require(
+            export_orders,
             "_build_margin_stability_qa",
             "export_orders.py must build smoothed margin stability QA before report export.",
         )
@@ -106,6 +121,21 @@ def main() -> int:
             daily_runner,
             "report_html",
             "daily_report_runner.py must still attach the generated main HTML report artifact.",
+        )
+        require(
+            daily_runner,
+            "build_data_quality_summary",
+            "daily_report_runner.py must summarize data quality in the email body.",
+        )
+        require(
+            daily_runner,
+            "ReportQaFailures",
+            "daily_report_runner.py must publish QA failure CloudWatch metrics.",
+        )
+        require(
+            daily_runner,
+            "ReportQaWarnings",
+            "daily_report_runner.py must publish QA warning CloudWatch metrics.",
         )
         require(
             html_report_generator + dashboard_modern,
@@ -126,6 +156,11 @@ def main() -> int:
             dashboard_modern,
             "Data assertions",
             "Modern dashboard must surface data assertion warnings explicitly.",
+        )
+        require(
+            dashboard_modern,
+            "Critical failures",
+            "Modern dashboard must expose QA failure counts in data assertions cards.",
         )
         require(
             dashboard_modern,


### PR DESCRIPTION
## Summary
- wire acquisition-source x product-family cube into advanced DTC metrics
- expose proxy source/family rows in the modern dashboard payload
- add marketing charts for source/family mix, 90d contribution quality, and source summary

## Verification
- python -m py_compile export_orders.py html_report_generator.py dashboard_modern.py
- python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31
- python export_orders.py --project roy --from-date 2026-03-01 --to-date 2026-03-31