### PR TITLE
Add VEVO marketing decision metrics and fix CM3 overhead

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-04-11
+Last updated: 2026-04-13
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -78,6 +78,21 @@ Bootstrap entrypoints:
   - SES delivery confirmed in CloudWatch logs
   - scheduler target updated to `arn:aws:ecs:eu-central-1:919341186960:task-definition/roy-reporting-daily:2`
 - Fixed `html_report_generator.py` period-switcher syntax so `Env Check` / `reporting_qa_smoke.py` pass again on GitHub Actions and on local Python 3.11.
+- VEVO runtime now supports explicit `fixed_daily_cost`, and March 2026 verification confirms `CM3` now diverges from `CM2` once fixed overhead is applied (`fixed_daily_cost = 70 EUR`).
+- VEVO modern dashboard now surfaces practical marketing decision metrics:
+  - total marketing spend
+  - spend / revenue
+  - CM3 margin
+  - CM3 per ad euro
+  - CM2 -> CM3 drag
+  - paid-day CM3 win rate
+  - returning revenue share on paid days
+  - best CM3 spend ranges
+- VEVO spend-bucket effectiveness table now shows:
+  - CM3 margin
+  - returning revenue share
+  - AOV
+- CFO KPI helper no longer double-subtracts fixed costs when building company-margin views from `date_agg`.
 
 ## 6) Integration Notes (External Systems)
 
@@ -136,6 +151,30 @@ Bootstrap entrypoints:
 - Verify the next scheduled ROY production email run from `roy-daily-report-email` against task definition `roy-reporting-daily:2`, then decide whether ROY recipients stay single-recipient or should be expanded.
 
 ## 9) Change Log
+
+### 2026-04-13
+- Added shared runtime support for explicit per-day fixed overhead via `fixed_daily_cost` while preserving monthly fixed-cost support.
+- Set VEVO project runtime to `fixed_daily_cost = 70` so CM3 metrics include fixed overhead in the active reporting path.
+- Fixed CFO KPI aggregation mismatch:
+  - daily rows now use post-ad profit ex fixed (`contribution_profit`) as the pre-CM3 layer,
+  - company-margin-with-fixed now subtracts actual fixed overhead from the daily rows instead of reapplying a blind constant over already-net profit.
+- Added new marketing decision metrics into the active modern dashboard and payload:
+  - marketing spend / revenue
+  - CM3 per ad euro
+  - CM2 -> CM3 drag
+  - paid-day CM3 win rate
+  - returning revenue share on paid days
+  - best CM3 spend range
+  - best CM3 margin range
+- Expanded spend-bucket effectiveness rows with CM3 margin, returning revenue share, and AOV.
+- Verified locally with:
+  - `python -m py_compile export_orders.py dashboard_modern.py reporting_core/runtime.py reporting_core/cfo_kpis.py`
+  - `python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31`
+  - `python scripts/reporting_qa_smoke.py`
+- Verification outcome:
+  - `aggregate_by_date_20260301-20260331.csv` shows `fixed_daily_cost = 70.0` and `CM2 != CM3`
+  - `dashboard_payload_20260301-20260331.json` now contains `dashboard.marketing_decision_summary`
+  - rendered HTML contains the new marketing cards and the expanded spend-bucket table
 
 ### 2026-03-30
 - Added env governance baseline: `.env.required`, pre-commit hook, CI env check.

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -912,7 +912,22 @@ def generate_modern_dashboard(
         }
     else:
         ads_effectiveness_payload = {"labels": [], "orders": [], "revenue": [], "fb_spend": [], "google_spend": [], "profit_without_fixed": [], "profit_with_fixed": [], "profit": []}
