### PR TITLE
Clarify reporting repo boundaries and branch workflow

### DIFF
--- a/OPERATING_PROTOCOL.md
+++ b/OPERATING_PROTOCOL.md
@@ -15,8 +15,15 @@ The goal is to keep one source of truth, avoid cross-PC drift, and prevent branc
 ## Project Map
 
 - Reporting: `biznisweb` repo, branch `main`
-- Doklady: `biznisweb` repo, branch `codex/doklady-saas-clean`
+- Doklady: `doklady-saas` repo, branch `main`
 - OpenClaw: `openclaw-agents-platform` repo, branch `main`
+
+## Branch Model
+
+- Repositories separate products.
+- Branches separate short-lived changes inside one product.
+- Do not keep long-lived product branches inside a shared repository.
+- Delete merged or superseded task branches quickly.
 
 ## Session Start Rules
 
@@ -68,6 +75,7 @@ Then update `PROJECT_STATE.md` with:
   - `.env.example`
   - `.env.required`
 - Hooks and bootstrap must be repo-local and reproducible from the repository.
+- Reporting, Doklady, and OpenClaw must keep their own `PROJECT_STATE.md` and their own GitHub source of truth.
 
 ## Safety Rules
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-04-13
+Last updated: 2026-04-15
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -33,8 +33,10 @@ Purpose: repo-scoped handoff and execution state for this codebase.
 
 ## 3) Current Branching / Workflow Rules
 
-- Reporting work stays on `main`
+- Reporting work stays in this repository on `main`
+- Doklady work moved out to the standalone `Terem21/doklady-saas` repository
 - OpenClaw work was moved out to the standalone `openclaw-agents-platform` repository
+- Use short-lived task branches only; branches are not product boundaries
 - `main` only through reviewed merge
 - Before work: `git fetch --all --prune && git pull --rebase`
 - After major step: commit + push immediately
@@ -103,6 +105,7 @@ Bootstrap entrypoints:
 ### Doklady
 - Integration is API-level only
 - Doklady remains system-of-record for accounting document state
+- Canonical code repository: `Terem21/doklady-saas`
 - Do not store Doklady runtime assumptions here beyond API contract references
 
 ### OpenClaw
@@ -151,10 +154,15 @@ Bootstrap entrypoints:
   - top brands by profit
 
 ## 8) Next Exact Step
+- Review the remaining active reporting branches (`codex/qa-geo-guardrails`, `codex/roy-meta-project-env`) and either open/merge PRs or close them intentionally.
 - Monitor the next production VEVO and ROY daily runner outputs to confirm the new Executive KPI `All-time` toggle is present in the emailed HTML attachments.
-- Verify the next scheduled ROY production email run from `roy-daily-report-email` against task definition `roy-reporting-daily:2`, then decide whether ROY recipients stay single-recipient or should be expanded.
 
 ## 9) Change Log
+
+### 2026-04-15
+- Split Doklady into its own GitHub repository: `Terem21/doklady-saas`.
+- Reporting workflow now treats repositories as product boundaries and branches as short-lived task scopes only.
+- Prepared reporting repo branch cleanup by identifying merged/superseded remote branches versus the still-active reporting branches.
 
 ### 2026-04-14
 - Added regression coverage for CFO KPI deck layer mapping in `scripts/reporting_qa_smoke.py`.

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -11,6 +11,8 @@ Do not treat any local Desktop/Downloads scripts as authoritative.
 - Never keep required runtime/deploy logic only on one PC.
 - Production/runtime secrets must not be committed.
 - Update `PROJECT_STATE.md` after each major change.
+- This repository owns Reporting only; Doklady and OpenClaw must live in their own repositories.
+- Treat branches as short-lived work units, not as long-lived product buckets.
 
 ## Multi-PC Workflow
 
@@ -88,4 +90,16 @@ This creates a new `projects/<slug>/` bundle from `templates/reporting-client/`.
 
 This repo contains the reporting codebase.
 OpenClaw and Doklady may integrate with it, but they are not managed here.
+Canonical product split:
+- Reporting: `vzeman/biznisweb`
+- Doklady: `Terem21/doklady-saas`
+- OpenClaw: `Terem21/openclaw-agents-platform`
+
+## Branch discipline
+
+- `main` is the source of truth for reporting.
+- Use short-lived branches for concrete work only, for example `codex/roy-inventory-metrics`.
+- Delete merged branches quickly so GitHub branch lists stay operationally readable.
+- If a branch starts representing a separate product, stop and move that product into its own repository.
+
 Use `PROJECT_STATE.md` only for this repo plus short integration notes.


### PR DESCRIPTION
## Summary\n- document reporting as the sole product in this repository\n- move Doklady references to the standalone repo\n- codify short-lived branch discipline for reporting work\n\n## Why\nThe repository had drifted into acting like a shared product bucket. This PR resets the workflow contract so repo boundaries match product boundaries and branches remain temporary task scopes.