### PR TITLE
Add Roy product demand analytics

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -116,10 +116,17 @@ Bootstrap entrypoints:
   - ROY March 2026 export is `warning` because fallback coverage still touches 3.20% of item revenue and 6.26% of pre-ad item profit
 - VEVO now resolves ambiguous shared-EAN fragrance SKUs by exact item label / compound key before identifier fallback, so Natural vs Premium 500ml/200ml lines no longer collapse onto the same cost.
 - ROY now supports project-configured excluded order statuses for realized revenue filtering, so non-revenue final states can be removed without hardcoded edits in `export_orders.py`.
+- ROY dashboard now exposes product-demand analytics in the active modern report:
+  - growing products
+  - declining products
+  - product seasonality
+  - product sales forecast from historical data
+  - top brands by revenue
+  - top brands by profit
 
 ## 8) Next Exact Step
 
-- Verify the next scheduled VEVO production email run from `vevo-daily-report-email` against the new `main` image, then decide whether ROY should get its own AWS daily runner or stay manual-only for now.
+- Merge the Roy product-demand analytics branch to `main`, rebuild the production image, and verify that the production Roy full-history report renders the new product-demand section end-to-end.
 
 ## 9) Change Log
 
@@ -1359,3 +1366,26 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - `data/vevo/export_20250503-20250505.csv` no longer contains `madfrog stara odoslana`
   - `data/vevo/export_20250503-20260410.csv` no longer contains `madfrog stara odoslana`
   - refreshed full-history VEVO artifacts were regenerated on the current code path
+
+### 2026-04-11 (ROY product demand analytics)
+- Added Roy-only product-demand analytics into `export_orders.py` and the active modern dashboard:
+  - growing products based on recent 4-week revenue vs previous 4 weeks
+  - declining products on the same comparison window
+  - product seasonality based on full historical months in the selected report range
+  - next-30-day product sales forecast from weekly historical revenue and units
+  - top brands by revenue
+  - top brands by profit
+- Added project-configured Roy brand groups in `projects/roy/settings.json` to avoid noisy pseudo-brand labels.
+- Added brand display guardrails so tiny one-order / low-revenue brands do not dominate the profit ranking tables.
+- Verified locally with:
+  - `python -m py_compile export_orders.py dashboard_modern.py html_report_generator.py`
+  - `python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-10`
+  - `python scripts/reporting_qa_smoke.py`
+- Verification outcome:
+  - full-history Roy report regenerates successfully
+  - dashboard payload now includes `roy_product_demand.summary`, trend rows, seasonality rows, forecast rows, and brand ranking rows
+  - full-history Roy payload currently reports:
+    - `23` growing products
+    - `15` declining products
+    - `26` forecasted products
+    - `14` displayed brands after guardrails

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1078,6 +1078,104 @@ def generate_modern_dashboard(
         ],
         limit=20,
     )
+    roy_product_demand = (advanced_dtc_metrics or {}).get("roy_product_demand", {}) if advanced_dtc_metrics else {}
+    roy_product_demand_summary = (roy_product_demand or {}).get("summary", {}) if roy_product_demand else {}
+    roy_growing_rows = _frame_rows(
+        (roy_product_demand or {}).get("growing_rows"),
+        [
+            "sku",
+            "product",
+            "prior_window_revenue",
+            "recent_window_revenue",
+            "prior_window_units",
+            "recent_window_units",
+            "revenue_growth_pct",
+            "qty_growth_pct",
+            "revenue_delta",
+            "total_revenue",
+            "trend_window_weeks",
+        ],
+        limit=10,
+    )
+    roy_declining_rows = _frame_rows(
+        (roy_product_demand or {}).get("declining_rows"),
+        [
+            "sku",
+            "product",
+            "prior_window_revenue",
+            "recent_window_revenue",
+            "prior_window_units",
+            "recent_window_units",
+            "revenue_growth_pct",
+            "qty_growth_pct",
+            "revenue_delta",
+            "total_revenue",
+            "trend_window_weeks",
+        ],
+        limit=10,
+    )
+    roy_seasonality_rows = _frame_rows(
+        (roy_product_demand or {}).get("seasonality_rows"),
+        [
+            "sku",
+            "product",
+            "best_month",
+            "best_month_index",
+            "worst_month",
+            "worst_month_index",
+            "seasonality_swing_pct",
+            "months_with_sales",
+            "total_revenue",
+        ],
+        limit=10,
+    )
+    roy_forecast_rows = _frame_rows(
+        (roy_product_demand or {}).get("forecast_rows"),
+        [
+            "sku",
+            "product",
+            "recent_30d_revenue",
+            "forecast_30d_revenue",
+            "forecast_30d_units",
+            "forecast_delta_pct",
+            "confidence",
+            "weeks_used",
+            "days_since_last_sale",
+        ],
+        limit=10,
+    )
+    roy_brand_revenue_rows = _frame_rows(
+        (roy_product_demand or {}).get("brand_revenue_rows"),
+        [
+            "brand_key",
+            "brand_label",
+            "orders",
+            "products",
+            "units",
+            "revenue",
+            "profit_without_fixed",
+            "profit_with_fixed",
+            "margin_with_fixed_pct",
+            "margin_without_fixed_pct",
+        ],
+        limit=12,
+    )
+    roy_brand_profit_rows = _frame_rows(
+        (roy_product_demand or {}).get("brand_profit_rows"),
+        [
+            "brand_key",
+            "brand_label",
+            "orders",
+            "products",
+            "units",
+            "revenue",
+            "profit_without_fixed",
+            "profit_with_fixed",
+            "margin_with_fixed_pct",
+            "margin_without_fixed_pct",
+        ],
+        limit=12,
+    )
 
     heatmap_rows = _frame_rows(day_hour_heatmap, ["day_name", "hour", "orders"], limit=None)
     b2b_rows = _frame_rows(
@@ -1555,6 +1653,15 @@ def generate_modern_dashboard(
             "source_rows": acquisition_family_source_rows,
             "family_rows": acquisition_family_family_rows,
         },
+        "roy_product_demand": {
+            "summary": {k: _maybe_num(v) if isinstance(v, (int, float)) else _json_safe(v) for k, v in ((roy_product_demand or {}).get("summary") or {}).items()},
+            "growing_rows": roy_growing_rows,
+            "declining_rows": roy_declining_rows,
+            "seasonality_rows": roy_seasonality_rows,
+            "forecast_rows": roy_forecast_rows,
+            "brand_revenue_rows": roy_brand_revenue_rows,
+            "brand_profit_rows": roy_brand_profit_rows,
+        },
         "daily_margin_rows": daily_margin_rows,
         "payday_window_rows": payday_window_rows,
         "cohort_payback_rows": cohort_payback_rows,
@@ -1616,6 +1723,8 @@ def generate_modern_dashboard(
         },
     }
     payload_json = _json_script_content(payload)
