### PR TITLE
Fix SES email body regression

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-04-10
+Last updated: 2026-04-11
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -103,7 +103,7 @@ Bootstrap entrypoints:
 
 ## 8) Next Exact Step
 
-- Audit Roy Google Ads scope if business owners still consider the live API spend too high, then continue with Vevo cohort refill model on top of the now-fixed revenue/manual-spend baseline.
+- Verify the new short SES email body in a production-equivalent VEVO runtime run after the ECR image rebuild, then continue with Vevo cohort refill model on top of the now-fixed revenue/manual-spend baseline.
 
 ## 9) Change Log
 
@@ -1039,3 +1039,17 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - Vevo full range `2025-05-03 .. 2026-04-10`
 - Roy now connects to the live Google Ads account `Roy.sk` (`5313708530` via MCC `6704852923`) and no longer uses the old fixed spend fallback.
 - Vevo now connects to the live Google Ads account `Vevo.sk` (`7592903323`) with no fixed-spend fallback.
+
+### 2026-04-11 (short SES email body regression fix)
+- Identified that `daily_report_runner.py` still sent the old long-form executive summary in the SES plain-text body.
+- Replaced the body template with a short production mail:
+  - attachment notice
+  - covered date range
+  - concise data quality status
+  - one short QA warning note only when needed
+- Removed the old `build_report_summary(...)` output from the actual SES send path; the long CFO-style narrative is no longer injected into the mail body.
+- Verified locally with:
+  - `python -m py_compile daily_report_runner.py`
+  - direct function render of `build_email_body(...)`
+- Expected runtime effect:
+  - the daily scheduled VEVO mail should again send the short, clear body once the updated image is built and pulled by the scheduled ECS task.

--- a/daily_report_runner.py
+++ b/daily_report_runner.py
@@ -873,21 +873,44 @@ def build_report_summary(file_paths: Dict[str, Path]) -> str:
 def build_email_body(
     from_date: str,
     to_date: str,
-    summary_text: str,
     reporting_defaults: Dict[str, Any],
     data_quality: Optional[Dict[str, Any]] = None,
 ) -> str:
     display_name = reporting_defaults["display_name"]
     reporting_system_name = reporting_defaults["reporting_system_name"]
-    data_quality_block = build_data_quality_summary(data_quality or {})
-    return (
-        "Dobry den,\n\n"
-        f"v prilohe posielam denny {display_name} report v HTML formate.\n"
-        f"Sledovane obdobie: {from_date} az {to_date}.\n\n"
-        f"{summary_text}\n\n"
-        f"{data_quality_block}\n\n"
-        f"Tento email bol odoslany automaticky zo systemu {reporting_system_name}.\n"
+    dq = data_quality or {}
+    overall_status = str(dq.get("overall_status") or "unknown").upper()
+    qa_status = str(dq.get("qa_status") or "unknown").upper()
+    qa_failure_count = int(dq.get("qa_failure_count") or 0)
+    qa_warning_count = int(dq.get("qa_warning_count") or 0)
+    is_partial = bool(dq.get("is_partial"))
+
+    lines = [
+        "Dobry den,",
+        "",
+        f"v prilohe posielam denny {display_name} report v HTML formate.",
+        f"Sledovane obdobie: {from_date} az {to_date}.",
+        "",
+        f"Stav dat: {overall_status} / QA {qa_status}",
+    ]
+
+    if is_partial or qa_failure_count > 0 or qa_warning_count > 0:
+        lines.append(
+            "Poznamka: report obsahuje datove upozornenia. "
+            f"QA failures: {qa_failure_count}, QA warnings: {qa_warning_count}. "
+            "Detail je priamo v reporte v sekciach Source health a QA."
+        )
+    else:
+        lines.append("Data presli kontrolami bez kritickeho upozornenia.")
+
+    lines.extend(
+        [
+            "",
+            f"Tento email bol odoslany automaticky zo systemu {reporting_system_name}.",
+        ]
     )
+
+    return "\n".join(lines)
 
 
 def put_metric(metric_name: str, value: float, project: str, reporting_defaults: Dict[str, Any], unit: str = "Count") -> None:
@@ -1057,8 +1080,7 @@ def main() -> None:
         return
 
     subject = build_email_subject(reporting_defaults)
-    summary_text = build_report_summary(output_paths)
-    body_text = build_email_body(from_date, to_date, summary_text, reporting_defaults, data_quality)
+    body_text = build_email_body(from_date, to_date, reporting_defaults, data_quality)
     message_id = send_email_ses(
         subject=subject,
         body_text=body_text,


### PR DESCRIPTION
## Summary
- replace the old long-form SES email body with a short production-safe text body
- keep only period coverage and concise data-quality status in the mail body
- update PROJECT_STATE with the regression fix and runtime expectation

## Verification
- python -m py_compile daily_report_runner.py
- direct build_email_body() render smoke test
