### PR TITLE
Raise ROY fixed cost to 5500 EUR

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1540,3 +1540,18 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - the ROY `prodcheck3` marker payload returned `consistency.* = null`; this did not block the deployed KPI fix or localhost HTML verification, but if ROY is expected to show those consistency deltas in UI, it should get a dedicated follow-up audit
 - Next exact step:
   - optionally audit why ROY `consistency` fields are null in the prodcheck artifact and decide whether that is expected dataset behavior or another dashboard binding gap
+
+### 2026-04-14 (ROY fixed cost source-of-truth raised to 5500 EUR/month)
+- Updated ROY project settings source-of-truth in `projects/roy/settings.json`:
+  - `fixed_monthly_cost`: `4900` -> `5500`
+- Removed runner-level fixed-cost drift in `daily_report_runner.py`:
+  - `_window_aggregate()` no longer subtracts a stale global fallback from `net_profit`
+  - runner company-profit-with-fixed now follows the exported `net_profit` rows, which already include fixed overhead
+- Added regression guards in `scripts/reporting_qa_smoke.py`:
+  - assert ROY runtime loads `fixed_monthly_cost = 5500`
+  - assert daily runner does not double-subtract fixed overhead from aggregate rows
+- Expected runtime effect after production image refresh:
+  - future ROY daily runs will load `5500 EUR/month` from Git-backed project settings
+  - April daily fixed allocation becomes `183.33 EUR/day` before CSV rounding
+- Next exact step:
+  - merge the branch, wait for the guarded ECR build to finish, then verify on a manual ROY ECS task that localhost marker output reports `fixed_monthly_cost = 5500`