+    roy_trend_window_weeks = max(2, int(round(_num(roy_product_demand_summary.get("trend_window_weeks"))))) if roy_product_demand_summary else 4
+    roy_forecast_horizon_days = max(1, int(round(_num(roy_product_demand_summary.get("forecast_horizon_days"))))) if roy_product_demand_summary else 30
 
     product_rows_html = "".join(
         (
@@ -1637,6 +1746,155 @@ def generate_modern_dashboard(
         f"<tr><td>{escape(str(row.get('product') or 'Unknown'))}</td><td>{escape(str(row.get('trend') or '-'))}</td><td>{_num(row.get('revenue_growth_pct')):+.1f}%</td><td>{_num(row.get('qty_growth_pct')):+.1f}%</td><td>€{_num(row.get('total_revenue')):,.2f}</td></tr>"
         for row in trend_rows
     ) or '<tr><td colspan="5"><span class="lang-en">No product trend data available.</span><span class="lang-sk hidden">Produktové trendy nie sú dostupné.</span></td></tr>'
+
+    roy_growing_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>&euro;{_num(row.get('prior_window_revenue')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('recent_window_revenue')):,.2f}</td>"
+            f"<td>{_num(row.get('revenue_growth_pct')):+.1f}%</td>"
+            f"<td>{_num(row.get('qty_growth_pct')):+.1f}%</td>"
+            "</tr>"
+        )
+        for row in roy_growing_rows
+    ) or '<tr><td colspan="5"><span class="lang-en">No meaningful growing products in the recent comparison window.</span><span class="lang-sk hidden">V poslednom porovnavanom okne nie su ziadne vyrazne rastuce produkty.</span></td></tr>'
+    roy_declining_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>&euro;{_num(row.get('prior_window_revenue')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('recent_window_revenue')):,.2f}</td>"
+            f"<td>{_num(row.get('revenue_growth_pct')):+.1f}%</td>"
+            f"<td>{_num(row.get('qty_growth_pct')):+.1f}%</td>"
+            "</tr>"
+        )
+        for row in roy_declining_rows
+    ) or '<tr><td colspan="5"><span class="lang-en">No meaningful declining products in the recent comparison window.</span><span class="lang-sk hidden">V poslednom porovnavanom okne nie su ziadne vyrazne klesajuce produkty.</span></td></tr>'
+    roy_seasonality_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>{escape(str(row.get('best_month') or '-'))}</td>"
+            f"<td>{_num(row.get('best_month_index')):.1f}</td>"
+            f"<td>{escape(str(row.get('worst_month') or '-'))}</td>"
+            f"<td>{_num(row.get('worst_month_index')):.1f}</td>"
+            f"<td>{_num(row.get('seasonality_swing_pct')):.1f}</td>"
+            "</tr>"
+        )
+        for row in roy_seasonality_rows
+    ) or '<tr><td colspan="6"><span class="lang-en">Not enough full historical months for product seasonality yet.</span><span class="lang-sk hidden">Na produktovu sezonnost zatial nie je dost plnych historickych mesiacov.</span></td></tr>'
+    roy_forecast_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>&euro;{_num(row.get('recent_30d_revenue')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('forecast_30d_revenue')):,.2f}</td>"
+            f"<td>{_num(row.get('forecast_30d_units')):.1f}</td>"
+            f"<td>{_num(row.get('forecast_delta_pct')):+.1f}%</td>"
+            f"<td>{escape(str(row.get('confidence') or '-'))}</td>"
+            "</tr>"
+        )
+        for row in roy_forecast_rows
+    ) or '<tr><td colspan="6"><span class="lang-en">Not enough stable product history for product-level sales forecasting yet.</span><span class="lang-sk hidden">Na forecast predaja na urovni produktu zatial nie je dost stabilnej historie.</span></td></tr>'
+    roy_brand_revenue_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('brand_label') or 'Unknown'))}</td>"
+            f"<td>&euro;{_num(row.get('revenue')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('profit_with_fixed')):,.2f}</td>"
+            f"<td>{_num(row.get('margin_with_fixed_pct')):.1f}%</td>"
+            f"<td>{int(round(_num(row.get('orders'))))}</td>"
+            f"<td>{int(round(_num(row.get('products'))))}</td>"
+            "</tr>"
+        )
+        for row in roy_brand_revenue_rows
+    ) or '<tr><td colspan="6"><span class="lang-en">No brand aggregation data available.</span><span class="lang-sk hidden">Agregacia znaciek nie je dostupna.</span></td></tr>'
+    roy_brand_profit_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('brand_label') or 'Unknown'))}</td>"
+            f"<td>&euro;{_num(row.get('profit_with_fixed')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('revenue')):,.2f}</td>"
+            f"<td>{_num(row.get('margin_with_fixed_pct')):.1f}%</td>"
+            f"<td>{int(round(_num(row.get('orders'))))}</td>"
+            f"<td>{int(round(_num(row.get('products'))))}</td>"
+            "</tr>"
+        )
+        for row in roy_brand_profit_rows
+    ) or '<tr><td colspan="6"><span class="lang-en">No brand profit data available.</span><span class="lang-sk hidden">Data o ziskovosti znaciek nie su dostupne.</span></td></tr>'
+    roy_product_demand_section_html = ""
+    if any([roy_growing_rows, roy_declining_rows, roy_seasonality_rows, roy_forecast_rows, roy_brand_revenue_rows, roy_brand_profit_rows]):
+        roy_product_demand_section_html = f"""
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel chart-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Growing products</span><span class="lang-sk hidden">Rastúce produkty</span></h3><p><span class="lang-en">Recent {roy_trend_window_weeks}-week revenue versus the previous {roy_trend_window_weeks} weeks.</span><span class="lang-sk hidden">Posledných {roy_trend_window_weeks} týzdnov tržieb oproti predošlým {roy_trend_window_weeks} týždnom.</span></p></div></div>
+                            <div class="chart-shell"><canvas id="royGrowingProductsChart"></canvas></div>
+                        </div>
+                        <div class="panel chart-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Declining products</span><span class="lang-sk hidden">Klesajúce produkty</span></h3><p><span class="lang-en">Products losing the most revenue in the same recent comparison window.</span><span class="lang-sk hidden">Produkty s najväčším poklesom tržieb v rovnakom porovnavacom okne.</span></p></div></div>
+                            <div class="chart-shell"><canvas id="royDecliningProductsChart"></canvas></div>
+                        </div>
+                    </div>
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Growing product table</span><span class="lang-sk hidden">Tabulka rastucich produktov</span></h3></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Prev window revenue</span><span class="lang-sk hidden">Trzby predosle okno</span></th><th><span class="lang-en">Recent revenue</span><span class="lang-sk hidden">Trzby posledne okno</span></th><th><span class="lang-en">Revenue growth</span><span class="lang-sk hidden">Rast trzby</span></th><th><span class="lang-en">Qty growth</span><span class="lang-sk hidden">Rast kusov</span></th></tr></thead>
+                                <tbody>{roy_growing_rows_html}</tbody>
+                            </table>
+                        </div>
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Declining product table</span><span class="lang-sk hidden">Tabulka klesajucich produktov</span></h3></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Prev window revenue</span><span class="lang-sk hidden">Trzby predosle okno</span></th><th><span class="lang-en">Recent revenue</span><span class="lang-sk hidden">Trzby posledne okno</span></th><th><span class="lang-en">Revenue growth</span><span class="lang-sk hidden">Rast trzby</span></th><th><span class="lang-en">Qty growth</span><span class="lang-sk hidden">Rast kusov</span></th></tr></thead>
+                                <tbody>{roy_declining_rows_html}</tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel chart-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Product seasonality</span><span class="lang-sk hidden">Sezonnost produktov</span></h3><p><span class="lang-en">Peak and trough month index based on full historical months in the report range.</span><span class="lang-sk hidden">Peak a trough index podla plnych historickych mesiacov v reportovanom rozsahu.</span></p></div></div>
+                            <div class="chart-shell"><canvas id="royProductSeasonalityChart"></canvas></div>
+                        </div>
+                        <div class="panel chart-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Product sales forecast</span><span class="lang-sk hidden">Predikcia predaja produktov</span></h3><p><span class="lang-en">Blended trend + recent-history forecast for the next {roy_forecast_horizon_days} days.</span><span class="lang-sk hidden">Blended trend + nedavna historia pre odhad najblizsich {roy_forecast_horizon_days} dni.</span></p></div></div>
+                            <div class="chart-shell"><canvas id="royProductForecastChart"></canvas></div>
+                        </div>
+                    </div>
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Seasonality table</span><span class="lang-sk hidden">Tabulka sezonnosti</span></h3></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Best month</span><span class="lang-sk hidden">Najlepsi mesiac</span></th><th><span class="lang-en">Peak index</span><span class="lang-sk hidden">Peak index</span></th><th><span class="lang-en">Worst month</span><span class="lang-sk hidden">Najslabsi mesiac</span></th><th><span class="lang-en">Trough index</span><span class="lang-sk hidden">Trough index</span></th><th><span class="lang-en">Swing</span><span class="lang-sk hidden">Swing</span></th></tr></thead>
+                                <tbody>{roy_seasonality_rows_html}</tbody>
+                            </table>
+                        </div>
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Forecast table</span><span class="lang-sk hidden">Tabulka forecastu</span></h3></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Recent 30d revenue</span><span class="lang-sk hidden">Trzby poslednych 30 dni</span></th><th><span class="lang-en">Forecast {roy_forecast_horizon_days}d</span><span class="lang-sk hidden">Forecast {roy_forecast_horizon_days}d</span></th><th><span class="lang-en">Forecast units</span><span class="lang-sk hidden">Forecast kusov</span></th><th><span class="lang-en">Delta</span><span class="lang-sk hidden">Delta</span></th><th><span class="lang-en">Confidence</span><span class="lang-sk hidden">Istota</span></th></tr></thead>
+                                <tbody>{roy_forecast_rows_html}</tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Top brands by revenue</span><span class="lang-sk hidden">Top znacky podla trzby</span></h3></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Brand</span><span class="lang-sk hidden">Znacka</span></th><th><span class="lang-en">Revenue</span><span class="lang-sk hidden">Trzby</span></th><th><span class="lang-en">Profit incl. fixed</span><span class="lang-sk hidden">Zisk s fixami</span></th><th><span class="lang-en">Margin incl. fixed</span><span class="lang-sk hidden">Marza s fixami</span></th><th><span class="lang-en">Orders</span><span class="lang-sk hidden">Objednavky</span></th><th><span class="lang-en">Products</span><span class="lang-sk hidden">Produkty</span></th></tr></thead>
+                                <tbody>{roy_brand_revenue_rows_html}</tbody>
+                            </table>
+                        </div>
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Top brands by profit</span><span class="lang-sk hidden">Top znacky podla zisku</span></h3></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Brand</span><span class="lang-sk hidden">Znacka</span></th><th><span class="lang-en">Profit incl. fixed</span><span class="lang-sk hidden">Zisk s fixami</span></th><th><span class="lang-en">Revenue</span><span class="lang-sk hidden">Trzby</span></th><th><span class="lang-en">Margin incl. fixed</span><span class="lang-sk hidden">Marza s fixami</span></th><th><span class="lang-en">Orders</span><span class="lang-sk hidden">Objednavky</span></th><th><span class="lang-en">Products</span><span class="lang-sk hidden">Produkty</span></th></tr></thead>
+                                <tbody>{roy_brand_profit_rows_html}</tbody>
+                            </table>
+                        </div>
+                    </div>
+        """
 
     geo_rows_html = "".join(
         (
@@ -2923,6 +3181,7 @@ def generate_modern_dashboard(
                             <tbody>{product_trend_rows_html}</tbody>
                         </table>
                     </div>
+                    {roy_product_demand_section_html}
                     <div class="grid-2" style="margin-top:18px;">
                         <div class="panel chart-card">
                             <div class="card-head"><div><h3><span class="lang-en">SKU Pareto contribution</span><span class="lang-sk hidden">SKU Pareto contribution</span></h3><p><span class="lang-en">Cumulative contribution concentration by SKU.</span><span class="lang-sk hidden">Kumulovana koncentracia contribution podla SKU.</span></p></div></div>
@@ -3567,6 +3826,58 @@ def generate_modern_dashboard(
                     type: 'bar',
                     data: {{ labels: DATA.trend_rows.map(x => (x.product || 'Unknown').slice(0, 28)), datasets: [{{ label: 'Revenue growth %', data: DATA.trend_rows.map(x => Number(x.revenue_growth_pct || 0)), backgroundColor: DATA.trend_rows.map(x => Number(x.revenue_growth_pct || 0) >= 0 ? 'rgba(31,157,102,.72)' : 'rgba(207,80,96,.72)'), borderRadius: 8 }}] }},
                     options: {{ ...baseOptions(), indexAxis: 'y', plugins: {{ ...baseOptions().plugins, legend: {{ display: false }} }} }},
+                }});
+            }}
+            if ((DATA.roy_product_demand || {{}}).growing_rows?.length && document.getElementById('royGrowingProductsChart')) {{
+                new Chart(document.getElementById('royGrowingProductsChart'), {{
+                    type: 'bar',
+                    data: {{
+                        labels: DATA.roy_product_demand.growing_rows.map(x => (x.product || 'Unknown').slice(0, 28)),
+                        datasets: [{{ label: 'Revenue growth %', data: DATA.roy_product_demand.growing_rows.map(x => Number(x.revenue_growth_pct || 0)), backgroundColor: 'rgba(31,157,102,.72)', borderRadius: 8 }}],
+                    }},
+                    options: {{ ...baseOptions(), indexAxis: 'y', plugins: {{ ...baseOptions().plugins, legend: {{ display: false }} }} }},
+                }});
+            }}
+            if ((DATA.roy_product_demand || {{}}).declining_rows?.length && document.getElementById('royDecliningProductsChart')) {{
+                new Chart(document.getElementById('royDecliningProductsChart'), {{
+                    type: 'bar',
+                    data: {{
+                        labels: DATA.roy_product_demand.declining_rows.map(x => (x.product || 'Unknown').slice(0, 28)),
+                        datasets: [{{ label: 'Revenue growth %', data: DATA.roy_product_demand.declining_rows.map(x => Number(x.revenue_growth_pct || 0)), backgroundColor: 'rgba(207,80,96,.72)', borderRadius: 8 }}],
+                    }},
+                    options: {{ ...baseOptions(), indexAxis: 'y', plugins: {{ ...baseOptions().plugins, legend: {{ display: false }} }} }},
+                }});
+            }}
+            if ((DATA.roy_product_demand || {{}}).seasonality_rows?.length && document.getElementById('royProductSeasonalityChart')) {{
+                new Chart(document.getElementById('royProductSeasonalityChart'), {{
+                    type: 'bar',
+                    data: {{
+                        labels: DATA.roy_product_demand.seasonality_rows.map(x => (x.product || 'Unknown').slice(0, 24)),
+                        datasets: [
+                            {{ label: 'Peak index', data: DATA.roy_product_demand.seasonality_rows.map(x => Number(x.best_month_index || 0)), backgroundColor: 'rgba(255,138,31,.70)', borderRadius: 8 }},
+                            {{ label: 'Trough index', data: DATA.roy_product_demand.seasonality_rows.map(x => Number(x.worst_month_index || 0)), backgroundColor: 'rgba(71,102,255,.58)', borderRadius: 8 }},
+                        ],
+                    }},
+                    options: {{ ...baseOptions(), indexAxis: 'y' }},
+                }});
+            }}
+            if ((DATA.roy_product_demand || {{}}).forecast_rows?.length && document.getElementById('royProductForecastChart')) {{
+                new Chart(document.getElementById('royProductForecastChart'), {{
+                    data: {{
+                        labels: DATA.roy_product_demand.forecast_rows.map(x => (x.product || 'Unknown').slice(0, 24)),
+                        datasets: [
+                            {{ type: 'bar', label: 'Recent 30d revenue', data: DATA.roy_product_demand.forecast_rows.map(x => Number(x.recent_30d_revenue || 0)), backgroundColor: 'rgba(71,102,255,.56)', borderRadius: 8 }},
+                            {{ type: 'bar', label: 'Forecast 30d revenue', data: DATA.roy_product_demand.forecast_rows.map(x => Number(x.forecast_30d_revenue || 0)), backgroundColor: 'rgba(31,157,102,.72)', borderRadius: 8 }},
+                            {{ type: 'line', label: 'Forecast delta %', data: DATA.roy_product_demand.forecast_rows.map(x => Number(x.forecast_delta_pct || 0)), borderColor: '#ff8a1f', tension: .30, borderWidth: 2.0, pointRadius: 3, yAxisID: 'y1' }},
+                        ],
+                    }},
+                    options: {{
+                        ...baseOptions(),
+                        scales: {{
+                            ...baseOptions().scales,
+                            y1: {{ position: 'right', grid: {{ display: false }}, ticks: {{ color: '#8a8178', font: {{ size: 11 }} }}, border: {{ display: false }} }},
+                        }},
+                    }},
                 }});
             }}
             const economicsOpts = baseOptions();

