### PR TITLE
Fix html period switcher syntax for CI

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -71,6 +71,7 @@ Bootstrap entrypoints:
   - HTML report saved as `data/vevo/report_20250503-20260402.html`
   - SES delivery confirmed in CloudWatch logs
   - no remaining `PutMetricData` warning in the verified log stream
+- Fixed `html_report_generator.py` period-switcher syntax so `Env Check` / `reporting_qa_smoke.py` pass again on GitHub Actions and on local Python 3.11.
 
 ## 6) Integration Notes (External Systems)
 
@@ -109,7 +110,7 @@ Bootstrap entrypoints:
 
 ## 8) Next Exact Step
 
-- Review the new Vevo growth sections in the active dashboard on a full-history VEVO export, then decide whether to continue with dedicated refill-model refinement or with stricter campaign-attribution normalization.
+- Verify the green `Env Check` run on `main`, then continue with full-history validation of the new Vevo growth sections before refining refill-model methodology.
 
 ## 9) Change Log
 

--- a/html_report_generator.py
+++ b/html_report_generator.py
@@ -327,12 +327,30 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                 """
             )
 
+        heading_html = ""
+        desc_html = ""
+        if not compact:
+            heading_html = (
+                '<h3 class="period-switcher-heading" '
+                'data-en="Choose a complete report period" '
+                'data-sk="Vyber cele obdobie reportu">'
+                "Choose a complete report period"
+                "</h3>"
+            )
+            desc_html = (
+                '<p class="period-switcher-desc" '
+                'data-en="This changes the entire report consistently: KPI cards, charts, tables, cities, products and diagnostics all switch to the selected server-calculated period." '
+                'data-sk="Toto prepne cely report konzistentne: KPI karty, grafy, tabulky, mesta, produkty aj diagnostika sa prepocitaju na vybrane serverovo vyratane obdobie.">'
+                "This changes the entire report consistently: KPI cards, charts, tables, cities, products and diagnostics all switch to the selected server-calculated period."
+                "</p>"
+            )
+
         return f"""
         <div class="{mode_class}" data-period-current="{escape(current_key)}">
             <div class="period-switcher-copy">
                 <div class="section-kicker" data-en="{label_en}" data-sk="{label_sk}">{label_en}</div>
-                {"<h3 class=\"period-switcher-heading\" data-en=\"Choose a complete report period\" data-sk=\"Vyber cele obdobie reportu\">Choose a complete report period</h3>" if not compact else ""}
-                {"<p class=\"period-switcher-desc\" data-en=\"This changes the entire report consistently: KPI cards, charts, tables, cities, products and diagnostics all switch to the selected server-calculated period.\" data-sk=\"Toto prepne cely report konzistentne: KPI karty, grafy, tabulky, mesta, produkty aj diagnostika sa prepocitaju na vybrane serverovo vyratane obdobie.\">This changes the entire report consistently: KPI cards, charts, tables, cities, products and diagnostics all switch to the selected server-calculated period.</p>" if not compact else ""}
+                {heading_html}
+                {desc_html}
             </div>
             <div class="period-switcher-controls">
                 <div class="period-switcher-options">


### PR DESCRIPTION
## Summary
- fix the html period switcher f-string syntax error in html_report_generator.py
- update PROJECT_STATE.md with the verified CI/runtime fix
- restore green env/security smoke checks on GitHub Actions

## Verification
- python -m py_compile html_report_generator.py export_orders.py dashboard_modern.py scripts/security_ci.py scripts/reporting_qa_smoke.py
- python scripts/security_ci.py
- python scripts/reporting_qa_smoke.py