### PR TITLE
Add all-time Executive KPI toggle

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -104,6 +104,7 @@ Bootstrap entrypoints:
 - Legacy `__test` and `__test2` artifacts are no longer part of the active workflow.
 - Env Check CI baseline now validates partial-data rendering in the active HTML layer (`html_report_generator.py` / `dashboard_modern.py`) instead of the retired daily runner rendering path.
 - Production dashboard now keeps `Executive KPI deck` on its own `Daily / Weekly / Monthly` switch while the rest of the report uses a separate global analytics window switcher in the sidebar.
+- Executive KPI deck now supports `All-time` alongside Daily / Weekly / Monthly in both VEVO and ROY reports, using the shared CFO KPI payload and the active modern dashboard shell.
 - Period bundle generation is enabled for plain production reports, so the sidebar analytics switch now works outside of test-tag exports too.
 - Shipping semantics are now normalized to net shipping in runtime config and dashboard labels, but CM taxonomy naming is still mixed between legacy labels and CM1/CM2/CM3 terms in some views.
 - Full QA assertions are now computed into `data_quality` sidecars and surfaced in dashboard/email/CloudWatch.
@@ -131,7 +132,7 @@ Bootstrap entrypoints:
   - top brands by profit
 
 ## 8) Next Exact Step
-
+- Monitor the next production VEVO and ROY daily runner outputs to confirm the new Executive KPI `All-time` toggle is present in the emailed HTML attachments.
 - Verify the next scheduled ROY production email run from `roy-daily-report-email` against task definition `roy-reporting-daily:2`, then decide whether ROY recipients stay single-recipient or should be expanded.
 
 ## 9) Change Log

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -30,6 +30,7 @@ WINDOW_LABELS = {
     "daily": {"en": "Last day", "sk": "Posledný deň"},
     "weekly": {"en": "Last 7 days", "sk": "Posledných 7 dní"},
     "monthly": {"en": "Last 30 days", "sk": "Posledných 30 dní"},
+    "all_time": {"en": "All-time", "sk": "Za celé obdobie"},
 }
 
 COMPARISON_LABELS = {
@@ -44,6 +45,10 @@ COMPARISON_LABELS = {
     "monthly": {
         "vs_prev_30d": {"en": "vs previous 30d", "sk": "vs predošlých 30 dní"},
         "vs_year": {"en": "vs same month last year", "sk": "vs rovnaké obdobie minulý rok"},
+    },
+    "all_time": {
+        "vs_prev_span": {"en": "vs previous same span", "sk": "vs predchádzajúce rovnaké obdobie"},
+        "vs_year": {"en": "vs same span last year", "sk": "vs rovnaké obdobie minulý rok"},
     },
 }
 
@@ -305,8 +310,8 @@ def _period_switcher_html(period_switcher: Optional[dict]) -> str:
         '<div class="label"><span class="lang-en">Analytics window</span><span class="lang-sk hidden">Analyticke okno</span></div>'
         '<div class="period-summary">'
         f'<strong><span class="lang-en">{current_range_en}</span><span class="lang-sk hidden">{current_range_sk}</span></strong>'
-        '<small><span class="lang-en">Applies to all chart sections below. Executive KPI deck keeps its own Daily / Weekly / Monthly switch.</span>'
-        '<span class="lang-sk hidden">Plati pre vsetky sekcie s grafmi nizsie. Executive KPI deck ma vlastne prepinanie Denne / Tyzdenne / Mesacne.</span></small>'
+        '<small><span class="lang-en">Applies to all chart sections below. Executive KPI deck keeps its own Daily / Weekly / Monthly / All-time switch.</span>'
+        '<span class="lang-sk hidden">Plati pre vsetky sekcie s grafmi nizsie. Executive KPI deck ma vlastne prepinanie Denne / Tyzdenne / Mesacne / Cele obdobie.</span></small>'
         '</div>'
         '<div class="pill-row pill-row-wrap">' + "".join(links) + '</div>'
         '</div>'
@@ -2495,6 +2500,7 @@ def generate_modern_dashboard(
                             <button type="button" class="window-btn" data-window="daily"><span class="lang-en">Daily</span><span class="lang-sk hidden">Denne</span></button>
                             <button type="button" class="window-btn" data-window="weekly"><span class="lang-en">Weekly</span><span class="lang-sk hidden">Týždenne</span></button>
                             <button type="button" class="window-btn" data-window="monthly"><span class="lang-en">Monthly</span><span class="lang-sk hidden">Mesačne</span></button>
+                            <button type="button" class="window-btn" data-window="all_time"><span class="lang-en">All-time</span><span class="lang-sk hidden">Celé obdobie</span></button>
                         </div>
                         <div id="kpiGrid" class="kpi-grid"></div>
                     </div>

--- a/reporting_core/cfo_kpis.py
+++ b/reporting_core/cfo_kpis.py
@@ -253,6 +253,12 @@ def _window_aggregate(
     }
 
 
+def _all_time_window_days(sorted_dates: List[date]) -> int:
+    if not sorted_dates:
+        return 0
+    return max((sorted_dates[-1] - sorted_dates[0]).days + 1, 1)
+
+
 def build_cfo_kpi_payload(
     date_agg: pd.DataFrame,
     export_df: Optional[pd.DataFrame],
@@ -285,6 +291,11 @@ def build_cfo_kpi_payload(
                 return True
         return False
 
+    sorted_dates = sorted(row_by_date.keys())
+    all_time_days = _all_time_window_days(sorted_dates)
+    all_time_prev_end = sorted_dates[0] - timedelta(days=1) if sorted_dates else last_date
+    all_time_year_end = _shift_years(last_date, -1)
+
     day_cur = _window_aggregate(row_by_date, last_date, 1, customer_by_date, order_records, fixed_daily_cost_eur)
     day_prev = _window_aggregate(row_by_date, prev_day, 1, customer_by_date, order_records, fixed_daily_cost_eur) if prev_day in row_by_date else None
     day_week = _window_aggregate(row_by_date, same_weekday_last_week, 1, customer_by_date, order_records, fixed_daily_cost_eur) if same_weekday_last_week in row_by_date else None
@@ -300,6 +311,18 @@ def build_cfo_kpi_payload(
     w30_prev = _window_aggregate(row_by_date, monthly_prev_end, 30, customer_by_date, order_records, fixed_daily_cost_eur) if has_window_data(monthly_prev_end, 30) else None
     w30_year = _window_aggregate(row_by_date, monthly_last_year_end, 30, customer_by_date, order_records, fixed_daily_cost_eur) if has_window_data(monthly_last_year_end, 30) else None
 
+    all_time = _window_aggregate(row_by_date, last_date, all_time_days, customer_by_date, order_records, fixed_daily_cost_eur)
+    all_time_prev = (
+        _window_aggregate(row_by_date, all_time_prev_end, all_time_days, customer_by_date, order_records, fixed_daily_cost_eur)
+        if all_time_days > 0 and has_window_data(all_time_prev_end, all_time_days)
+        else None
+    )
+    all_time_year = (
+        _window_aggregate(row_by_date, all_time_year_end, all_time_days, customer_by_date, order_records, fixed_daily_cost_eur)
+        if all_time_days > 0 and has_window_data(all_time_year_end, all_time_days)
+        else None
+    )
+
     metric_defs = [
         {"key": "revenue", "label": "Revenue", "direction": "up"},
         {"key": "profit", "label": "Profit", "direction": "up"},
@@ -313,11 +336,11 @@ def build_cfo_kpi_payload(
     ]
 
     metric_keys = [metric["key"] for metric in metric_defs]
-    sorted_dates = sorted(row_by_date.keys())
     trend_labels = {
         "daily": {"en": "14d trend", "sk": "Trend 14 dni"},
         "weekly": {"en": "8x 7d trend", "sk": "Trend 8x 7 dni"},
         "monthly": {"en": "8x 30d trend", "sk": "Trend 8x 30 dni"},
+        "all_time": {"en": "12x 30d trend", "sk": "Trend 12x 30 dni"},
     }
 
     def safe_kpi_value(metric_key: str, aggregate: Optional[Dict[str, Optional[float]]]) -> Optional[float]:
@@ -383,6 +406,10 @@ def build_cfo_kpi_payload(
     w30_prev_vals = snapshot(w30_prev) if w30_prev else {}
     w30_year_vals = snapshot(w30_year) if w30_year else {}
 
+    all_time_vals = snapshot(all_time)
+    all_time_prev_vals = snapshot(all_time_prev) if all_time_prev else {}
+    all_time_year_vals = snapshot(all_time_year) if all_time_year else {}
+
     def delta(current: Optional[float], reference: Optional[float]) -> Optional[float]:
         if current is None or reference is None:
             return None
@@ -392,6 +419,7 @@ def build_cfo_kpi_payload(
         "daily": {},
         "weekly": {},
         "monthly": {},
+        "all_time": {},
     }
 
     for metric in metric_defs:
@@ -410,6 +438,10 @@ def build_cfo_kpi_payload(
         comparisons["monthly"][metric_key] = {
             "vs_prev_30d": delta(w30_vals.get(metric_key), w30_prev_vals.get(metric_key)),
             "vs_year": delta(w30_vals.get(metric_key), w30_year_vals.get(metric_key)),
+        }
+        comparisons["all_time"][metric_key] = {
+            "vs_prev_span": delta(all_time_vals.get(metric_key), all_time_prev_vals.get(metric_key)),
+            "vs_year": delta(all_time_vals.get(metric_key), all_time_year_vals.get(metric_key)),
         }
 
     return {
@@ -433,6 +465,12 @@ def build_cfo_kpi_payload(
                 "metrics": w30_vals,
                 "secondary_metrics": secondary_snapshot(w30),
                 "trend": trend_snapshot(30, 8, "monthly"),
+            },
+            "all_time": {
+                "label": "All-time",
+                "metrics": all_time_vals,
+                "secondary_metrics": secondary_snapshot(all_time),
+                "trend": trend_snapshot(30, min(12, len(sorted_dates)), "all_time"),
             },
         },
         "comparisons": comparisons,


### PR DESCRIPTION
## Summary
- add all-time window support to the shared CFO KPI payload
- expose the new All-time toggle in the modern dashboard Executive KPI deck for Roy and Vevo
- update PROJECT_STATE with the new verified dashboard capability

## Verification
- python -m py_compile reporting_core\\cfo_kpis.py dashboard_modern.py html_report_generator.py export_orders.py
- python export_orders.py --project vevo --from-date 2025-05-03 --to-date 2026-04-11
- python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-11
- python scripts\\reporting_qa_smoke.py