-    spend_effectiveness_rows = _frame_rows(_to_frame((ads_effectiveness or {}).get("spend_effectiveness")), ["spend_range", "avg_orders", "avg_revenue", "avg_spend", "avg_profit_without_fixed", "avg_profit_with_fixed", "roas"], limit=20)
+    spend_effectiveness_rows = _frame_rows(
+        _to_frame((ads_effectiveness or {}).get("spend_effectiveness")),
+        [
+            "spend_range",
+            "avg_orders",
+            "avg_revenue",
+            "avg_spend",
+            "avg_profit_without_fixed",
+            "avg_profit_with_fixed",
+            "avg_cm3_margin_pct",
+            "avg_returning_revenue_share_pct",
+            "avg_aov",
+            "roas",
+        ],
+        limit=20,
+    )
     dow_effectiveness_rows = _normalize_dow_effectiveness_rows(
         _frame_rows(
             _to_frame((ads_effectiveness or {}).get("dow_effectiveness")),
@@ -1461,6 +1476,7 @@ def generate_modern_dashboard(
     google_source_available = _source_has_metric_coverage(source_health, "google_ads")
     google_cpo_value = _maybe_num((cost_per_order or {}).get("google_cpo")) if google_source_available else None
     ads_correlation_source = ((ads_effectiveness or {}).get("correlations") or {})
+    marketing_decision_summary = (ads_effectiveness or {}).get("decision_summary") or {}
 
     avg_customer_ltv = _maybe_num((financial_metrics or {}).get("avg_customer_ltv"))
     if avg_customer_ltv is None:
@@ -1485,6 +1501,14 @@ def generate_modern_dashboard(
     cm3_profit = _maybe_num((financial_metrics or {}).get("cm3_profit"))
     cm3_margin_pct = _maybe_num((financial_metrics or {}).get("cm3_margin_pct"))
     cm3_profit_per_order = _maybe_num((financial_metrics or {}).get("cm3_profit_per_order"))
+    marketing_spend_share_pct = _maybe_num((financial_metrics or {}).get("marketing_spend_share_pct"))
+    cm3_per_ad_eur = _maybe_num((financial_metrics or {}).get("cm3_per_ad_eur"))
+    fixed_overhead_drag = _maybe_num((financial_metrics or {}).get("cm2_to_cm3_overhead_drag"))
+    fixed_overhead_drag_pct = _maybe_num((financial_metrics or {}).get("cm2_to_cm3_overhead_drag_pct"))
+    paid_day_cm3_win_rate_pct = _maybe_num(marketing_decision_summary.get("paid_day_cm3_win_rate_pct"))
+    paid_day_returning_revenue_share_pct = _maybe_num(marketing_decision_summary.get("paid_day_returning_revenue_share_pct"))
+    best_cm3_range = str(marketing_decision_summary.get("best_cm3_range") or "N/A")
+    best_cm3_margin_range = str(marketing_decision_summary.get("best_cm3_margin_range") or "N/A")
     cm_taxonomy_note = str((financial_metrics or {}).get("cm_taxonomy_note") or "")
     cac_break_even_ratio = None
     if break_even_cac not in (None, 0) and current_fb_cac is not None:
@@ -1643,6 +1667,7 @@ def generate_modern_dashboard(
         "dow_effectiveness_rows": dow_effectiveness_rows,
         "incrementality_primary": incrementality_primary,
         "incrementality_rows": incrementality_rows,
+        "marketing_decision_summary": (ads_effectiveness or {}).get("decision_summary") or {},
         "basket_contribution_rows": basket_contribution_rows,
         "sku_pareto_rows": sku_pareto_rows,
         "attach_rate_rows": attach_rate_rows,
@@ -2040,6 +2065,9 @@ def generate_modern_dashboard(
             f"<td>&euro;{_num(row.get('avg_revenue')):,.2f}</td>"
             f"<td>&euro;{_num(row.get('avg_profit_without_fixed')):,.2f}</td>"
             f"<td>&euro;{_num(row.get('avg_profit_with_fixed')):,.2f}</td>"
+            f"<td>{_num(row.get('avg_cm3_margin_pct')):.1f}%</td>"
+            f"<td>{_num(row.get('avg_returning_revenue_share_pct')):.1f}%</td>"
+            f"<td>&euro;{_num(row.get('avg_aov')):,.2f}</td>"
             f"<td>{_num(row.get('roas')):.2f}x</td>"
             "</tr>"
         )
@@ -2573,6 +2601,18 @@ def generate_modern_dashboard(
                         </div>
                         <p class="muted-note">{escape(cm_taxonomy_note) if cm_taxonomy_note else '<span class="lang-en">CM1 currently excludes payment fees because the reporting model does not ingest them separately.</span><span class="lang-sk hidden">CM1 zatial vylucuje payment fees, pretoze reporting ich zatial nenasava samostatne.</span>'}</p>
                     </div>
+                    <div class="panel chart-card" style="margin-bottom:18px;">
+                        <div class="mini-grid">
+                            <div class="mini-card"><small><span class="lang-en">Marketing spend</span><span class="lang-sk hidden">Marketing spend</span></small><strong>{_format_mini_value_html(_maybe_num((financial_metrics or {}).get("total_ad_spend")), kind="currency")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Spend / revenue</span><span class="lang-sk hidden">Spend / trzby</span></small><strong>{_format_mini_value_html(marketing_spend_share_pct, kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">CM3 margin</span><span class="lang-sk hidden">CM3 marza</span></small><strong>{_format_mini_value_html(cm3_margin_pct, kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">CM3 per ad euro</span><span class="lang-sk hidden">CM3 na euro reklamy</span></small><strong>{_format_mini_value_html(cm3_per_ad_eur, kind="multiple")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">CM2 to CM3 drag</span><span class="lang-sk hidden">CM2 na CM3 drag</span></small><strong>{_format_mini_value_html(fixed_overhead_drag, kind="currency")}</strong><span class="delta neutral">{_format_mini_value_html(fixed_overhead_drag_pct, kind="percent")}</span></div>
+                            <div class="mini-card"><small><span class="lang-en">Paid-day CM3 win rate</span><span class="lang-sk hidden">Uspesnost paid dni v CM3</span></small><strong>{_format_mini_value_html(paid_day_cm3_win_rate_pct, kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Returning rev. on paid days</span><span class="lang-sk hidden">Vracajuce trzby v paid dnoch</span></small><strong>{_format_mini_value_html(paid_day_returning_revenue_share_pct, kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Best CM3 spend range</span><span class="lang-sk hidden">Najlepsi CM3 spend rozsah</span></small><strong>{escape(best_cm3_range)}</strong><span class="delta neutral">{escape(best_cm3_margin_range)}</span></div>
+                        </div>
+                    </div>
                     <div class="grid-2">
                         <div class="panel chart-card">
                             <div class="card-head"><div><h3><span class="lang-en">Revenue vs total costs</span><span class="lang-sk hidden">Trzby vs celkove naklady</span></h3><p><span class="lang-en">Daily revenue compared with full cost base.</span><span class="lang-sk hidden">Denne trzby oproti plnej nakladovej baze.</span></p></div></div>
@@ -2653,7 +2693,7 @@ def generate_modern_dashboard(
                         <div class="panel table-card">
                             <div class="card-head"><div><h3><span class="lang-en">Spend bucket effectiveness</span><span class="lang-sk hidden">Efektivita spend bucketov</span></h3><p><span class="lang-en">Average output by spend range.</span><span class="lang-sk hidden">Priemerny vystup podla spend rozsahu.</span></p></div></div>
                             <table>
-                                <thead><tr><th><span class="lang-en">Range</span><span class="lang-sk hidden">Rozsah</span></th><th><span class="lang-en">Spend</span><span class="lang-sk hidden">Spend</span></th><th><span class="lang-en">Orders</span><span class="lang-sk hidden">Obj.</span></th><th><span class="lang-en">Revenue</span><span class="lang-sk hidden">Trzby</span></th><th><span class="lang-en">Profit ex fixed</span><span class="lang-sk hidden">Zisk bez fixov</span></th><th><span class="lang-en">Profit incl. fixed</span><span class="lang-sk hidden">Zisk s fixami</span></th><th>ROAS</th></tr></thead>
+                                <thead><tr><th><span class="lang-en">Range</span><span class="lang-sk hidden">Rozsah</span></th><th><span class="lang-en">Spend</span><span class="lang-sk hidden">Spend</span></th><th><span class="lang-en">Orders</span><span class="lang-sk hidden">Obj.</span></th><th><span class="lang-en">Revenue</span><span class="lang-sk hidden">Trzby</span></th><th><span class="lang-en">Profit ex fixed</span><span class="lang-sk hidden">Zisk bez fixov</span></th><th><span class="lang-en">Profit incl. fixed</span><span class="lang-sk hidden">Zisk s fixami</span></th><th><span class="lang-en">CM3 margin</span><span class="lang-sk hidden">CM3 marza</span></th><th><span class="lang-en">Returning rev. share</span><span class="lang-sk hidden">Podiel vracajucich sa trz.</span></th><th><span class="lang-en">AOV</span><span class="lang-sk hidden">AOV</span></th><th>ROAS</th></tr></thead>
                                 <tbody>{spend_effectiveness_rows_html}</tbody>
                             </table>
                         </div>

--- a/export_orders.py
+++ b/export_orders.py
@@ -107,6 +107,7 @@ PACKAGING_COST_PER_ORDER = 0.3  # EUR per order
 SHIPPING_SUBSIDY_PER_ORDER = 0.2  # legacy alias; use SHIPPING_NET_PER_ORDER semantics below
 SHIPPING_NET_PER_ORDER = SHIPPING_SUBSIDY_PER_ORDER  # positive = business cost, negative = shipping profit
 FIXED_MONTHLY_COST = 0  # EUR per month (Marek, Uctovnictvo)
+FIXED_DAILY_COST = 0  # EUR per day; when set, overrides monthly fixed-cost spreading
 EXPENSE_MATCH_MODE = "identifier_first"  # Match product costs by identifiers first unless project opts into title-first
 PRODUCT_NAME_ALIASES: Dict[str, str] = {}  # Optional project-scoped aliases for canonical reporting product names
 ZERO_MARGIN_BRANDS: List[str] = []  # Optional list of brands that should always run at 0 product margin
@@ -2375,6 +2376,8 @@ class BizniWebExporter:
     
     def get_daily_fixed_cost(self, date: datetime) -> float:
         """Calculate daily fixed cost based on days in the month"""
+        if FIXED_DAILY_COST > 0:
+            return float(FIXED_DAILY_COST)
         days_in_month = calendar.monthrange(date.year, date.month)[1]
         return FIXED_MONTHLY_COST / days_in_month
     
@@ -3773,7 +3776,7 @@ class BizniWebExporter:
         cfo_kpi_payload = build_cfo_kpi_payload(
             date_agg=date_agg,
             export_df=analytics_df,
-            fixed_daily_cost_eur=float(os.getenv("CFO_FIXED_DAILY_COST_EUR", "70")),
+            fixed_daily_cost_eur=float(self.get_daily_fixed_cost(pd.Timestamp(date_agg["date"].max())) if not date_agg.empty else 0.0),
         )
 
         # Cost Per Order analysis with campaign attribution
@@ -8568,6 +8571,36 @@ class BizniWebExporter:
             daily_data["returning_revenue"] = 0.0
         daily_data["new_revenue"] = pd.to_numeric(daily_data.get("new_revenue", 0), errors="coerce").fillna(0.0)
         daily_data["returning_revenue"] = pd.to_numeric(daily_data.get("returning_revenue", 0), errors="coerce").fillna(0.0)
+        daily_data["new_revenue_share_pct"] = np.where(
+            daily_data["revenue"] > 0,
+            daily_data["new_revenue"] / daily_data["revenue"] * 100,
+            np.nan,
+        )
+        daily_data["returning_revenue_share_pct"] = np.where(
+            daily_data["revenue"] > 0,
+            daily_data["returning_revenue"] / daily_data["revenue"] * 100,
+            np.nan,
+        )
+        daily_data["ad_spend_share_pct"] = np.where(
+            daily_data["revenue"] > 0,
+            daily_data["total_ad_spend"] / daily_data["revenue"] * 100,
+            np.nan,
+        )
+        daily_data["cm2_margin_pct"] = np.where(
+            daily_data["revenue"] > 0,
+            daily_data["profit_without_fixed"] / daily_data["revenue"] * 100,
+            np.nan,
+        )
+        daily_data["cm3_margin_pct"] = np.where(
+            daily_data["revenue"] > 0,
+            daily_data["profit_with_fixed"] / daily_data["revenue"] * 100,
+            np.nan,
+        )
+        daily_data["cm3_per_ad_eur"] = np.where(
+            daily_data["total_ad_spend"] > 0,
+            daily_data["profit_with_fixed"] / daily_data["total_ad_spend"],
+            np.nan,
+        )
 
         orders = df[["order_num", "customer_email", "purchase_date"]].drop_duplicates(subset=["order_num"]).copy()
         orders["date"] = pd.to_datetime(orders["purchase_date"]).dt.date
@@ -8927,6 +8960,13 @@ class BizniWebExporter:
             'roas_fb': round(total_revenue / total_fb_spend, 2) if total_fb_spend > 0 else 0,
             'roas_google': round(total_revenue / total_google_spend, 2) if total_google_spend > 0 else 0,
             'mer': round(total_revenue / total_ad_spend, 2) if total_ad_spend > 0 else 0,
+            'marketing_spend_share_pct': round(total_ad_spend / total_revenue * 100, 1) if total_revenue > 0 else 0,
+            'fixed_overhead_share_pct': round(total_fixed_overhead / total_revenue * 100, 1) if total_revenue > 0 else 0,
+            'marketing_and_fixed_share_pct': round((total_ad_spend + total_fixed_overhead) / total_revenue * 100, 1) if total_revenue > 0 else 0,
+            'cm2_to_cm3_overhead_drag': round(total_fixed_overhead, 2),
+            'cm2_to_cm3_overhead_drag_pct': round(total_fixed_overhead / total_revenue * 100, 1) if total_revenue > 0 else 0,
+            'cm2_per_ad_eur': round(total_contribution_profit / total_ad_spend, 2) if total_ad_spend > 0 else None,
+            'cm3_per_ad_eur': round(total_company_profit / total_ad_spend, 2) if total_ad_spend > 0 else None,
             'revenue_per_customer': round(total_revenue / total_customers, 2) if total_customers > 0 else 0,
             'orders_per_customer': round(total_orders / total_customers, 2) if total_customers > 0 else 0,
             'cost_per_order': round(total_company_cost / total_orders, 2) if total_orders > 0 else 0,
@@ -9333,6 +9373,9 @@ class BizniWebExporter:
                 "avg_spend",
                 "avg_profit_without_fixed",
                 "avg_profit_with_fixed",
+                "avg_cm3_margin_pct",
+                "avg_returning_revenue_share_pct",
+                "avg_aov",
                 "roas",
             ]
         )
@@ -9357,6 +9400,9 @@ class BizniWebExporter:
                     total_ad_spend=("total_ad_spend", "mean"),
                     profit_without_fixed=("profit_without_fixed", "mean"),
                     profit_with_fixed=("profit_with_fixed", "mean"),
+                    cm3_margin_pct=("cm3_margin_pct", "mean"),
+                    returning_revenue_share_pct=("returning_revenue_share_pct", "mean"),
+                    aov=("aov", "mean"),
                 )
                 .reset_index()
             )
@@ -9367,10 +9413,55 @@ class BizniWebExporter:
                 "avg_spend",
                 "avg_profit_without_fixed",
                 "avg_profit_with_fixed",
+                "avg_cm3_margin_pct",
+                "avg_returning_revenue_share_pct",
+                "avg_aov",
             ]
             spend_effectiveness["avg_profit"] = spend_effectiveness["avg_profit_without_fixed"]
             spend_effectiveness["roas"] = (spend_effectiveness["avg_revenue"] / spend_effectiveness["avg_spend"]).round(2)
             spend_effectiveness["roas"] = spend_effectiveness["roas"].replace([float("inf"), float("-inf")], 0).fillna(0)
+
+        paid_days = daily_data[daily_data["has_any_ads"]].copy()
+        if paid_days.empty:
+            paid_day_cm3_win_rate_pct = None
+            paid_day_returning_revenue_share_pct = None
+            paid_day_aov = None
+        else:
+            paid_day_cm3_win_rate_pct = round(float((paid_days["profit_with_fixed"] > 0).mean() * 100), 1)
+            paid_revenue_total = float(paid_days["revenue"].sum())
+            paid_day_returning_revenue_share_pct = (
+                round(float(paid_days["returning_revenue"].sum() / paid_revenue_total * 100), 1)
+                if paid_revenue_total > 0
+                else None
+            )
+            paid_orders_total = float(paid_days["orders"].sum())
+            paid_day_aov = round(float(paid_revenue_total / paid_orders_total), 2) if paid_orders_total > 0 else None
+
+        best_cm3_range = (
+            spend_effectiveness.loc[spend_effectiveness["avg_profit_with_fixed"].idxmax(), "spend_range"]
+            if not spend_effectiveness.empty
+            else "N/A"
+        )
+        best_cm3_margin_range = (
+            spend_effectiveness.loc[spend_effectiveness["avg_cm3_margin_pct"].idxmax(), "spend_range"]
+            if not spend_effectiveness.empty
+            else "N/A"
+        )
+        decision_summary = {
+            "total_marketing_spend": float((financial_metrics or {}).get("total_ad_spend") or daily_data["total_ad_spend"].sum()),
+            "marketing_spend_share_pct": float((financial_metrics or {}).get("marketing_spend_share_pct") or 0.0),
+            "cm3_profit": float((financial_metrics or {}).get("cm3_profit") or 0.0),
+            "cm3_margin_pct": float((financial_metrics or {}).get("cm3_margin_pct") or 0.0),
+            "cm3_per_ad_eur": (float((financial_metrics or {}).get("cm3_per_ad_eur")) if (financial_metrics or {}).get("cm3_per_ad_eur") is not None else None),
+            "cm2_to_cm3_overhead_drag": float((financial_metrics or {}).get("cm2_to_cm3_overhead_drag") or 0.0),
+            "cm2_to_cm3_overhead_drag_pct": float((financial_metrics or {}).get("cm2_to_cm3_overhead_drag_pct") or 0.0),
+            "paid_days": int(len(paid_days)),
+            "paid_day_cm3_win_rate_pct": paid_day_cm3_win_rate_pct,
+            "paid_day_returning_revenue_share_pct": paid_day_returning_revenue_share_pct,
+            "paid_day_aov": paid_day_aov,
+            "best_cm3_range": str(best_cm3_range),
+            "best_cm3_margin_range": str(best_cm3_margin_range),
+        }
 
         dow_effectiveness = (
             daily_data.groupby("day_of_week")
@@ -9547,9 +9638,10 @@ class BizniWebExporter:
             "best_roas_range": spend_effectiveness.loc[spend_effectiveness["roas"].idxmax(), "spend_range"]
             if not spend_effectiveness.empty
             else "N/A",
-            "best_profit_range": spend_effectiveness.loc[spend_effectiveness["avg_profit"].idxmax(), "spend_range"]
-            if not spend_effectiveness.empty
-            else "N/A",
+            "best_profit_range": best_cm3_range,
+            "best_cm3_range": best_cm3_range,
+            "best_cm3_margin_range": best_cm3_margin_range,
+            "decision_summary": decision_summary,
             "daily_data": daily_data[
                 [
                     "date",
@@ -9569,6 +9661,12 @@ class BizniWebExporter:
                     "returning_orders",
                     "new_revenue",
                     "returning_revenue",
+                    "new_revenue_share_pct",
+                    "returning_revenue_share_pct",
+                    "ad_spend_share_pct",
+                    "cm2_margin_pct",
+                    "cm3_margin_pct",
+                    "cm3_per_ad_eur",
                     "has_fb_ads",
                     "has_google_ads",
                     "has_any_ads",
@@ -9604,6 +9702,21 @@ class BizniWebExporter:
             )
         if not incrementality_comparisons:
             recommendations.append("There are not enough paid and unpaid days in this range yet to judge ad incrementality.")
+        if decision_summary["best_cm3_range"] not in {"N/A", ""}:
+            recommendations.append(
+                f"Current data says the healthiest spend corridor for CM3 is {decision_summary['best_cm3_range']}."
+            )
+        if decision_summary["paid_day_cm3_win_rate_pct"] is not None and decision_summary["paid_day_cm3_win_rate_pct"] < 50:
+            recommendations.append(
+                "Less than half of paid days stay CM3-positive after fixed costs, so scale only inside the profitable spend corridor."
+            )
+        if (
+            decision_summary["paid_day_returning_revenue_share_pct"] is not None
+            and decision_summary["paid_day_returning_revenue_share_pct"] < 30
+        ):
+            recommendations.append(
+                "Paid-day revenue is still too dependent on new customers; CRM and remarketing should improve before pushing budget harder."
+            )
         result["recommendations"] = recommendations
 
         print(
@@ -10356,6 +10469,7 @@ def main():
         default_packaging_cost_per_order=PACKAGING_COST_PER_ORDER,
         default_shipping_subsidy_per_order=SHIPPING_SUBSIDY_PER_ORDER,
         default_fixed_monthly_cost=FIXED_MONTHLY_COST,
+        default_fixed_daily_cost=FIXED_DAILY_COST,
     )
     apply_project_runtime(runtime, globals())
 

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -10,6 +10,7 @@
   "packaging_cost_per_order": 0.3,
   "shipping_net_per_order": 0.2,
   "fixed_monthly_cost": 0,
+  "fixed_daily_cost": 70,
   "excluded_order_statuses": [
     "madfrog stara odoslana"
   ],

--- a/reporting_core/cfo_kpis.py
+++ b/reporting_core/cfo_kpis.py
@@ -140,7 +140,8 @@ def _build_daily_rows_from_date_agg(date_agg: pd.DataFrame) -> List[Dict[str, An
         facebook_ads = float(row.get("fb_ads_spend", 0) or 0)
         google_ads = float(row.get("google_ads_spend", 0) or 0)
         total_ads = facebook_ads + google_ads
-        profit = float(row.get("net_profit", 0) or 0)
+        profit = float(row.get("contribution_profit", row.get("net_profit", 0)) or 0)
+        fixed_overhead = float(row.get("fixed_daily_cost", 0) or 0)
         pre_ad_contribution = float(row.get("pre_ad_contribution_profit", 0) or 0)
         contribution_margin_percent = float(row.get("pre_ad_contribution_margin_pct", 0) or 0)
 
@@ -164,6 +165,7 @@ def _build_daily_rows_from_date_agg(date_agg: pd.DataFrame) -> List[Dict[str, An
                 "google_ads": google_ads,
                 "total_ads": total_ads,
                 "profit": profit,
+                "fixed_overhead": fixed_overhead,
                 "roas": roas,
                 "contribution_margin_percent": contribution_margin_percent,
                 "pre_ad_contribution": pre_ad_contribution,
@@ -189,6 +191,7 @@ def _window_aggregate(
     fb_ads = 0.0
     google_ads = 0.0
     profit = 0.0
+    fixed_overhead = 0.0
     pre_ad_contribution = 0.0
     new_customers = 0
     returning_orders = 0
@@ -204,6 +207,7 @@ def _window_aggregate(
             fb_ads += float(row["facebook_ads"])
             google_ads += float(row["google_ads"])
             profit += float(row["profit"])
+            fixed_overhead += float(row.get("fixed_overhead", 0.0) or 0.0)
             pre_ad_contribution += float(row["pre_ad_contribution"])
 
         customer = customer_by_date.get(d, {})
@@ -222,7 +226,9 @@ def _window_aggregate(
     payback_orders = (cac / contribution_per_order) if (cac is not None and contribution_per_order > 0) else None
     unique_customers = _window_unique_customers(order_records, end_date, days)
     ltv = (revenue / unique_customers) if unique_customers > 0 else None
-    company_profit_with_fixed = profit - (fixed_daily_cost_eur * days)
+    fallback_fixed_total = fixed_daily_cost_eur * days
+    fixed_overhead_total = fixed_overhead if fixed_overhead > 0 else fallback_fixed_total
+    company_profit_with_fixed = profit - fixed_overhead_total
     company_margin_with_fixed = (company_profit_with_fixed / revenue * 100) if revenue > 0 else 0.0
 
     return {
@@ -232,6 +238,7 @@ def _window_aggregate(
         "fb_ads": fb_ads,
         "google_ads": google_ads,
         "profit": profit,
+        "fixed_overhead": fixed_overhead_total,
         "pre_ad_contribution": pre_ad_contribution,
         "aov": aov,
         "roas": roas,

--- a/reporting_core/runtime.py
+++ b/reporting_core/runtime.py
@@ -26,6 +26,7 @@ class ProjectRuntime:
     packaging_cost_per_order: float
     shipping_subsidy_per_order: float
     fixed_monthly_cost: float
+    fixed_daily_cost: float
     currency_rates_to_eur: Dict[str, float]
     product_expenses: Dict[str, float]
     zero_margin_brands: List[str]
@@ -62,6 +63,7 @@ class ProjectRuntime:
             "shipping_subsidy_per_order": self.shipping_subsidy_per_order,
             "shipping_net_per_order": self.shipping_net_per_order,
             "fixed_monthly_cost": self.fixed_monthly_cost,
+            "fixed_daily_cost": self.fixed_daily_cost,
             "currency_rates_to_eur": dict(self.currency_rates_to_eur),
             "product_expenses": dict(self.product_expenses),
             "zero_margin_brands": list(self.zero_margin_brands),
@@ -88,6 +90,7 @@ def load_project_runtime(
     default_packaging_cost_per_order: float,
     default_shipping_subsidy_per_order: float,
     default_fixed_monthly_cost: float,
+    default_fixed_daily_cost: float,
     default_weather_timezone: str = "Europe/Bratislava",
 ) -> ProjectRuntime:
     project_path = project_dir(project_name)
@@ -144,6 +147,7 @@ def load_project_runtime(
             )
         ),
         fixed_monthly_cost=float(settings.get("fixed_monthly_cost", default_fixed_monthly_cost)),
+        fixed_daily_cost=float(settings.get("fixed_daily_cost", default_fixed_daily_cost)),
         currency_rates_to_eur={
             str(k).upper(): float(v)
             for k, v in dict(settings.get("currency_rates_to_eur", default_currency_rates or {})).items()
@@ -184,6 +188,7 @@ def apply_project_runtime(runtime: ProjectRuntime, target_globals: Dict[str, Any
     target_globals["SHIPPING_SUBSIDY_PER_ORDER"] = float(runtime.shipping_subsidy_per_order)
     target_globals["SHIPPING_NET_PER_ORDER"] = float(runtime.shipping_net_per_order)
     target_globals["FIXED_MONTHLY_COST"] = float(runtime.fixed_monthly_cost)
+    target_globals["FIXED_DAILY_COST"] = float(runtime.fixed_daily_cost)
     target_globals["CURRENCY_RATES_TO_EUR"] = dict(runtime.currency_rates_to_eur)
     target_globals["PRODUCT_EXPENSES"] = dict(runtime.product_expenses)
     target_globals["ZERO_MARGIN_BRANDS"] = [str(v).strip().lower() for v in runtime.zero_margin_brands if str(v).strip()]

--- a/templates/reporting-client/settings.template.json
+++ b/templates/reporting-client/settings.template.json
@@ -7,6 +7,7 @@
   "packaging_cost_per_order": 0.3,
   "shipping_net_per_order": 0.0,
   "fixed_monthly_cost": 0,
+  "fixed_daily_cost": 0,
   "excluded_order_statuses": [],
   "weather": {
     "enabled": false,


### PR DESCRIPTION
## Summary\n- add VEVO marketing decision metrics to the modern dashboard and payload\n- fix CM3 so fixed overhead is applied via fixed_daily_cost\n- align CFO helper so fixed costs are not double-subtracted\n\n## Verification\n- python -m py_compile export_orders.py dashboard_modern.py reporting_core/runtime.py reporting_core/cfo_kpis.py\n- python export_orders.py --project vevo --from-date 2026-03-01 --to-date 2026-03-31\n- python scripts/reporting_qa_smoke.py\n- python scripts/security_ci.py