### PR TITLE
Fix revenue VAT sourcing and disable manual ad totals fallback

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -103,7 +103,7 @@ Bootstrap entrypoints:
 
 ## 8) Next Exact Step
 
-- Implement Vevo cohort refill model (sample/full-size first-order cohorts, refill windows, and cohort refill timing charts) on top of the now-verified QA assertion layer.
+- Audit Roy Google Ads scope if business owners still consider the live API spend too high, then continue with Vevo cohort refill model on top of the now-fixed revenue/manual-spend baseline.
 
 ## 9) Change Log
 
@@ -1027,3 +1027,15 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - no regression in existing advanced DTC or marketing sections
 - Next exact step:
   - add Vevo cohort refill model so refill timing is measured by first-item cohort and horizon, not only by generic repeat-purchase logic.
+
+### 2026-04-11 (revenue + manual ads regression fix)
+- Disabled manual ads totals as a fallback path unless a project explicitly opts into `prefer_manual_ads_totals=true`.
+- Removed Roy manual FB/Google totals from project settings so Roy now relies only on live Meta/Google Ads sources.
+- Namespaced Facebook and Google Ads caches by ad account/customer IDs to avoid cross-project cache pollution.
+- Fixed order-item revenue sourcing to prefer BizniWeb explicit line totals (`items.sum` as net, `items.sum_with_tax` as gross) instead of inferring VAT from unreliable `is_net_price` flags.
+- Modern dashboard KPI labels now explicitly mark revenue and AOV as net metrics.
+- Verified with no-cache exports:
+  - Roy full range `2025-09-24 .. 2026-04-10`
+  - Vevo full range `2025-05-03 .. 2026-04-10`
+- Roy now connects to the live Google Ads account `Roy.sk` (`5313708530` via MCC `6704852923`) and no longer uses the old fixed spend fallback.
+- Vevo now connects to the live Google Ads account `Vevo.sk` (`7592903323`) with no fixed-spend fallback.

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -14,10 +14,10 @@ import pandas as pd
 
 
 METRIC_LABELS = {
-    "revenue": {"en": "Revenue", "sk": "Trzby"},
+    "revenue": {"en": "Revenue (net)", "sk": "Tržby (netto)"},
     "profit": {"en": "Profit", "sk": "Zisk"},
     "orders": {"en": "Orders", "sk": "Objednávky"},
-    "aov": {"en": "AOV", "sk": "Priemerná objednávka"},
+    "aov": {"en": "AOV (net)", "sk": "Priemerná objednávka (netto)"},
     "cac": {"en": "CAC", "sk": "CAC"},
     "roas": {"en": "ROAS", "sk": "ROAS"},
     "pre_ad_contribution_margin": {"en": "Pre-ad contribution", "sk": "Pre-ad kontribučná marža"},

--- a/export_orders.py
+++ b/export_orders.py
@@ -113,6 +113,7 @@ MARGIN_15_LABEL_PATTERNS: List[str] = []  # Optional label patterns forced to 15
 EXCLUDE_ZERO_PRICE_LABEL_PATTERNS: List[str] = []  # Optional label patterns excluded only when line price is 0
 MANUAL_FB_ADS_TOTAL: Optional[float] = None  # Optional fixed total FB spend for selected report range
 MANUAL_GOOGLE_ADS_TOTAL: Optional[float] = None  # Optional fixed total Google spend for selected report range
+PREFER_MANUAL_ADS_TOTALS = False
 WEATHER_SETTINGS: Dict[str, Any] = {
     "enabled": False,
     "timezone": "Europe/Bratislava",
@@ -309,6 +310,24 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
           }
         }
         price {
+          value
+          formatted
+          is_net_price
+          currency {
+            symbol
+            code
+          }
+        }
+        sum {
+          value
+          formatted
+          is_net_price
+          currency {
+            symbol
+            code
+          }
+        }
+        sum_with_tax {
           value
           formatted
           is_net_price
@@ -2617,30 +2636,48 @@ class BizniWebExporter:
             item_rows = []
             for item in items:
                 item_price = item.get('price', {}) or {}
+                item_sum = item.get('sum', {}) or {}
+                item_sum_with_tax = item.get('sum_with_tax', {}) or {}
                 weight = item.get('weight', {}) or {}
                 recycle_fee = item.get('recycle_fee', {}) or {}
                 
-                # Get item currency (use order currency if not specified)
-                item_currency = item_price.get('currency', {}).get('code') if item_price.get('currency') else order_currency
-                
-                # Calculate prices with and without tax
+                # Get item currency (prefer explicit line totals, then unit price, then order currency).
+                item_currency = (
+                    (item_sum.get('currency', {}) or {}).get('code')
+                    or (item_sum_with_tax.get('currency', {}) or {}).get('code')
+                    or (item_price.get('currency', {}) or {}).get('code')
+                    or order_currency
+                )
+
                 item_price_value_original = item_price.get('value', 0) or 0
-                # Convert to EUR
                 item_price_value = self.convert_to_eur(item_price_value_original, item_currency)
                 item_quantity = item.get('quantity', 1) or 1
                 item_tax_rate = item.get('tax_rate', 0) or 0
-                
-                # Calculate total price for this item (price * quantity) in EUR
-                item_total_with_tax = item_price_value * item_quantity
-                
-                # Calculate price without tax
-                # Price without tax = Price with tax / (1 + tax_rate/100)
-                if item_tax_rate > 0:
-                    item_total_without_tax = item_total_with_tax / (1 + item_tax_rate / 100)
-                    item_tax_amount = item_total_with_tax - item_total_without_tax
+                tax_multiplier = (1 + item_tax_rate / 100) if item_tax_rate > 0 else 1.0
+                item_line_net_original = item_sum.get('value')
+                item_line_gross_original = item_sum_with_tax.get('value')
+
+                # BizniWeb returns reliable line totals in `sum` (net) and `sum_with_tax` (gross).
+                # The `is_net_price` flags on these payloads are not reliable enough to drive business
+                # logic, so prefer the explicit total fields and use VAT math only as fallback.
+                if item_line_net_original is not None:
+                    item_total_without_tax = self.convert_to_eur(item_line_net_original, item_currency)
+                    if item_line_gross_original is not None:
+                        item_total_with_tax = self.convert_to_eur(item_line_gross_original, item_currency)
+                    else:
+                        item_total_with_tax = item_total_without_tax * tax_multiplier
+                elif item_line_gross_original is not None:
+                    item_total_with_tax = self.convert_to_eur(item_line_gross_original, item_currency)
+                    if item_tax_rate > 0:
+                        item_total_without_tax = item_total_with_tax / tax_multiplier
+                    else:
+                        item_total_without_tax = item_total_with_tax
                 else:
-                    item_total_without_tax = item_total_with_tax
-                    item_tax_amount = 0
+                    # Final fallback when line sums are missing: BizniWeb unit prices behave as net in
+                    # the live data for both Roy and Vevo, even when `is_net_price` is inverted.
+                    item_total_without_tax = item_price_value * item_quantity
+                    item_total_with_tax = item_total_without_tax * tax_multiplier
+                item_tax_amount = item_total_with_tax - item_total_without_tax
                 
                 # Get expense per item from mapping (using product_sku - EAN or hash)
                 item_label = item.get('item_label', '')
@@ -2700,6 +2737,8 @@ class BizniWebExporter:
                     'item_currency': item_currency,
                     'item_unit_price_original': item_price_value_original,
                     'item_unit_price': item_price_value,  # In EUR
+                    'item_line_sum_original': item_line_net_original,
+                    'item_line_sum_with_tax_original': item_line_gross_original,
                     'item_total_with_tax': round(item_total_with_tax, 2),  # In EUR
                     'item_total_without_tax': round(item_total_without_tax, 2),  # In EUR
                     'item_tax_amount': round(item_tax_amount, 2),  # In EUR
@@ -2790,7 +2829,7 @@ class BizniWebExporter:
         fb_campaigns = []
         fb_hourly_stats = []
         fb_dow_stats = []
-        if MANUAL_FB_ADS_TOTAL is not None:
+        if PREFER_MANUAL_ADS_TOTALS and MANUAL_FB_ADS_TOTAL is not None:
             fb_daily_spend = self._distribute_total_spend(MANUAL_FB_ADS_TOTAL, date_from, date_to)
             print(
                 f"Using manual Facebook Ads total: {MANUAL_FB_ADS_TOTAL:.2f} EUR "
@@ -2860,6 +2899,18 @@ class BizniWebExporter:
                     campaign_count=len(fb_campaigns),
                     hourly_rows=len(fb_hourly_stats),
                 )
+        elif MANUAL_FB_ADS_TOTAL is not None:
+            source_health["sources"]["facebook_ads"] = self._build_source_entry(
+                key="facebook_ads",
+                label="Facebook Ads",
+                status="disabled",
+                mode="manual_total_available_but_disabled",
+                message=(
+                    f"Manual Facebook Ads total {MANUAL_FB_ADS_TOTAL:.2f} EUR is configured, "
+                    "but manual ads mode is disabled. No FB spend loaded."
+                ),
+                healthy=True,
+            )
         else:
             source_health["sources"]["facebook_ads"] = self._build_source_entry(
                 key="facebook_ads",
@@ -2872,7 +2923,7 @@ class BizniWebExporter:
         
         # Fetch Google Ads spend data
         google_ads_daily_spend = {}
-        if MANUAL_GOOGLE_ADS_TOTAL is not None:
+        if PREFER_MANUAL_ADS_TOTALS and MANUAL_GOOGLE_ADS_TOTAL is not None:
             google_ads_daily_spend = self._distribute_total_spend(MANUAL_GOOGLE_ADS_TOTAL, date_from, date_to)
             print(
                 f"Using manual Google Ads total: {MANUAL_GOOGLE_ADS_TOTAL:.2f} EUR "
@@ -2914,6 +2965,18 @@ class BizniWebExporter:
                     healthy=True,
                     active_days=len(google_ads_daily_spend),
                 )
+        elif MANUAL_GOOGLE_ADS_TOTAL is not None:
+            source_health["sources"]["google_ads"] = self._build_source_entry(
+                key="google_ads",
+                label="Google Ads",
+                status="disabled",
+                mode="manual_total_available_but_disabled",
+                message=(
+                    f"Manual Google Ads total {MANUAL_GOOGLE_ADS_TOTAL:.2f} EUR is configured, "
+                    "but manual ads mode is disabled. No Google spend loaded."
+                ),
+                healthy=True,
+            )
         else:
             source_health["sources"]["google_ads"] = self._build_source_entry(
                 key="google_ads",

--- a/facebook_ads.py
+++ b/facebook_ads.py
@@ -135,7 +135,8 @@ class FacebookAdsClient:
         """Generate cache filename for a date range"""
         from_str = date_from.strftime('%Y%m%d')
         to_str = date_to.strftime('%Y%m%d')
-        return self.cache_dir / f"fb_ads_{from_str}_{to_str}.json"
+        account_part = (self.ad_account_id or "unknown").replace('act_', '').replace('-', '')
+        return self.cache_dir / f"fb_ads_{account_part}_{from_str}_{to_str}.json"
     
     def should_use_cache(self, date: datetime) -> bool:
         """Determine if cache should be used for a given date"""

--- a/google_ads.py
+++ b/google_ads.py
@@ -78,7 +78,10 @@ class GoogleAdsClient:
         """Generate cache filename for a date range"""
         from_str = date_from.strftime('%Y%m%d')
         to_str = date_to.strftime('%Y%m%d')
-        return self.cache_dir / f"google_ads_{from_str}_{to_str}.json"
+        customer_part = (self.customer_id or "unknown").replace('-', '')
+        login_part = (self.login_customer_id or "").replace('-', '')
+        suffix = customer_part if not login_part else f"{customer_part}_{login_part}"
+        return self.cache_dir / f"google_ads_{suffix}_{from_str}_{to_str}.json"
     
     def should_use_cache(self, date: datetime) -> bool:
         """Determine if cache should be used for a given date"""

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -31,8 +31,6 @@
       "chart_min_orders": 3
     }
   },
-  "manual_fb_ads_total": 690,
-  "manual_google_ads_total": 9945.95,
   "exclude_zero_price_label_patterns": [
     "Roy Hunter Knife 11004"
   ],

--- a/reporting_core/runtime.py
+++ b/reporting_core/runtime.py
@@ -33,6 +33,7 @@ class ProjectRuntime:
     exclude_zero_price_label_patterns: List[str]
     manual_fb_ads_total: Optional[float]
     manual_google_ads_total: Optional[float]
+    prefer_manual_ads_totals: bool
     weather: Dict[str, Any]
     reporting_defaults: Dict[str, Any]
 
@@ -64,6 +65,7 @@ class ProjectRuntime:
             "exclude_zero_price_label_patterns": list(self.exclude_zero_price_label_patterns),
             "manual_fb_ads_total": self.manual_fb_ads_total,
             "manual_google_ads_total": self.manual_google_ads_total,
+            "prefer_manual_ads_totals": self.prefer_manual_ads_totals,
             "weather": copy.deepcopy(self.weather),
             "reporting_defaults": dict(self.reporting_defaults),
         }