--- a/daily_report_runner.py
+++ b/daily_report_runner.py
@@ -39,7 +39,6 @@ from reporting_core import (
 
 ROOT_DIR = Path(__file__).resolve().parent
 DEFAULT_PROJECT = os.getenv("REPORT_PROJECT", BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
-CFO_FIXED_DAILY_COST_EUR = float(os.getenv("CFO_FIXED_DAILY_COST_EUR", "70"))
 STABLE_LIVE_ARTIFACT_NAMES = {
     "report_latest.html",
     "dashboard_payload_latest.json",
@@ -384,6 +383,7 @@ def _load_daily_rows(date_csv: Path) -> List[Dict[str, Any]]:
             profit = _to_float(row.get("net_profit", ""))
             pre_ad_contribution = _to_float(row.get("pre_ad_contribution_profit", ""))
             contribution_margin_percent = _to_float(row.get("pre_ad_contribution_margin_pct", ""))
+            fixed_daily_cost = _to_float(row.get("fixed_daily_cost", ""))
 
             aov = (revenue / orders) if orders > 0 else 0.0
             roas = (revenue / total_ads) if total_ads > 0 else 0.0
@@ -405,6 +405,7 @@ def _load_daily_rows(date_csv: Path) -> List[Dict[str, Any]]:
                     "google_ads": google_ads,
                     "total_ads": total_ads,
                     "profit": profit,
+                    "fixed_daily_cost": fixed_daily_cost,
                     "roas": roas,
                     "contribution_margin_percent": contribution_margin_percent,
                     "pre_ad_contribution": pre_ad_contribution,
@@ -504,6 +505,7 @@ def _window_aggregate(
     google_ads = 0.0
     profit = 0.0
     pre_ad_contribution = 0.0
+    fixed_overhead = 0.0
     new_customers = 0
     returning_orders = 0
     returning_customers = 0
@@ -519,6 +521,7 @@ def _window_aggregate(
             google_ads += float(row["google_ads"])
             profit += float(row["profit"])
             pre_ad_contribution += float(row["pre_ad_contribution"])
+            fixed_overhead += float(row.get("fixed_daily_cost", 0.0) or 0.0)
 
         customer = customer_by_date.get(d, {})
         new_customers += int(customer.get("new_customers", 0))
@@ -536,7 +539,8 @@ def _window_aggregate(
     payback_orders = (cac / contribution_per_order) if (cac is not None and contribution_per_order > 0) else None
     unique_customers = _window_unique_customers(order_records, end_date, days)
     ltv = (revenue / unique_customers) if unique_customers > 0 else None
-    company_profit_with_fixed = profit - (CFO_FIXED_DAILY_COST_EUR * days)
+    # aggregate_by_date CSV rows already use net_profit, which includes fixed overhead
+    company_profit_with_fixed = profit
     company_margin_with_fixed = (company_profit_with_fixed / revenue * 100) if revenue > 0 else 0.0
 
     return {
@@ -554,6 +558,7 @@ def _window_aggregate(
         "post_ad_margin": post_ad_margin,
         "company_margin_with_fixed": company_margin_with_fixed,
         "company_profit_with_fixed": company_profit_with_fixed,
+        "fixed_overhead": fixed_overhead,
         "contribution_per_order": contribution_per_order,
         "profit_per_order": profit_per_order,
         "new_customers": float(new_customers),

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -6,7 +6,7 @@
   "report_from_date": "2025-09-24",
   "packaging_cost_per_order": 0.05,
   "shipping_net_per_order": -0.2,
-  "fixed_monthly_cost": 4900,
+  "fixed_monthly_cost": 5500,
   "excluded_order_statuses": [
     "Stripe - cancelled",
     "Stripe - expired",

--- a/scripts/reporting_qa_smoke.py
+++ b/scripts/reporting_qa_smoke.py
@@ -15,8 +15,18 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from export_orders import BizniWebExporter
+from daily_report_runner import _window_aggregate as runner_window_aggregate
+from export_orders import (
+    BizniWebExporter,
+    CURRENCY_RATES_TO_EUR,
+    FIXED_DAILY_COST,
+    FIXED_MONTHLY_COST,
+    PACKAGING_COST_PER_ORDER,
+    PRODUCT_EXPENSES,
+    SHIPPING_SUBSIDY_PER_ORDER,
+)
 from html_report_generator import generate_html_report
+from reporting_core import load_project_runtime, load_project_settings
 from reporting_core.cfo_kpis import build_cfo_kpi_payload
 
 
@@ -347,6 +357,63 @@ def assert_dashboard_consistency_payload_mapping() -> None:
     assert consistency["cac_ok"] is False, consistency
 
 
+def assert_roy_fixed_cost_source_of_truth() -> None:
+    settings = load_project_settings("roy")
+    runtime = load_project_runtime(
+        "roy",
+        settings=settings,
+        legacy_product_expenses=PRODUCT_EXPENSES,
+        default_currency_rates=CURRENCY_RATES_TO_EUR,
+        default_packaging_cost_per_order=PACKAGING_COST_PER_ORDER,
+        default_shipping_subsidy_per_order=SHIPPING_SUBSIDY_PER_ORDER,
+        default_fixed_monthly_cost=FIXED_MONTHLY_COST,
+        default_fixed_daily_cost=FIXED_DAILY_COST,
+    )
+    assert math.isclose(runtime.fixed_monthly_cost, 5500.0, rel_tol=1e-9, abs_tol=1e-9), runtime.to_dict()
+    assert math.isclose(runtime.fixed_daily_cost, 0.0, rel_tol=1e-9, abs_tol=1e-9), runtime.to_dict()
+
+
+def assert_daily_runner_fixed_overhead_not_double_subtracted() -> None:
+    row_by_date = {
+        datetime(2026, 4, 1).date(): {
+            "revenue": 100.0,
+            "orders": 1,
+            "total_ads": 10.0,
+            "facebook_ads": 4.0,
+            "google_ads": 6.0,
+            "profit": 20.0,
+            "pre_ad_contribution": 40.0,
+            "fixed_daily_cost": 15.0,
+        },
+        datetime(2026, 4, 2).date(): {
+            "revenue": 200.0,
+            "orders": 2,
+            "total_ads": 20.0,
+            "facebook_ads": 8.0,
+            "google_ads": 12.0,
+            "profit": 50.0,
+            "pre_ad_contribution": 90.0,
+            "fixed_daily_cost": 15.0,
+        },
+    }
+    aggregate = runner_window_aggregate(
+        row_by_date=row_by_date,
+        end_date=datetime(2026, 4, 2).date(),
+        days=2,
+        customer_by_date={},
+        order_records=[],
+    )
+    assert math.isclose(float(aggregate["profit"]), 70.0, rel_tol=1e-9, abs_tol=1e-9), aggregate
+    assert math.isclose(float(aggregate["company_profit_with_fixed"]), 70.0, rel_tol=1e-9, abs_tol=1e-9), aggregate
+    assert math.isclose(
+        float(aggregate["company_margin_with_fixed"]),
+        70.0 / 300.0 * 100.0,
+        rel_tol=1e-9,
+        abs_tol=1e-9,
+    ), aggregate
+    assert math.isclose(float(aggregate["fixed_overhead"]), 30.0, rel_tol=1e-9, abs_tol=1e-9), aggregate
+
+
 def main() -> int:
     exporter = make_exporter()
     assert_data_assertions_ok(exporter)
@@ -357,6 +424,8 @@ def main() -> int:
     assert_product_expense_coverage(exporter)
     assert_cfo_kpi_layer_invariants()
     assert_dashboard_consistency_payload_mapping()
+    assert_roy_fixed_cost_source_of_truth()
+    assert_daily_runner_fixed_overhead_not_double_subtracted()
     print("reporting_qa_smoke.py: OK")
     return 0
 


### PR DESCRIPTION
## Summary
- raise the ROY Git-backed fixed monthly cost source of truth from 4900 EUR to 5500 EUR
- remove the stale runner fallback that could double-subtract fixed overhead from aggregate net profit rows
- add regression smoke guards for the ROY fixed cost source of truth and runner fixed-overhead handling

## Verification
- python -m py_compile daily_report_runner.py scripts/reporting_qa_smoke.py export_orders.py reporting_core/runtime.py
- python scripts/reporting_qa_smoke.py
- inline runtime check confirmed ROY fixed_monthly_cost=5500.0