### PR TITLE
Harden production reporting deployment gate

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -18,7 +18,9 @@ on:
       - facebook_ads.py
       - google_ads.py
       - reporting_core/**
-      - projects/vevo/**
+      - projects/**
+      - templates/**
+      - scripts/reporting_qa_smoke.py
       - .github/workflows/build-and-push-ecr.yml
 
 env:
@@ -34,6 +36,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install reporting dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Reporting regression smoke gate
+        run: |
+          python scripts/reporting_qa_smoke.py
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r /app/requirements.txt && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir -r /app/requirements.txt && \
     pip install --no-cache-dir boto3
 
 COPY . /app

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1492,3 +1492,25 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
 - Operational note:
   - ROY now has a real scheduled AWS daily email runner and it is aligned with the current reporting start date
   - the current runtime secret still sends ROY report emails to `mil.terem@gmail.com`
+
+### 2026-04-14 (production regression gate + host verification hardening)
+- Verified the KPI regression fixes were merged to `main` as PR `#39` and the production image refresh completed:
+  - merge commit on `main`: `28a7c2692b0baa50755b77384e7f0514ac1476b3`
+  - ECR `latest` digest after merge: `sha256:d4188b3febd622e7c308dc08e4aa8a79ca214af4addae86820a2ad689cafb47f`
+- Ran a manual VEVO production-equivalent ECS task on the new image and verified host-level artifact rendering with a localhost marker in CloudWatch:
+  - task ARN: `arn:aws:ecs:eu-central-1:919341186960:task/vevo-reporting-cluster/2dbe88c1a6d948e78fded177a3fe108f`
+  - private runtime IP: `172.31.4.112`
+  - marker: `LOCALHOST_MARKER_OK`
+  - verified serialized consistency payload fields (`roas_delta`, `margin_delta`, `cac_delta`) were present in the generated dashboard artifact
+- Found a production-verification gap during the equivalent ROY host check:
+  - the runtime image did not include `curl`, so a strict `curl localhost` host verification wrapper exited `127` before the report marker step
+  - this was a verification-tooling gap, not evidence of the KPI regression returning
+- Hardened production deployment to make this class of issue much harder to reintroduce:
+  - added `curl` into the Docker runtime image so future host checks can use the required localhost verification path directly
+  - added `python scripts/reporting_qa_smoke.py` as a hard gate inside `.github/workflows/build-and-push-ecr.yml` before any ECR login/build/push
+  - broadened build trigger paths to include `projects/**`, `templates/**`, and `scripts/reporting_qa_smoke.py` so runtime-shaping changes cannot silently miss a production image refresh
+- Verification to run after merge of this hardening branch:
+  - GitHub Actions `Build and Push ECR` must pass with the new smoke gate
+  - rerun manual ROY ECS verification with `curl localhost` marker on the refreshed image
+- Next exact step:
+  - merge the hardening branch, wait for the guarded ECR build to finish, then rerun the ROY manual host-level verification and confirm the marker payload in CloudWatch


### PR DESCRIPTION
## Summary
- add a regression smoke gate to the production ECR workflow before any image push
- broaden build trigger paths so runtime-shaping project/template changes rebuild the production image
- install curl in the runtime image so host-level localhost verification can use the required curl marker path

## Verification
- python -m py_compile daily_report_runner.py dashboard_modern.py export_orders.py scripts/reporting_qa_smoke.py
- python scripts/reporting_qa_smoke.py