@@ -142,6 +144,7 @@ def load_project_runtime(
             if settings.get("manual_google_ads_total") is not None
             else None
         ),
+        prefer_manual_ads_totals=bool(settings.get("prefer_manual_ads_totals", False)),
         weather=weather_settings,
         reporting_defaults=resolve_reporting_defaults(project_name, settings),
     )
@@ -164,5 +167,6 @@ def apply_project_runtime(runtime: ProjectRuntime, target_globals: Dict[str, Any
     ]
     target_globals["MANUAL_FB_ADS_TOTAL"] = runtime.manual_fb_ads_total
     target_globals["MANUAL_GOOGLE_ADS_TOTAL"] = runtime.manual_google_ads_total
+    target_globals["PREFER_MANUAL_ADS_TOTALS"] = bool(runtime.prefer_manual_ads_totals)
     target_globals["WEATHER_SETTINGS"] = copy.deepcopy(runtime.weather)
     target_globals["ENABLE_EMAIL_STRATEGY_REPORT"] = bool(runtime.reporting_defaults.get("enable_email_strategy_report", False))


### PR DESCRIPTION
## Summary
- disable manual ad totals fallback unless explicitly opted in
- remove Roy manual FB/Google totals from project settings
- namespace Meta/Google cache files by account/customer IDs
- source item revenue from explicit BizniWeb line sums to avoid double VAT subtraction
- clarify modern dashboard labels as net revenue/AOV

## Verification
- python -m py_compile export_orders.py facebook_ads.py google_ads.py reporting_core/runtime.py dashboard_modern.py
- python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-10 --no-cache
- python export_orders.py --project vevo --from-date 2025-05-03 --to-date 2026-04-10 --no-cache