--- a/export_orders.py
+++ b/export_orders.py
@@ -1690,6 +1690,17 @@ class BizniWebExporter:
         groups = self.project_settings.get("product_family_groups") or []
         return groups if isinstance(groups, list) else []
 
+    def _brand_groups_config(self) -> List[Dict[str, Any]]:
+        groups = self.project_settings.get("brand_groups") or []
+        return groups if isinstance(groups, list) else []
+
+    def _extract_product_brand(self, label: Any) -> Tuple[str, str]:
+        brand_key, brand_label = self._match_named_group(label, self._brand_groups_config())
+        if brand_key:
+            return brand_key, brand_label
+
+        return "other_unknown", "Other / unknown"
+
     def _build_growth_order_item_frames(
         self,
         df: pd.DataFrame,
@@ -7392,6 +7403,12 @@ class BizniWebExporter:
             customer_orders=customer_orders,
             revenue_col=revenue_col,
         )
+        roy_product_demand = self.analyze_roy_product_demand_analytics(
+            df,
+            orders_df=orders_df,
+            item_df=item_df,
+            revenue_col=revenue_col,
+        )
         vevo_direct_assisted_profitability = {"summary": {}, "entry_rows": pd.DataFrame(), "window_rows": pd.DataFrame()}
         vevo_scent_size_refill_matrix = {"summary": {}, "same_scent_rows": pd.DataFrame(), "migration_rows": pd.DataFrame()}
         vevo_bundle_recommender = {"summary": {}, "recommendation_rows": pd.DataFrame(), "anchor_rows": pd.DataFrame()}
