### PR TITLE
Harden KPI reporting regression guards

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -93,6 +93,10 @@ Bootstrap entrypoints:
   - returning revenue share
   - AOV
 - CFO KPI helper no longer double-subtracts fixed costs when building company-margin views from `date_agg`.
+- CFO KPI smoke coverage now validates layer mapping and window invariants:
+  - `profit` must reconcile to post-ad profit ex fixed (`contribution_profit`)
+  - `company_margin_with_fixed` secondary value must reconcile to CM3 / net profit
+  - margin percentages must reconcile back to their absolute profit layers
 
 ## 6) Integration Notes (External Systems)
 
@@ -151,6 +155,18 @@ Bootstrap entrypoints:
 - Verify the next scheduled ROY production email run from `roy-daily-report-email` against task definition `roy-reporting-daily:2`, then decide whether ROY recipients stay single-recipient or should be expanded.
 
 ## 9) Change Log
+
+### 2026-04-14
+- Added regression coverage for CFO KPI deck layer mapping in `scripts/reporting_qa_smoke.py`.
+- Smoke QA now asserts for `daily`, `weekly`, `monthly`, and `all_time` that:
+  - revenue reconciles to raw series totals
+  - KPI `profit` reconciles to `contribution_profit`
+  - secondary company-profit value reconciles to `net_profit`
+  - post-ad and company margins recompute correctly from absolute values
+- Hardened `reporting_core/cfo_kpis.py` date parsing so KPI payload building accepts `date`, `datetime`, and `pd.Timestamp`, not only strict `YYYY-MM-DD` strings.
+- Verified locally with:
+  - `python -m py_compile scripts/reporting_qa_smoke.py reporting_core/cfo_kpis.py`
+  - `python scripts/reporting_qa_smoke.py`
 
 ### 2026-04-13
 - Added shared runtime support for explicit per-day fixed overhead via `fixed_daily_cost` while preserving monthly fixed-cost support.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -164,8 +164,13 @@ Bootstrap entrypoints:
   - secondary company-profit value reconciles to `net_profit`
   - post-ad and company margins recompute correctly from absolute values
 - Hardened `reporting_core/cfo_kpis.py` date parsing so KPI payload building accepts `date`, `datetime`, and `pd.Timestamp`, not only strict `YYYY-MM-DD` strings.
+- Fixed modern dashboard `consistency` payload mapping so ROAS / margin / CAC deltas and OK flags now serialize from the live validation keys instead of stale field names.
+- Geo QA now warns explicitly when country profitability excludes non-zero Google Ads spend, because country rows currently model Facebook-attributed spend only.
+- Expanded `scripts/reporting_qa_smoke.py` with regressions for:
+  - dashboard consistency payload serialization
+  - geo profitability warning when Google spend is present but not country-attributed
 - Verified locally with:
-  - `python -m py_compile scripts/reporting_qa_smoke.py reporting_core/cfo_kpis.py`
+  - `python -m py_compile dashboard_modern.py export_orders.py scripts/reporting_qa_smoke.py`
   - `python scripts/reporting_qa_smoke.py`
 
 ### 2026-04-13

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1434,11 +1434,11 @@ def generate_modern_dashboard(
     segment_rows = sorted(segment_rows, key=lambda row: (row["priority"], -row["count"]))
 
     consistency_payload = {
-        "roas_delta": _maybe_num((consistency_checks or {}).get("roas_check_delta")),
-        "margin_delta": _maybe_num((consistency_checks or {}).get("margin_check_delta")),
-        "cac_delta": _maybe_num((consistency_checks or {}).get("cac_check_delta")),
+        "roas_delta": _maybe_num((consistency_checks or {}).get("roas_delta")),
+        "margin_delta": _maybe_num((consistency_checks or {}).get("company_margin_delta_pct")),
+        "cac_delta": _maybe_num((consistency_checks or {}).get("cac_delta")),
         "roas_ok": bool((consistency_checks or {}).get("roas_ok")),
-        "margin_ok": bool((consistency_checks or {}).get("margin_ok")),
+        "margin_ok": bool((consistency_checks or {}).get("company_margin_ok")),
         "cac_ok": bool((consistency_checks or {}).get("cac_ok")),
     }
     financial_payload = {

--- a/export_orders.py
+++ b/export_orders.py
@@ -935,10 +935,16 @@ class BizniWebExporter:
             "chart_min_orders": settings["chart_min_orders"],
         }
 
-    def _build_geo_qa(self, country_analysis: Optional[pd.DataFrame], geo_profitability: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    def _build_geo_qa(
+        self,
+        country_analysis: Optional[pd.DataFrame],
+        geo_profitability: Optional[Dict[str, Any]],
+        date_agg: Optional[pd.DataFrame] = None,
+    ) -> Dict[str, Any]:
         country_df = country_analysis.copy() if isinstance(country_analysis, pd.DataFrame) else pd.DataFrame()
         geo_table = (geo_profitability or {}).get("table")
         geo_df = geo_table.copy() if isinstance(geo_table, pd.DataFrame) else pd.DataFrame()
+        date_df = date_agg.copy() if isinstance(date_agg, pd.DataFrame) else pd.DataFrame()
 
         warnings: List[str] = []
         ignore_count = 0
@@ -950,6 +956,7 @@ class BizniWebExporter:
         observe_revenue = 0.0
         total_orders = 0.0
         total_revenue = 0.0
+        unallocated_google_spend = 0.0
 
         if not geo_df.empty and "confidence_status" in geo_df.columns:
             if "orders" in geo_df.columns:
@@ -972,6 +979,14 @@ class BizniWebExporter:
             if observe_count > 0:
                 warnings.append(
                     f"{observe_count} country row(s) are in observe mode only. Treat margin/CPO reads as directional rather than decisive."
+                )
+        if not date_df.empty and "google_ads_spend" in date_df.columns:
+            unallocated_google_spend = float(
+                pd.to_numeric(date_df["google_ads_spend"], errors="coerce").fillna(0).sum()
+            )
+            if not geo_df.empty and unallocated_google_spend > 0.05:
+                warnings.append(
+                    f"Geo profitability excludes Google Ads country allocation, so EUR {unallocated_google_spend:.2f} of Google spend is not reflected in the country contribution rows."
                 )
 
         unknown_country_rate = None
@@ -1015,6 +1030,7 @@ class BizniWebExporter:
             "observe_revenue_share_pct": observe_revenue_share_pct,
             "low_confidence_order_share_pct": round(ignore_order_share_pct + observe_order_share_pct, 2),
             "low_confidence_revenue_share_pct": round(ignore_revenue_share_pct + observe_revenue_share_pct, 2),
+            "unallocated_google_spend": round(unallocated_google_spend, 2),
         }
 
     def _build_data_assertions_qa(
@@ -3794,6 +3810,7 @@ class BizniWebExporter:
         source_health.setdefault("qa", {})["geo"] = self._build_geo_qa(
             country_analysis=country_analysis,
             geo_profitability=geo_profitability,
+            date_agg=date_agg,
         )
         source_health.setdefault("qa", {})["data_assertions"] = self._build_data_assertions_qa(
             financial_metrics=financial_metrics,

--- a/reporting_core/cfo_kpis.py
+++ b/reporting_core/cfo_kpis.py
@@ -124,12 +124,19 @@ def _build_daily_rows_from_date_agg(date_agg: pd.DataFrame) -> List[Dict[str, An
         return rows
 
     for _, row in date_agg.iterrows():
-        date_value = str(row.get("date") or "").strip()
-        if not date_value:
+        date_value = row.get("date")
+        if pd.isna(date_value):
             continue
         try:
-            d = datetime.strptime(date_value, "%Y-%m-%d").date()
-        except ValueError:
+            if isinstance(date_value, pd.Timestamp):
+                d = date_value.date()
+            elif isinstance(date_value, datetime):
+                d = date_value.date()
+            elif isinstance(date_value, date):
+                d = date_value
+            else:
+                d = pd.to_datetime(str(date_value).strip()).date()
+        except (TypeError, ValueError):
             continue
 
         revenue = float(row.get("total_revenue", 0) or 0)

--- a/scripts/reporting_qa_smoke.py
+++ b/scripts/reporting_qa_smoke.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import json
 import math
 import pathlib
+import re
 import sys
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pandas as pd
 
@@ -14,6 +16,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from export_orders import BizniWebExporter
+from html_report_generator import generate_html_report
 from reporting_core.cfo_kpis import build_cfo_kpi_payload
 
 
@@ -62,6 +65,33 @@ def base_cost_per_order() -> dict:
             "total_orders": 100.0,
         },
     }
+
+
+def sample_date_agg() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "date": pd.date_range("2026-03-01", periods=3, freq="D"),
+            "total_items": [3, 5, 2],
+            "total_quantity": [3, 4, 2],
+            "total_revenue": [100.0, 200.0, 50.0],
+            "product_expense": [30.0, 60.0, 20.0],
+            "unique_orders": [2, 4, 1],
+            "fb_ads_spend": [5.0, 10.0, 2.0],
+            "google_ads_spend": [5.0, 10.0, 3.0],
+            "packaging_cost": [2.0, 4.0, 1.0],
+            "shipping_net_cost": [3.0, 6.0, 1.0],
+            "pre_ad_contribution_profit": [65.0, 130.0, 28.0],
+            "pre_ad_contribution_margin_pct": [65.0, 65.0, 56.0],
+            "pre_ad_contribution_profit_per_order": [32.5, 32.5, 28.0],
+            "contribution_profit": [55.0, 110.0, 23.0],
+            "contribution_profit_per_order": [27.5, 27.5, 23.0],
+            "post_ad_contribution_margin_pct": [55.0, 55.0, 46.0],
+            "net_profit": [45.0, 90.0, 18.0],
+            "fixed_daily_cost": [10.0, 20.0, 5.0],
+            "total_cost": [55.0, 110.0, 32.0],
+            "roi_percent": [81.82, 81.82, 56.25],
+        }
+    )
 
 
 def assert_data_assertions_ok(exporter: BizniWebExporter) -> None:
@@ -143,6 +173,26 @@ def assert_geo_warning(exporter: BizniWebExporter) -> None:
     assert qa["unknown_country_rate"] == 10.0, qa
 
 
+def assert_geo_google_spend_warning(exporter: BizniWebExporter) -> None:
+    qa = exporter._build_geo_qa(
+        country_analysis=pd.DataFrame({"country": ["sk"], "orders": [100]}),
+        geo_profitability={
+            "table": pd.DataFrame(
+                {
+                    "country": ["sk"],
+                    "orders": [100],
+                    "revenue": [1500.0],
+                    "confidence_status": ["ready"],
+                }
+            )
+        },
+        date_agg=sample_date_agg(),
+    )
+    assert qa["status"] == "warning", qa
+    assert math.isclose(float(qa["unallocated_google_spend"]), 18.0, rel_tol=1e-9, abs_tol=1e-9), qa
+    assert any("Google Ads country allocation" in msg for msg in qa["warnings"]), qa
+
+
 def assert_margin_stability(exporter: BizniWebExporter) -> None:
     stable = exporter._build_margin_stability_qa(
         pd.DataFrame(
@@ -210,24 +260,7 @@ def assert_product_expense_coverage(exporter: BizniWebExporter) -> None:
 
 
 def assert_cfo_kpi_layer_invariants() -> None:
-    date_agg = pd.DataFrame(
-        {
-            "date": pd.date_range("2026-03-01", periods=3, freq="D"),
-            "total_quantity": [3, 4, 2],
-            "total_revenue": [100.0, 200.0, 50.0],
-            "product_expense": [30.0, 60.0, 20.0],
-            "unique_orders": [2, 4, 1],
-            "fb_ads_spend": [5.0, 10.0, 2.0],
-            "google_ads_spend": [5.0, 10.0, 3.0],
-            "packaging_cost": [2.0, 4.0, 1.0],
-            "shipping_net_cost": [3.0, 6.0, 1.0],
-            "pre_ad_contribution_profit": [65.0, 130.0, 28.0],
-            "pre_ad_contribution_margin_pct": [65.0, 65.0, 56.0],
-            "contribution_profit": [55.0, 110.0, 23.0],
-            "net_profit": [45.0, 90.0, 18.0],
-            "fixed_daily_cost": [10.0, 20.0, 5.0],
-        }
-    )
+    date_agg = sample_date_agg()
 
     payload = build_cfo_kpi_payload(date_agg=date_agg, export_df=None, fixed_daily_cost_eur=999.0)
     assert payload["default_window"] == "monthly", payload
@@ -282,14 +315,48 @@ def assert_cfo_kpi_layer_invariants() -> None:
     ), payload["windows"]["monthly"]
 
 
+def assert_dashboard_consistency_payload_mapping() -> None:
+    date_agg = sample_date_agg()
+    cfo_kpi_payload = build_cfo_kpi_payload(date_agg=date_agg, export_df=None, fixed_daily_cost_eur=15.0)
+    html = generate_html_report(
+        date_agg=date_agg,
+        date_product_agg=pd.DataFrame(),
+        items_agg=pd.DataFrame(),
+        date_from=datetime(2026, 3, 1),
+        date_to=datetime(2026, 3, 3),
+        report_title="QA Smoke",
+        consistency_checks={
+            "roas_delta": 0.1234,
+            "company_margin_delta_pct": -0.02,
+            "cac_delta": 0.56,
+            "roas_ok": False,
+            "company_margin_ok": True,
+            "cac_ok": False,
+        },
+        cfo_kpi_payload=cfo_kpi_payload,
+    )
+    match = re.search(r'<script id="report-dashboard-json" type="application/json">(.*?)</script>', html, re.S)
+    assert match, "dashboard payload script missing"
+    payload = json.loads(match.group(1))
+    consistency = payload["consistency"]
+    assert math.isclose(float(consistency["roas_delta"]), 0.1234, rel_tol=1e-9, abs_tol=1e-9), consistency
+    assert math.isclose(float(consistency["margin_delta"]), -0.02, rel_tol=1e-9, abs_tol=1e-9), consistency
+    assert math.isclose(float(consistency["cac_delta"]), 0.56, rel_tol=1e-9, abs_tol=1e-9), consistency
+    assert consistency["roas_ok"] is False, consistency
+    assert consistency["margin_ok"] is True, consistency
+    assert consistency["cac_ok"] is False, consistency
+
+
 def main() -> int:
     exporter = make_exporter()
     assert_data_assertions_ok(exporter)
     assert_refund_registry_failure(exporter)
     assert_geo_warning(exporter)
+    assert_geo_google_spend_warning(exporter)
     assert_margin_stability(exporter)
     assert_product_expense_coverage(exporter)
     assert_cfo_kpi_layer_invariants()
+    assert_dashboard_consistency_payload_mapping()
     print("reporting_qa_smoke.py: OK")
     return 0
 

--- a/scripts/reporting_qa_smoke.py
+++ b/scripts/reporting_qa_smoke.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import math
 import pathlib
 import sys
+from datetime import timedelta
 
 import pandas as pd
 
@@ -12,6 +14,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from export_orders import BizniWebExporter
+from reporting_core.cfo_kpis import build_cfo_kpi_payload
 
 
 def make_exporter() -> BizniWebExporter:
@@ -206,6 +209,79 @@ def assert_product_expense_coverage(exporter: BizniWebExporter) -> None:
     assert risky["top_fallback_items"][0]["product_sku"] == "SKU-FALLBACK", risky
 
 
+def assert_cfo_kpi_layer_invariants() -> None:
+    date_agg = pd.DataFrame(
+        {
+            "date": pd.date_range("2026-03-01", periods=3, freq="D"),
+            "total_quantity": [3, 4, 2],
+            "total_revenue": [100.0, 200.0, 50.0],
+            "product_expense": [30.0, 60.0, 20.0],
+            "unique_orders": [2, 4, 1],
+            "fb_ads_spend": [5.0, 10.0, 2.0],
+            "google_ads_spend": [5.0, 10.0, 3.0],
+            "packaging_cost": [2.0, 4.0, 1.0],
+            "shipping_net_cost": [3.0, 6.0, 1.0],
+            "pre_ad_contribution_profit": [65.0, 130.0, 28.0],
+            "pre_ad_contribution_margin_pct": [65.0, 65.0, 56.0],
+            "contribution_profit": [55.0, 110.0, 23.0],
+            "net_profit": [45.0, 90.0, 18.0],
+            "fixed_daily_cost": [10.0, 20.0, 5.0],
+        }
+    )
+
+    payload = build_cfo_kpi_payload(date_agg=date_agg, export_df=None, fixed_daily_cost_eur=999.0)
+    assert payload["default_window"] == "monthly", payload
+
+    date_agg = date_agg.copy()
+    date_agg["date"] = pd.to_datetime(date_agg["date"]).dt.date
+    last_date = date_agg["date"].max()
+    first_date = date_agg["date"].min()
+    all_time_days = (last_date - first_date).days + 1
+
+    def expected(days: int) -> dict:
+        start_date = last_date - timedelta(days=days - 1)
+        window = date_agg[(date_agg["date"] >= start_date) & (date_agg["date"] <= last_date)]
+        revenue = float(window["total_revenue"].sum())
+        profit_without_fixed = float(window["contribution_profit"].sum())
+        profit_with_fixed = float(window["net_profit"].sum())
+        orders = float(window["unique_orders"].sum())
+        return {
+            "revenue": revenue,
+            "profit": profit_without_fixed,
+            "company_profit": profit_with_fixed,
+            "orders": orders,
+            "post_margin": (profit_without_fixed / revenue * 100) if revenue > 0 else 0.0,
+            "company_margin": (profit_with_fixed / revenue * 100) if revenue > 0 else 0.0,
+        }
+
+    def assert_close(actual: float, exp: float, label: str) -> None:
+        assert math.isclose(actual, exp, rel_tol=1e-9, abs_tol=1e-9), f"{label}: {actual} != {exp}"
+
+    for window_key, days in {"daily": 1, "weekly": 7, "monthly": 30, "all_time": all_time_days}.items():
+        current = payload["windows"][window_key]
+        metrics = current["metrics"]
+        secondary = current["secondary_metrics"]
+        exp = expected(days)
+
+        assert_close(float(metrics["revenue"]), exp["revenue"], f"{window_key} revenue")
+        assert_close(float(metrics["profit"]), exp["profit"], f"{window_key} profit_without_fixed")
+        assert_close(float(secondary["company_margin_with_fixed"]), exp["company_profit"], f"{window_key} company_profit_with_fixed")
+        assert_close(float(metrics["orders"]), exp["orders"], f"{window_key} orders")
+        assert_close(float(metrics["post_ad_margin"]), exp["post_margin"], f"{window_key} post_ad_margin")
+        assert_close(
+            float(metrics["company_margin_with_fixed"]),
+            exp["company_margin"],
+            f"{window_key} company_margin_with_fixed",
+        )
+
+    assert not math.isclose(
+        float(payload["windows"]["monthly"]["metrics"]["profit"]),
+        float(payload["windows"]["monthly"]["secondary_metrics"]["company_margin_with_fixed"]),
+        rel_tol=1e-9,
+        abs_tol=1e-9,
+    ), payload["windows"]["monthly"]
+
+
 def main() -> int:
     exporter = make_exporter()
     assert_data_assertions_ok(exporter)
@@ -213,6 +289,7 @@ def main() -> int:
     assert_geo_warning(exporter)
     assert_margin_stability(exporter)
     assert_product_expense_coverage(exporter)
+    assert_cfo_kpi_layer_invariants()
     print("reporting_qa_smoke.py: OK")
     return 0
 


### PR DESCRIPTION
## Summary
- add smoke coverage for KPI layer invariants, dashboard consistency payload serialization, and geo Google-spend warnings
- fix modern dashboard consistency payload mapping to use the live validation keys
- warn when geo profitability excludes non-zero Google Ads spend from country rows

## Verification
- python -m py_compile dashboard_modern.py export_orders.py scripts/reporting_qa_smoke.py
- python scripts/reporting_qa_smoke.py