@@ -7556,6 +7573,7 @@ class BizniWebExporter:
             'attach_rate': attach_rate,
             'bundle_accessory_model': bundle_accessory_model,
             'acquisition_product_family_cube': acquisition_product_family_cube,
+            'roy_product_demand': roy_product_demand,
             'vevo_direct_assisted_profitability': vevo_direct_assisted_profitability,
             'vevo_scent_size_refill_matrix': vevo_scent_size_refill_matrix,
             'vevo_bundle_recommender': vevo_bundle_recommender,
@@ -8002,6 +8020,374 @@ class BizniWebExporter:
 
         print(f"Product trends analysis complete: {len(trends)} products")
         return trends
+
+    def analyze_roy_product_demand_analytics(
+        self,
+        df: pd.DataFrame,
+        orders_df: Optional[pd.DataFrame] = None,
+        item_df: Optional[pd.DataFrame] = None,
+        revenue_col: Optional[str] = None,
+    ) -> dict:
+        if self.project_name != "roy":
+            return {
+                "summary": {},
+                "growing_rows": pd.DataFrame(),
+                "declining_rows": pd.DataFrame(),
+                "seasonality_rows": pd.DataFrame(),
+                "forecast_rows": pd.DataFrame(),
+                "brand_revenue_rows": pd.DataFrame(),
+                "brand_profit_rows": pd.DataFrame(),
+            }
+
+        print("\nAnalyzing Roy product demand analytics...")
+
+        if orders_df is None or item_df is None:
+            orders_df, item_df, revenue_col = self._build_growth_order_item_frames(df, revenue_col=revenue_col)
+
+        if item_df is None or item_df.empty:
+            return {
+                "summary": {},
+                "growing_rows": pd.DataFrame(),
+                "declining_rows": pd.DataFrame(),
+                "seasonality_rows": pd.DataFrame(),
+                "forecast_rows": pd.DataFrame(),
+                "brand_revenue_rows": pd.DataFrame(),
+                "brand_profit_rows": pd.DataFrame(),
+            }
+
+        demand_df = item_df.copy()
+        demand_df["purchase_datetime"] = pd.to_datetime(demand_df["purchase_datetime"], errors="coerce")
+        demand_df = demand_df.dropna(subset=["purchase_datetime", "product_sku", "item_label"]).copy()
+        if demand_df.empty:
+            return {
+                "summary": {},
+                "growing_rows": pd.DataFrame(),
+                "declining_rows": pd.DataFrame(),
+                "seasonality_rows": pd.DataFrame(),
+                "forecast_rows": pd.DataFrame(),
+                "brand_revenue_rows": pd.DataFrame(),
+                "brand_profit_rows": pd.DataFrame(),
+            }
+
+        numeric_columns = ["item_quantity", "item_total_without_tax", "cm2_profit", "cm3_profit"]
+        for column in numeric_columns:
+            demand_df[column] = pd.to_numeric(demand_df[column], errors="coerce").fillna(0.0)
+
+        demand_df["week_start"] = demand_df["purchase_datetime"].dt.to_period("W").dt.start_time
+        demand_df["month_start"] = demand_df["purchase_datetime"].dt.to_period("M").dt.to_timestamp()
+
+        product_summary = (
+            demand_df.groupby("product_sku")
+            .agg(
+                product=("item_label", "first"),
+                orders=("order_num", "nunique"),
+                units=("item_quantity", "sum"),
+                revenue=("item_total_without_tax", "sum"),
+                profit_without_fixed=("cm2_profit", "sum"),
+                profit_with_fixed=("cm3_profit", "sum"),
+                first_sale=("purchase_datetime", "min"),
+                last_sale=("purchase_datetime", "max"),
+            )
+            .reset_index()
+        )
+
+        weekly = (
+            demand_df.groupby(["product_sku", "week_start"])
+            .agg(
+                product=("item_label", "first"),
+                revenue=("item_total_without_tax", "sum"),
+                units=("item_quantity", "sum"),
+                profit_with_fixed=("cm3_profit", "sum"),
+            )
+            .reset_index()
+            .sort_values(["product_sku", "week_start"])
+        )
+
+        def _growth_pct(base_value: float, current_value: float) -> float:
+            if abs(base_value) < 1e-9:
+                return 100.0 if current_value > 0 else 0.0
+            return ((current_value - base_value) / base_value) * 100.0
+
+        def _forecast_series(values: np.ndarray, horizon: int = 4) -> np.ndarray:
+            series = np.asarray(values, dtype=float)
+            if series.size == 0:
+                return np.zeros(horizon, dtype=float)
+            x = np.arange(series.size, dtype=float)
+            if series.size >= 2 and np.any(series != series[0]):
+                slope, intercept = np.polyfit(x, series, 1)
+            else:
+                slope, intercept = 0.0, float(series.mean())
+            recent_mean = float(series[-min(4, series.size):].mean()) if series.size else 0.0
+            recent_peak = float(series[-min(8, series.size):].max()) if series.size else 0.0
+            future_x = np.arange(series.size, series.size + horizon, dtype=float)
+            trend_projection = intercept + slope * future_x
+            blended = (trend_projection * 0.65) + (recent_mean * 0.35)
+            cap = max(recent_peak * 2.0, recent_mean * 2.0, 0.0)
+            if cap > 0:
+                blended = np.clip(blended, 0.0, cap)
+            else:
+                blended = np.zeros(horizon, dtype=float)
+            return blended
+
+        def _forecast_confidence(values: np.ndarray) -> str:
+            series = np.asarray(values, dtype=float)
+            if series.size == 0:
+                return "Low"
+            recent = series[-min(8, series.size):]
+            active_share = float(np.mean(recent > 0))
+            recent_mean = float(recent.mean()) if recent.size else 0.0
+            recent_std = float(recent.std(ddof=0)) if recent.size > 1 else 0.0
+            cv = (recent_std / recent_mean) if recent_mean > 0 else float("inf")
+            if active_share >= 0.75 and cv <= 0.6:
+                return "High"
+            if active_share >= 0.5 and cv <= 1.0:
+                return "Medium"
+            return "Low"
+
+        week_index = pd.DatetimeIndex([])
+        if not weekly.empty:
+            week_index = pd.date_range(
+                start=weekly["week_start"].min(),
+                end=weekly["week_start"].max(),
+                freq="W-MON",
+            )
+        trend_window_weeks = min(4, max(2, len(week_index) // 2)) if len(week_index) >= 4 else 0
+        forecast_horizon_weeks = 4
+        growing_rows: List[Dict[str, Any]] = []
+        declining_rows: List[Dict[str, Any]] = []
+        forecast_rows: List[Dict[str, Any]] = []
+        latest_sale = pd.to_datetime(demand_df["purchase_datetime"]).max()
+
+        if trend_window_weeks >= 2 and len(week_index) >= trend_window_weeks * 2:
+            for row in product_summary.itertuples(index=False):
+                series = (
+                    weekly.loc[weekly["product_sku"] == row.product_sku, ["week_start", "revenue", "units"]]
+                    .set_index("week_start")
+                    .reindex(week_index, fill_value=0.0)
+                )
+                if series.empty:
+                    continue
+                prior = series.iloc[-(trend_window_weeks * 2):-trend_window_weeks]
+                recent = series.iloc[-trend_window_weeks:]
+                prior_revenue = float(prior["revenue"].sum())
+                recent_revenue = float(recent["revenue"].sum())
+                prior_units = float(prior["units"].sum())
+                recent_units = float(recent["units"].sum())
+                combined_revenue = prior_revenue + recent_revenue
+                combined_units = prior_units + recent_units
+                if combined_revenue < 250 and combined_units < 4:
+                    continue
+
+                revenue_growth_pct = round(_growth_pct(prior_revenue, recent_revenue), 1)
+                qty_growth_pct = round(_growth_pct(prior_units, recent_units), 1)
+                revenue_delta = round(recent_revenue - prior_revenue, 2)
+                qty_delta = round(recent_units - prior_units, 2)
+
+                demand_row = {
+                    "sku": row.product_sku,
+                    "product": row.product,
+                    "prior_window_revenue": round(prior_revenue, 2),
+                    "recent_window_revenue": round(recent_revenue, 2),
+                    "prior_window_units": round(prior_units, 2),
+                    "recent_window_units": round(recent_units, 2),
+                    "revenue_growth_pct": revenue_growth_pct,
+                    "qty_growth_pct": qty_growth_pct,
+                    "revenue_delta": revenue_delta,
+                    "qty_delta": qty_delta,
+                    "total_revenue": round(float(row.revenue or 0.0), 2),
+                    "trend_window_weeks": trend_window_weeks,
+                }
+                if recent_revenue > prior_revenue and revenue_growth_pct >= 15:
+                    growing_rows.append(demand_row)
+                if recent_revenue < prior_revenue and revenue_growth_pct <= -15:
+                    declining_rows.append(demand_row)
+
+                recent_series = series["revenue"].tail(min(12, len(series))).to_numpy(dtype=float)
+                recent_units_series = series["units"].tail(min(12, len(series))).to_numpy(dtype=float)
+                if recent_series.size < 6:
+                    continue
+                if (latest_sale - row.last_sale).days > 45:
+                    continue
+                if float(row.revenue or 0.0) < 300:
+                    continue
+                forecast_rev_weeks = _forecast_series(recent_series, horizon=forecast_horizon_weeks)
+                forecast_units_weeks = _forecast_series(recent_units_series, horizon=forecast_horizon_weeks)
+                recent_window_days = max(7 * min(4, recent_series.size), 7)
+                recent_revenue_30d = float(recent_series[-min(4, recent_series.size):].sum()) * (30.0 / recent_window_days)
+                forecast_revenue_30d = float(forecast_rev_weeks.sum()) * (30.0 / (forecast_horizon_weeks * 7.0))
+                forecast_units_30d = float(forecast_units_weeks.sum()) * (30.0 / (forecast_horizon_weeks * 7.0))
+                forecast_rows.append(
+                    {
+                        "sku": row.product_sku,
+                        "product": row.product,
+                        "recent_30d_revenue": round(recent_revenue_30d, 2),
+                        "forecast_30d_revenue": round(forecast_revenue_30d, 2),
+                        "forecast_30d_units": round(forecast_units_30d, 1),
+                        "forecast_delta_pct": round(_growth_pct(recent_revenue_30d, forecast_revenue_30d), 1),
+                        "confidence": _forecast_confidence(recent_series),
+                        "weeks_used": int(recent_series.size),
+                        "days_since_last_sale": int((latest_sale - row.last_sale).days),
+                    }
+                )
+
+        growing_rows_df = (
+            pd.DataFrame(growing_rows).sort_values(["revenue_delta", "recent_window_revenue"], ascending=[False, False]).reset_index(drop=True)
+            if growing_rows else pd.DataFrame()
+        )
+        declining_rows_df = (
+            pd.DataFrame(declining_rows).sort_values(["revenue_delta", "prior_window_revenue"], ascending=[True, False]).reset_index(drop=True)
+            if declining_rows else pd.DataFrame()
+        )
+        forecast_rows_df = (
+            pd.DataFrame(forecast_rows).sort_values(["forecast_30d_revenue", "forecast_delta_pct"], ascending=[False, False]).reset_index(drop=True)
+            if forecast_rows else pd.DataFrame()
+        )
+
+        full_months = pd.PeriodIndex([], freq="M")
+        seasonality_rows_df = pd.DataFrame()
+        min_dt = demand_df["purchase_datetime"].dt.normalize().min()
+        max_dt = demand_df["purchase_datetime"].dt.normalize().max()
+        full_start = min_dt if min_dt.day == 1 else (min_dt + pd.offsets.MonthBegin(1))
+        max_month_last_day = (max_dt + pd.offsets.MonthEnd(0)).day
+        full_end = max_dt if max_dt.day == max_month_last_day else (max_dt - pd.offsets.MonthEnd(1))
+        if full_start <= full_end:
+            full_months = pd.period_range(full_start.to_period("M"), full_end.to_period("M"), freq="M")
+        if len(full_months) >= 3:
+            month_index = pd.to_datetime(full_months.astype(str))
+            calendar_df = pd.DataFrame({"month_start": month_index})
+            calendar_df["calendar_days"] = calendar_df["month_start"].dt.days_in_month
+            seasonality_monthly = (
+                demand_df[demand_df["month_start"].isin(month_index)]
+                .groupby(["product_sku", "month_start"])
+                .agg(
+                    product=("item_label", "first"),
+                    revenue=("item_total_without_tax", "sum"),
+                    units=("item_quantity", "sum"),
+                )
+                .reset_index()
+            )
+            eligible_products = product_summary.loc[
+                (product_summary["revenue"] >= 300) & (product_summary["orders"] >= 3),
+                ["product_sku", "product", "revenue"],
+            ].copy()
+            if not eligible_products.empty:
+                seasonal_grid = pd.MultiIndex.from_product(
+                    [eligible_products["product_sku"].tolist(), month_index.tolist()],
+                    names=["product_sku", "month_start"],
+                ).to_frame(index=False)
+                seasonality_grid = seasonal_grid.merge(
+                    eligible_products[["product_sku", "product", "revenue"]].rename(columns={"revenue": "total_revenue"}),
+                    on="product_sku",
+                    how="left",
+                )
+                seasonality_grid = seasonality_grid.merge(
+                    seasonality_monthly[["product_sku", "month_start", "revenue", "units"]],
+                    on=["product_sku", "month_start"],
+                    how="left",
+                ).merge(calendar_df, on="month_start", how="left")
+                seasonality_grid["revenue"] = seasonality_grid["revenue"].fillna(0.0)
+                seasonality_grid["units"] = seasonality_grid["units"].fillna(0.0)
+                seasonality_grid["avg_daily_revenue"] = seasonality_grid["revenue"] / seasonality_grid["calendar_days"].replace(0, np.nan)
+                summary_rows = []
+                for sku, sku_months in seasonality_grid.groupby("product_sku"):
+                    baseline = float(sku_months["avg_daily_revenue"].mean()) if not sku_months.empty else 0.0
+                    if baseline <= 0:
+                        continue
+                    sku_months = sku_months.copy()
+                    sku_months["seasonality_index"] = (sku_months["avg_daily_revenue"] / baseline) * 100.0
+                    months_with_sales = int((sku_months["revenue"] > 0).sum())
+                    if months_with_sales < 3:
+                        continue
+                    best_row = sku_months.loc[sku_months["seasonality_index"].idxmax()]
+                    worst_row = sku_months.loc[sku_months["seasonality_index"].idxmin()]
+                    summary_rows.append(
+                        {
+                            "sku": sku,
+                            "product": best_row["product"],
+                            "best_month": pd.Timestamp(best_row["month_start"]).strftime("%Y-%m"),
+                            "best_month_index": round(float(best_row["seasonality_index"]), 1),
+                            "worst_month": pd.Timestamp(worst_row["month_start"]).strftime("%Y-%m"),
+                            "worst_month_index": round(float(worst_row["seasonality_index"]), 1),
+                            "seasonality_swing_pct": round(float(best_row["seasonality_index"] - worst_row["seasonality_index"]), 1),
+                            "months_with_sales": months_with_sales,
+                            "total_revenue": round(float(best_row["total_revenue"] or 0.0), 2),
+                        }
+                    )
+                if summary_rows:
+                    seasonality_rows_df = (
+                        pd.DataFrame(summary_rows)
+                        .sort_values(["seasonality_swing_pct", "total_revenue"], ascending=[False, False])
+                        .reset_index(drop=True)
+                    )
+
+        brand_rows = []
+        brand_df = demand_df.copy()
+        brand_df[["brand_key", "brand_label"]] = brand_df["item_label"].apply(
+            lambda value: pd.Series(self._extract_product_brand(value))
+        )
+        brand_summary = (
+            brand_df.groupby(["brand_key", "brand_label"])
+            .agg(
+                orders=("order_num", "nunique"),
+                products=("product_sku", "nunique"),
+                units=("item_quantity", "sum"),
+                revenue=("item_total_without_tax", "sum"),
+                profit_without_fixed=("cm2_profit", "sum"),
+                profit_with_fixed=("cm3_profit", "sum"),
+            )
+            .reset_index()
+        )
+        if not brand_summary.empty:
+            brand_summary["margin_with_fixed_pct"] = np.where(
+                brand_summary["revenue"] != 0,
+                (brand_summary["profit_with_fixed"] / brand_summary["revenue"]) * 100.0,
+                0.0,
+            )
+            brand_summary["margin_without_fixed_pct"] = np.where(
+                brand_summary["revenue"] != 0,
+                (brand_summary["profit_without_fixed"] / brand_summary["revenue"]) * 100.0,
+                0.0,
+            )
+            brand_summary = brand_summary.sort_values(["revenue", "profit_with_fixed"], ascending=[False, False]).reset_index(drop=True)
+
+        brand_display_summary = brand_summary.copy()
+        if not brand_display_summary.empty:
+            brand_display_summary = brand_display_summary.loc[
+                (brand_display_summary["revenue"] >= 250.0) | (brand_display_summary["orders"] >= 3)
+            ].reset_index(drop=True)
+
+        brand_revenue_rows_df = (
+            brand_display_summary.sort_values(["revenue", "profit_with_fixed"], ascending=[False, False]).reset_index(drop=True)
+            if not brand_display_summary.empty else pd.DataFrame()
+        )
+        brand_profit_rows_df = (
+            brand_display_summary.sort_values(["profit_with_fixed", "revenue"], ascending=[False, False]).reset_index(drop=True)
+            if not brand_display_summary.empty else pd.DataFrame()
+        )
+
+        result = {
+            "summary": {
+                "trend_window_weeks": int(trend_window_weeks),
+                "forecast_horizon_days": 30,
+                "forecast_reference_date": latest_sale.strftime("%Y-%m-%d") if pd.notna(latest_sale) else None,
+                "seasonality_full_months": int(len(full_months)),
+                "growing_count": int(len(growing_rows_df)),
+                "declining_count": int(len(declining_rows_df)),
+                "forecast_count": int(len(forecast_rows_df)),
+                "brand_count": int(len(brand_display_summary)),
+            },
+            "growing_rows": growing_rows_df,
+            "declining_rows": declining_rows_df,
+            "seasonality_rows": seasonality_rows_df,
+            "forecast_rows": forecast_rows_df,
+            "brand_revenue_rows": brand_revenue_rows_df,
+            "brand_profit_rows": brand_profit_rows_df,
+        }
+        print(
+            f"Roy product demand analytics complete: growing={len(growing_rows_df)}, "
+            f"declining={len(declining_rows_df)}, forecasted={len(forecast_rows_df)}, brands={len(brand_summary)}"
+        )
+        return result
 
     def analyze_customer_concentration(self, df: pd.DataFrame) -> dict:
         """Analyze customer concentration (top customers % of revenue)"""

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -187,6 +187,113 @@
       "patterns": ["Pasca", "Mucholapka", "ArboBand", "RataStop", "FRUTABAND", "Nanoprotech", "vosk", "farby na tvar"]
     }
   ],
+  "brand_groups": [
+    {
+      "key": "wachman",
+      "label": "Wachman",
+      "patterns": ["Wachman"]
+    },
+    {
+      "key": "maco_stop",
+      "label": "MACO STOP",
+      "patterns": ["MACO STOP"]
+    },
+    {
+      "key": "welltar",
+      "label": "Welltar",
+      "patterns": ["Welltar"]
+    },
+    {
+      "key": "roy",
+      "label": "Roy",
+      "patterns": ["Roy "]
+    },
+    {
+      "key": "verbatim",
+      "label": "Verbatim",
+      "patterns": ["Verbatim"]
+    },
+    {
+      "key": "pard",
+      "label": "Pard",
+      "patterns": ["Pard "]
+    },
+    {
+      "key": "pixfra",
+      "label": "Pixfra",
+      "patterns": ["Pixfra"]
+    },
+    {
+      "key": "braun",
+      "label": "Braun",
+      "patterns": ["Braun"]
+    },
+    {
+      "key": "suntek",
+      "label": "Suntek",
+      "patterns": ["Suntek"]
+    },
+    {
+      "key": "helikon",
+      "label": "Helikon",
+      "patterns": ["Helikon"]
+    },
+    {
+      "key": "pentagon",
+      "label": "Pentagon",
+      "patterns": ["Pentagon"]
+    },
+    {
+      "key": "albainox",
+      "label": "Albainox",
+      "patterns": ["Albainox"]
+    },
+    {
+      "key": "walther",
+      "label": "Walther",
+      "patterns": ["Walther"]
+    },
+    {
+      "key": "mfh",
+      "label": "MFH",
+      "patterns": ["MFH"]
+    },
+    {
+      "key": "seeland",
+      "label": "Seeland",
+      "patterns": ["Seeland"]
+    },
+    {
+      "key": "wenger",
+      "label": "Wenger",
+      "patterns": ["Wenger"]
+    },
+    {
+      "key": "tagart",
+      "label": "Tagart",
+      "patterns": ["Tagart"]
+    },
+    {
+      "key": "bighorn",
+      "label": "Bighorn",
+      "patterns": ["Bighorn"]
+    },
+    {
+      "key": "m_tramp",
+      "label": "M-TRAMP",
+      "patterns": ["M-TRAMP", "M-Tramp"]
+    },
+    {
+      "key": "spromise",
+      "label": "Spromise",
+      "patterns": ["Spromise"]
+    },
+    {
+      "key": "blackfire",
+      "label": "BlackFire",
+      "patterns": ["BlackFire"]
+    }
+  ],
   "product_expenses_file": "product_expenses.json",
   "bundle_accessory_model": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- add Roy-specific product demand analytics to the active report
- render growing/declining products, seasonality, sales forecast, and top brand tables in the modern dashboard
- add Roy brand mapping config and record the change in PROJECT_STATE

## Verification
- python -m py_compile export_orders.py dashboard_modern.py html_report_generator.py
- python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-10
- python scripts\\reporting_qa_smoke.py