### PR TITLE
Add Roy inventory valuation and stock risk reporting

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -174,14 +174,13 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- Merge and deploy the `codex/roy-inventory-metrics` branch so the new ROY stock alert section reaches the real scheduled daily email path.
-- After deploy, verify on the production ECS host/run that:
-  - the generated ROY HTML contains `Actionable inventory alerts`
-  - the sent daily email includes the `SKLADOVE ALERTY` block
-- Then implement inbound-stock modeling so reorder alerts stop being purely conservative:
+- Implement inbound-stock modeling so reorder alerts stop being purely conservative:
   - define the source of truth for goods on the way
   - map inbound quantities to product/SKU
   - fold inbound stock into `net_available_quantity` and reorder recommendations
+- After inbound stock exists, promote `Prepare PO` into a less conservative purchasing workflow that distinguishes:
+  - real stockout risk with inbound cover
+  - already-covered risk that only needs ETA monitoring
 
 ## 9) Change Log
 
@@ -207,6 +206,9 @@ Bootstrap entrypoints:
 - Wired the new inventory alert outputs into the active report surfaces:
   - `dashboard_modern.py` renders summary mini-cards plus the new actionable alert table
   - `daily_report_runner.py` reads `dashboard_payload.json` and appends `SKLADOVE ALERTY` into the outbound email text
+- Removed the ROY sample funnel from the active runtime and report surface:
+  - `export_orders.py` no longer computes sample-funnel analytics for the ROY project
+  - `dashboard_modern.py` now suppresses the sample-funnel block for ROY while keeping it available for VEVO
 - Verified locally on live ROY data with a one-pass export:
   - `python -m py_compile export_orders.py dashboard_modern.py daily_report_runner.py`
   - production-equivalent ROY export for `2025-09-24 -> 2026-04-15` using output tag `inventory_alerts_verify`
@@ -222,6 +224,17 @@ Bootstrap entrypoints:
     - `12` excluded noise rows
     - HTML contains `Actionable inventory alerts`
     - email summary text contains `SKLADOVE ALERTY`
+- Verified the ROY sample-funnel removal locally with:
+  - production-equivalent ROY export for `2025-09-24 -> 2026-04-15` using output tag `no_sample_verify`
+  - generated artifacts:
+    - `data/roy/report_20250924-20260415__no_sample_verify.html`
+    - `data/roy/dashboard_payload_20250924-20260415__no_sample_verify.json`
+  - verification outcome:
+    - `dashboard.sample_funnel.summary = {}`
+    - `dashboard.sample_funnel.windows = []`
+    - `dashboard.sample_funnel.entry_rows = []`
+    - ROY HTML no longer renders the sample-funnel section
+    - inventory alert section remains present and populated
 
 ### 2026-04-15
 - Added Roy inventory snapshot ingestion from Biznisweb GraphQL product data:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -164,16 +164,21 @@ Bootstrap entrypoints:
   - stock-risk watchlist with projected stockout dates
   - dead-stock candidates
   - inventory cost-coverage diagnostics
+  - restock-priority scoring
+  - revenue-at-risk rollups
+  - inventory turns by brand / family
+  - forecast backtest accuracy
 
 ## 8) Next Exact Step
-- Review the live Roy inventory metrics with the business owner and confirm alert semantics:
+- Review the live Roy inventory metrics with the business owner and confirm the alert semantics for the now-implemented inventory layer:
   - which stock-risk thresholds should trigger action (`Critical`, `Low`, `Watch`)
+  - whether alerting should trigger on 30-day risk only or also on the 45-day watch bucket
   - whether inventory value should be watched at cost only or also at retail
   - which dead-stock cutoff should be treated as operationally actionable
-- After threshold approval, turn the current Roy inventory snapshot into explicit alerting outputs:
-  - low-stock notifications for products with recent demand
-  - forecasted stockout warning horizon
-  - restock-priority ordering that combines forecast demand, gross margin, and current cover days
+- Before automating alerts, tighten the forecast model because current backtest accuracy is weak on the first live sample:
+  - reduce over-forecast bias on volatile SKUs
+  - decide whether alerts should use recent-demand fallback, forecast, or a weighted blend by confidence
+  - then turn the validated logic into explicit low-stock / stockout alert outputs
 
 ## 9) Change Log
 
@@ -192,31 +197,56 @@ Bootstrap entrypoints:
   - inventory valuation table
   - stock-risk watchlist
   - dead-stock table
+- Extended Roy inventory analytics with operational inventory metrics:
+  - restock-priority score and bucket (`Urgent`, `High`, `Plan`, `Monitor`)
+  - 30d / 45d revenue-at-risk and profit-at-risk rollups
+  - dead-stock share on total inventory value / units
+  - negative-stock unit-gap tracking
+  - inventory turns and estimated days-in-inventory by brand and product family
+  - forecast holdout backtest accuracy rows and summary KPIs
+- Added Roy dashboard rendering for the extra inventory operations layer:
+  - revenue-at-risk table
+  - restock-priority table
+  - inventory turns by family
+  - inventory turns by brand
+  - forecast backtest accuracy table
 - Added explicit `inventory_model` settings to:
   - `projects/roy/settings.json`
   - `templates/reporting-client/settings.template.json`
 - Verified locally with:
   - `python -m py_compile export_orders.py dashboard_modern.py`
   - `python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-14 --output-tag inventory_probe`
+  - `python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-14 --output-tag inventory_ops`
 - Verification outcome on live Roy data:
   - Biznisweb inventory snapshot fetch succeeded (`56` pages, `2370` warehouse rows)
   - full-history Roy dashboard payload now reports:
     - `1669` tracked products
-    - `417` products with stock
-    - `43101` available units
-    - `EUR 120176.49` inventory cost value
-    - `EUR 343958.90` inventory retail value
-    - `94.39%` unit coverage by mapped costs
-    - `87.81%` retail-value coverage by mapped costs
-    - `29` critical / negative-stock items
-    - `36` items at 30-day stock risk
-    - `14` out-of-stock items with recent demand
-    - `330` dead-stock candidates worth `EUR 1866.59` at mapped cost
+    - `410` products with stock
+    - `12347` available units
+    - `EUR 50910.11` inventory cost value
+    - `EUR 183338.35` inventory retail value
+    - `81.28%` unit coverage by mapped costs
+    - `78.48%` retail-value coverage by mapped costs
+    - `32` critical / negative-stock items
+    - `39` items at 30-day stock risk
+    - `43` items at 45-day stock risk
+    - `17` out-of-stock items with recent demand
+    - `10` negative-stock products with `115` units below zero
+    - `328` dead-stock candidates worth `EUR 1866.59` at mapped cost
+    - dead-stock share now surfaces as `3.67%` of mapped inventory cost and `17.08%` of on-hand units
+    - revenue at risk now surfaces as `EUR 18336.52` over the 30-day risk bucket and `EUR 20802.32` over the 45-day bucket
+    - current restock watchlist contains `31` urgent and `7` high-priority products
+    - forecast backtest currently covers `25` products, but the first live sample is still weak (`74.77%` WAPE, `12.00%` within 20% error)
   - rendered HTML now contains the new sections:
     - `Inventory snapshot`
     - `Inventory valuation`
     - `Stock risk watchlist`
     - `Dead stock candidates`
+    - `Revenue at risk`
+    - `Restock priority`
+    - `Inventory turns by family`
+    - `Inventory turns by brand`
+    - `Forecast backtest accuracy`
 - Split Doklady into its own GitHub repository: `Terem21/doklady-saas`.
 - Reporting workflow now treats repositories as product boundaries and branches as short-lived task scopes only.
 - Prepared reporting repo branch cleanup by identifying merged/superseded remote branches versus the still-active reporting branches.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-04-15
+Last updated: 2026-04-16
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -168,19 +168,60 @@ Bootstrap entrypoints:
   - revenue-at-risk rollups
   - inventory turns by brand / family
   - forecast backtest accuracy
+- ROY inventory alert workflow is now wired through the active render/output path on the task branch:
+  - `dashboard_payload.json` now carries actionable `alert_rows`
+  - the modern HTML dashboard now renders a dedicated `Actionable inventory alerts` table
+  - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- Review the live Roy inventory metrics with the business owner and confirm the alert semantics for the now-implemented inventory layer:
-  - which stock-risk thresholds should trigger action (`Critical`, `Low`, `Watch`)
-  - whether alerting should trigger on 30-day risk only or also on the 45-day watch bucket
-  - whether inventory value should be watched at cost only or also at retail
-  - which dead-stock cutoff should be treated as operationally actionable
-- Before automating alerts, tighten the forecast model because current backtest accuracy is weak on the first live sample:
-  - reduce over-forecast bias on volatile SKUs
-  - decide whether alerts should use recent-demand fallback, forecast, or a weighted blend by confidence
-  - then turn the validated logic into explicit low-stock / stockout alert outputs
+- Merge and deploy the `codex/roy-inventory-metrics` branch so the new ROY stock alert section reaches the real scheduled daily email path.
+- After deploy, verify on the production ECS host/run that:
+  - the generated ROY HTML contains `Actionable inventory alerts`
+  - the sent daily email includes the `SKLADOVE ALERTY` block
+- Then implement inbound-stock modeling so reorder alerts stop being purely conservative:
+  - define the source of truth for goods on the way
+  - map inbound quantities to product/SKU
+  - fold inbound stock into `net_available_quantity` and reorder recommendations
 
 ## 9) Change Log
+
+### 2026-04-16
+- Applied the agreed ROY inventory business rules in config:
+  - thresholds confirmed for `Critical <= 14d`, `Low <= 30d`, `Watch <= 45d`, `Dead stock >= 90d`
+  - alert delivery narrowed to the 30-day bucket, 45-day rows kept as watchlist only
+  - primary inventory basis = cost, secondary = retail
+  - restock prioritization switched to margin without fixed overhead
+  - lead times configured by brand:
+    - `maco_stop = 10 wd`
+    - `wachman = 20 wd`
+    - `roy = 50 wd`
+  - alert exclusions configured for service / reklamacie / gifts / spare parts / test / obvious noise
+  - initial bundle-to-component rule added for MACO STOP spray sets
+- Extended ROY inventory analytics runtime with:
+  - actionable `alert_rows`
+  - conservative alert-demand blend by forecast confidence
+  - reorder deadline / reorder quantity / `Order now` vs `Prepare PO`
+  - hero-brand handling for Wachman and MACO STOP
+  - bundle-demand shifting onto component SKUs
+  - explicit inbound-stock placeholder state (`not_modeled`)
+- Wired the new inventory alert outputs into the active report surfaces:
+  - `dashboard_modern.py` renders summary mini-cards plus the new actionable alert table
+  - `daily_report_runner.py` reads `dashboard_payload.json` and appends `SKLADOVE ALERTY` into the outbound email text
+- Verified locally on live ROY data with a one-pass export:
+  - `python -m py_compile export_orders.py dashboard_modern.py daily_report_runner.py`
+  - production-equivalent ROY export for `2025-09-24 -> 2026-04-15` using output tag `inventory_alerts_verify`
+  - generated artifacts:
+    - `data/roy/report_20250924-20260415__inventory_alerts_verify.html`
+    - `data/roy/dashboard_payload_20250924-20260415__inventory_alerts_verify.json`
+  - verification outcome:
+    - `29` actionable 30d alerts
+    - `13` hero-SKU alerts
+    - `29` `Order now`, `0` `Prepare PO`
+    - `EUR 18,001.42` revenue at risk over 30d
+    - `EUR 50,795.03` inventory cost value
+    - `12` excluded noise rows
+    - HTML contains `Actionable inventory alerts`
+    - email summary text contains `SKLADOVE ALERTY`
 
 ### 2026-04-15
 - Added Roy inventory snapshot ingestion from Biznisweb GraphQL product data:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -143,6 +143,11 @@ Bootstrap entrypoints:
 - Product cost coverage QA is now active in source-health and the modern dashboard:
   - VEVO March 2026 export now passes with `0.00%` fallback revenue share after re-importing the April 2026 Excel costs and restoring title-first / alias-aware expense matching
   - ROY March 2026 export is `warning` because fallback coverage still touches 3.20% of item revenue and 6.26% of pre-ad item profit
+- ROY inventory valuation is now live, but cost-value accuracy still depends on explicit product-expense mapping coverage:
+  - live verification on `2026-04-15` reached `94.39%` of on-hand units and `87.81%` of retail-value exposure
+  - unmapped inventory still exists, so cost-value totals must keep surfacing coverage metadata
+- ROY full-history export now performs an extra live product-catalog pagination pass for inventory (`56` pages in the current catalog), so report runtime is materially higher than before the inventory layer
+- Biznisweb inventory can expose negative or zero available quantities on active products; the report now flags those rows explicitly instead of crashing, but replenishment response policy is still an open product decision
 - VEVO now resolves ambiguous shared-EAN fragrance SKUs by exact item label / compound key before identifier fallback, so Natural vs Premium 500ml/200ml lines no longer collapse onto the same cost.
 - ROY now supports project-configured excluded order statuses for realized revenue filtering, so non-revenue final states can be removed without hardcoded edits in `export_orders.py`.
 - ROY dashboard now exposes product-demand analytics in the active modern report:
@@ -152,14 +157,66 @@ Bootstrap entrypoints:
   - product sales forecast from historical data
   - top brands by revenue
   - top brands by profit
+- ROY dashboard now also exposes live Biznisweb inventory analytics in the active modern report:
+  - current on-hand units by product
+  - inventory value at mapped cost
+  - inventory retail value
+  - stock-risk watchlist with projected stockout dates
+  - dead-stock candidates
+  - inventory cost-coverage diagnostics
 
 ## 8) Next Exact Step
-- Review the remaining active reporting branches (`codex/qa-geo-guardrails`, `codex/roy-meta-project-env`) and either open/merge PRs or close them intentionally.
-- Monitor the next production VEVO and ROY daily runner outputs to confirm the new Executive KPI `All-time` toggle is present in the emailed HTML attachments.
+- Review the live Roy inventory metrics with the business owner and confirm alert semantics:
+  - which stock-risk thresholds should trigger action (`Critical`, `Low`, `Watch`)
+  - whether inventory value should be watched at cost only or also at retail
+  - which dead-stock cutoff should be treated as operationally actionable
+- After threshold approval, turn the current Roy inventory snapshot into explicit alerting outputs:
+  - low-stock notifications for products with recent demand
+  - forecasted stockout warning horizon
+  - restock-priority ordering that combines forecast demand, gross margin, and current cover days
 
 ## 9) Change Log
 
 ### 2026-04-15
+- Added Roy inventory snapshot ingestion from Biznisweb GraphQL product data:
+  - live product inventory fetch with warehouse rows, quantities, available quantities, and retail pricing
+  - cost-value mapping reuses the existing product-expense source of truth instead of retail price
+- Extended Roy product-demand analytics with inventory outputs:
+  - inventory valuation rows
+  - stock-risk rows with projected stockout date / days of cover
+  - dead-stock rows
+  - inventory summary KPIs in the dashboard payload
+- Added Roy dashboard rendering for the new inventory layer:
+  - inventory snapshot summary cards
+  - forecast table enriched with on-hand qty, days of cover, projected stockout, and stock-risk level
+  - inventory valuation table
+  - stock-risk watchlist
+  - dead-stock table
+- Added explicit `inventory_model` settings to:
+  - `projects/roy/settings.json`
+  - `templates/reporting-client/settings.template.json`
+- Verified locally with:
+  - `python -m py_compile export_orders.py dashboard_modern.py`
+  - `python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-14 --output-tag inventory_probe`
+- Verification outcome on live Roy data:
+  - Biznisweb inventory snapshot fetch succeeded (`56` pages, `2370` warehouse rows)
+  - full-history Roy dashboard payload now reports:
+    - `1669` tracked products
+    - `417` products with stock
+    - `43101` available units
+    - `EUR 120176.49` inventory cost value
+    - `EUR 343958.90` inventory retail value
+    - `94.39%` unit coverage by mapped costs
+    - `87.81%` retail-value coverage by mapped costs
+    - `29` critical / negative-stock items
+    - `36` items at 30-day stock risk
+    - `14` out-of-stock items with recent demand
+    - `330` dead-stock candidates worth `EUR 1866.59` at mapped cost
+  - rendered HTML now contains the new sections:
+    - `Inventory snapshot`
+    - `Inventory valuation`
+    - `Stock risk watchlist`
+    - `Dead stock candidates`
 - Split Doklady into its own GitHub repository: `Terem21/doklady-saas`.
 - Reporting workflow now treats repositories as product boundaries and branches as short-lived task scopes only.
 - Prepared reporting repo branch cleanup by identifying merged/superseded remote branches versus the still-active reporting branches.

--- a/daily_report_runner.py
+++ b/daily_report_runner.py
@@ -583,6 +583,114 @@ def _comparison_line_optional(label: str, current: Optional[float], previous: Op
     return _comparison_line(label, float(current), float(previous))
 
 
+def _load_dashboard_payload(path: Optional[Path]) -> Dict[str, Any]:
+    if not path or not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _build_roy_inventory_alert_summary(file_paths: Dict[str, Path]) -> str:
+    payload = _load_dashboard_payload(file_paths.get("dashboard_payload_json"))
+    dashboard = payload.get("dashboard") if isinstance(payload.get("dashboard"), dict) else payload
+    if not isinstance(dashboard, dict):
+        return ""
+
+    roy_inventory = dashboard.get("roy_product_demand") or {}
+    if not isinstance(roy_inventory, dict):
+        return ""
+
+    summary = roy_inventory.get("summary") or {}
+    if not isinstance(summary, dict):
+        summary = {}
+    alert_rows = list(roy_inventory.get("alert_rows") or [])
+    if not summary and not alert_rows:
+        return ""
+
+    inventory_status = str(summary.get("inventory_status") or "unavailable").strip().lower()
+    snapshot_date = str(summary.get("inventory_snapshot_date") or "-")
+    horizon_days = max(1, int(float(summary.get("alert_delivery_horizon_days") or 30)))
+    alert_count = int(float(summary.get("alert_delivery_count") or 0))
+    hero_count = int(float(summary.get("alert_delivery_hero_count") or 0))
+    reorder_now_count = int(float(summary.get("alert_reorder_now_count") or 0))
+    prepare_po_count = int(float(summary.get("alert_prepare_po_count") or 0))
+    excluded_count = int(float(summary.get("alert_excluded_count") or 0))
+    lead_time_count = int(float(summary.get("lead_time_configured_alert_count") or 0))
+    bundle_rule_count = int(float(summary.get("bundle_component_rule_count") or 0))
+    bundle_shift_30d = float(summary.get("bundle_component_adjustment_30d_units") or 0.0)
+    bundle_shift_90d = float(summary.get("bundle_component_adjustment_90d_units") or 0.0)
+    inbound_status = str(summary.get("inbound_stock_status") or "not_modeled").replace("_", " ")
+    inbound_source = str(summary.get("inbound_stock_source") or "not_modeled")
+    inventory_cost_value = float(summary.get("inventory_cost_value") or 0.0)
+    revenue_at_risk_30d = float(summary.get("revenue_at_risk_30d") or 0.0)
+    profit_at_risk_30d = float(summary.get("profit_at_risk_30d") or 0.0)
+    risk_45d_count = int(float(summary.get("stock_risk_45d_count") or 0))
+
+    lines = ["SKLADOVE ALERTY"]
+    if inventory_status != "ok":
+        lines.append(
+            f"- Inventory snapshot status: {inventory_status.upper()} (snapshot {snapshot_date})."
+        )
+        if inbound_status != "configured":
+            lines.append(f"- Inbound stock zatial nie je modelovany ({inbound_source}).")
+        return "\n".join(lines)
+
+    lines.extend(
+        [
+            (
+                f"- Snapshot skladu: {snapshot_date}. Akcne {horizon_days}d alerty: {alert_count}, "
+                f"z toho hero SKU {hero_count}. 45d watchlist: {risk_45d_count}."
+            ),
+            (
+                f"- Objednat teraz: {reorder_now_count}; pripravit PO: {prepare_po_count}; "
+                f"lead-time nastavene alerty: {lead_time_count}."
+            ),
+            (
+                f"- Hodnota skladu v nakupnych cenach: {_fmt_eur(inventory_cost_value)}. "
+                f"Trzby v riziku {horizon_days}d: {_fmt_eur(revenue_at_risk_30d)}; "
+                f"zisk v riziku: {_fmt_eur(profit_at_risk_30d)}."
+            ),
+        ]
+    )
+    if excluded_count > 0:
+        lines.append(
+            f"- Z alertov je odfiltrovanych {excluded_count} poloziek (servis/reklamacie/darceky/test SKU a bundle noise)."
+        )
+    if bundle_rule_count > 0:
+        lines.append(
+            f"- Bundle dopyt sa presuva na komponenty cez {bundle_rule_count} pravidla: +{bundle_shift_30d:.1f} ks za 30d a +{bundle_shift_90d:.1f} ks za 90d."
+        )
+    if inbound_status != "configured":
+        lines.append(f"- Inbound stock zatial nie je modelovany ({inbound_source}), takze alerty su konzervativnejsie.")
+
+    top_alerts = alert_rows[:5]
+    if top_alerts:
+        lines.append("- Top alerty na dnes:")
+        for row in top_alerts:
+            product = str(row.get("product") or "Unknown product")
+            risk = str(row.get("stock_risk_level") or "-")
+            available = float(row.get("available_quantity") or 0.0)
+            days_of_cover = float(row.get("days_of_cover") or 0.0)
+            lead_time = int(float(row.get("lead_time_working_days") or 0))
+            reorder_by = str(row.get("reorder_by_date") or "-")
+            reorder_units = int(round(float(row.get("suggested_reorder_units") or 0.0)))
+            action = str(row.get("reorder_action_label") or "-")
+            revenue_risk = float(row.get("alert_30d_revenue") or 0.0)
+            hero_flag = " HERO" if bool(row.get("strategic_stock_flag")) else ""
+            lines.append(
+                f"  - {product}{hero_flag}: {risk}, sklad {available:.1f} ks, cover {days_of_cover:.1f} dna, "
+                f"LT {lead_time} wd, objednat do {reorder_by}, odporucane {reorder_units} ks, akcia {action}, "
+                f"trzba v riziku {_fmt_eur(revenue_risk)}."
+            )
+    else:
+        lines.append("- Dnes nie su ziadne akcne 30-dnove stock alerty.")
+
+    return "\n".join(lines)
+
+
 def build_report_summary(file_paths: Dict[str, Path]) -> str:
     date_csv = file_paths.get("aggregate_by_date_csv")
     if not date_csv or not date_csv.exists():
@@ -782,14 +890,18 @@ def build_report_summary(file_paths: Dict[str, Path]) -> str:
     if w30["cac"] is None:
         context_lines.append("- CAC v casti porovnani moze byt miestami prazdne, ak v danom okne nebolo dost novych zakaznikov.")
 
-    return "\n\n".join([
+    sections = [
         "\n".join(overview_lines),
         "\n".join(good_lines),
         "\n".join(weaker_lines),
         "\n".join(insight_lines),
         "\n".join(action_lines),
         "\n".join(context_lines),
-    ])
+    ]
+    inventory_alert_summary = _build_roy_inventory_alert_summary(file_paths)
+    if inventory_alert_summary:
+        sections.append(inventory_alert_summary)
+    return "\n\n".join(sections)
 
 
 def build_email_body(

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1221,6 +1221,25 @@ def generate_modern_dashboard(
         ],
         limit=12,
     )
+    roy_alert_rows = _frame_rows(
+        (roy_product_demand or {}).get("alert_rows"),
+        [
+            "sku",
+            "product",
+            "strategic_stock_flag",
+            "stock_risk_level",
+            "available_quantity",
+            "alert_30d_units",
+            "days_of_cover",
+            "lead_time_working_days",
+            "reorder_by_date",
+            "suggested_reorder_units",
+            "reorder_action_label",
+            "alert_30d_revenue",
+            "projected_stockout_date",
+        ],
+        limit=12,
+    )
     roy_restock_priority_rows = _frame_rows(
         (roy_product_demand or {}).get("restock_priority_rows"),
         [
@@ -1840,6 +1859,7 @@ def generate_modern_dashboard(
             "inventory_rows": roy_inventory_rows,
             "stock_risk_rows": roy_stock_risk_rows,
             "dead_stock_rows": roy_dead_stock_rows,
+            "alert_rows": roy_alert_rows,
             "restock_priority_rows": roy_restock_priority_rows,
             "revenue_at_risk_rows": roy_revenue_at_risk_rows,
             "brand_turn_rows": roy_brand_turn_rows,
@@ -1914,6 +1934,8 @@ def generate_modern_dashboard(
     roy_inventory_cost_value = _num(roy_product_demand_summary.get("inventory_cost_value"))
     roy_inventory_retail_value = _num(roy_product_demand_summary.get("inventory_retail_value"))
     roy_inventory_available_units = _num(roy_product_demand_summary.get("inventory_available_units"))
+    roy_inventory_primary_value_basis = escape(str(roy_product_demand_summary.get("inventory_primary_value_basis") or "cost").upper())
+    roy_inventory_secondary_value_basis = escape(str(roy_product_demand_summary.get("inventory_secondary_value_basis") or "retail").upper())
     roy_inventory_cost_coverage_units_pct = _num(roy_product_demand_summary.get("inventory_cost_coverage_units_pct"))
     roy_inventory_cost_coverage_retail_pct = _num(roy_product_demand_summary.get("inventory_cost_coverage_retail_pct"))
     roy_stock_risk_critical_count = int(round(_num(roy_product_demand_summary.get("stock_risk_critical_count"))))
@@ -1932,6 +1954,18 @@ def generate_modern_dashboard(
     roy_profit_at_risk_45d = _num(roy_product_demand_summary.get("profit_at_risk_45d"))
     roy_restock_priority_urgent_count = int(round(_num(roy_product_demand_summary.get("restock_priority_urgent_count"))))
     roy_restock_priority_high_count = int(round(_num(roy_product_demand_summary.get("restock_priority_high_count"))))
+    roy_alert_delivery_horizon_days = int(round(_num(roy_product_demand_summary.get("alert_delivery_horizon_days"))))
+    roy_alert_delivery_count = int(round(_num(roy_product_demand_summary.get("alert_delivery_count"))))
+    roy_alert_delivery_hero_count = int(round(_num(roy_product_demand_summary.get("alert_delivery_hero_count"))))
+    roy_alert_reorder_now_count = int(round(_num(roy_product_demand_summary.get("alert_reorder_now_count"))))
+    roy_alert_prepare_po_count = int(round(_num(roy_product_demand_summary.get("alert_prepare_po_count"))))
+    roy_alert_excluded_count = int(round(_num(roy_product_demand_summary.get("alert_excluded_count"))))
+    roy_lead_time_configured_alert_count = int(round(_num(roy_product_demand_summary.get("lead_time_configured_alert_count"))))
+    roy_bundle_component_rule_count = int(round(_num(roy_product_demand_summary.get("bundle_component_rule_count"))))
+    roy_bundle_component_adjustment_30d_units = _num(roy_product_demand_summary.get("bundle_component_adjustment_30d_units"))
+    roy_bundle_component_adjustment_90d_units = _num(roy_product_demand_summary.get("bundle_component_adjustment_90d_units"))
+    roy_inbound_stock_status = escape(str(roy_product_demand_summary.get("inbound_stock_status") or "not_modeled").replace("_", " "))
+    roy_inbound_stock_source = escape(str(roy_product_demand_summary.get("inbound_stock_source") or "not_modeled"))
     roy_forecast_backtest_products = int(round(_num(roy_product_demand_summary.get("forecast_backtest_products"))))
     roy_forecast_backtest_wape_pct = _num(roy_product_demand_summary.get("forecast_backtest_wape_pct"))
     roy_forecast_backtest_median_accuracy_pct = _num(roy_product_demand_summary.get("forecast_backtest_median_accuracy_pct"))
@@ -1943,10 +1977,16 @@ def generate_modern_dashboard(
         roy_inventory_status_note_html = (
             f'<p class="muted-note"><span class="lang-en">Live Biznisweb inventory snapshot from {roy_inventory_snapshot_date}. '
             f'Cost mapping covers {_format_mini_value_html(roy_inventory_cost_coverage_units_pct, kind="percent")} of on-hand units '
-            f'and {_format_mini_value_html(roy_inventory_cost_coverage_retail_pct, kind="percent")} of retail-value exposure.</span>'
+            f'and {_format_mini_value_html(roy_inventory_cost_coverage_retail_pct, kind="percent")} of retail-value exposure. '
+            f'Primary valuation basis: {roy_inventory_primary_value_basis}; secondary: {roy_inventory_secondary_value_basis}. '
+            f'Inbound stock: {roy_inbound_stock_status} ({roy_inbound_stock_source}). '
+            f'Bundle-to-component rules matched: {roy_bundle_component_rule_count}.</span>'
             f'<span class="lang-sk hidden">Live Biznisweb snapshot skladu z {roy_inventory_snapshot_date}. '
             f'Coverage nakupnych cien pokryva {_format_mini_value_html(roy_inventory_cost_coverage_units_pct, kind="percent")} skladovych kusov '
-            f'a {_format_mini_value_html(roy_inventory_cost_coverage_retail_pct, kind="percent")} retail hodnoty skladu.</span></p>'
+            f'a {_format_mini_value_html(roy_inventory_cost_coverage_retail_pct, kind="percent")} retail hodnoty skladu. '
+            f'Primarne ocenenie: {roy_inventory_primary_value_basis}; sekundarne: {roy_inventory_secondary_value_basis}. '
+            f'Inbound sklad: {roy_inbound_stock_status} ({roy_inbound_stock_source}). '
+            f'Bundle pravidla zhodene na komponenty: {roy_bundle_component_rule_count}.</span></p>'
         )
     elif roy_inventory_status == "empty":
         roy_inventory_status_note_html = (
@@ -2082,6 +2122,24 @@ def generate_modern_dashboard(
         )
         for row in roy_dead_stock_rows
     ) or '<tr><td colspan="5"><span class="lang-en">No dead-stock products detected from the current cutoff.</span><span class="lang-sk hidden">Podla aktualneho cut-offu sa nenasiel dead stock.</span></td></tr>'
+    roy_alert_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>{'Hero SKU' if bool(row.get('strategic_stock_flag')) else '-'}</td>"
+            f"<td>{escape(str(row.get('stock_risk_level') or '-'))}</td>"
+            f"<td>{_num(row.get('available_quantity')):.1f}</td>"
+            f"<td>{_num(row.get('alert_30d_units')):.1f}</td>"
+            f"<td>{_num(row.get('days_of_cover')):.1f}</td>"
+            f"<td>{int(round(_num(row.get('lead_time_working_days'))))}</td>"
+            f"<td>{escape(str(row.get('reorder_by_date') or '-'))}</td>"
+            f"<td>{_num(row.get('suggested_reorder_units')):.0f}</td>"
+            f"<td>{escape(str(row.get('reorder_action_label') or '-'))}</td>"
+            f"<td>&euro;{_num(row.get('alert_30d_revenue')):,.2f}</td>"
+            "</tr>"
+        )
+        for row in roy_alert_rows
+    ) or '<tr><td colspan="11"><span class="lang-en">No actionable 30-day stock alerts are active.</span><span class="lang-sk hidden">Momentlane nie su aktivne ziadne akcne 30-dnove skladove alerty.</span></td></tr>'
     roy_restock_priority_rows_html = "".join(
         (
             "<tr>"
@@ -2190,6 +2248,7 @@ def generate_modern_dashboard(
         roy_inventory_rows,
         roy_stock_risk_rows,
         roy_dead_stock_rows,
+        roy_alert_rows,
         roy_restock_priority_rows,
         roy_revenue_at_risk_rows,
         roy_brand_turn_rows,
@@ -2262,6 +2321,9 @@ def generate_modern_dashboard(
                             <div class="mini-card"><small><span class="lang-en">Critical / OOS</span><span class="lang-sk hidden">Kriticke / vypredane</span></small><strong>{roy_stock_risk_critical_count}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">30d risk count</span><span class="lang-sk hidden">Riziko do 30 dni</span></small><strong>{roy_stock_risk_30d_count}</strong><span class="delta neutral"><span class="lang-en">{roy_out_of_stock_recent_demand_count} already out</span><span class="lang-sk hidden">{roy_out_of_stock_recent_demand_count} uz vypredane</span></span></div>
                             <div class="mini-card"><small><span class="lang-en">45d risk count</span><span class="lang-sk hidden">Riziko do 45 dni</span></small><strong>{roy_stock_risk_45d_count}</strong><span class="delta neutral"><span class="lang-en">{roy_negative_stock_count} negative stock</span><span class="lang-sk hidden">{roy_negative_stock_count} negativny sklad</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">Actionable alerts</span><span class="lang-sk hidden">Akcne alerty</span></small><strong>{roy_alert_delivery_count}</strong><span class="delta neutral"><span class="lang-en">{roy_alert_delivery_hero_count} hero SKUs</span><span class="lang-sk hidden">{roy_alert_delivery_hero_count} hero SKU</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">Order now / Prepare PO</span><span class="lang-sk hidden">Objednat teraz / pripravit PO</span></small><strong>{roy_alert_reorder_now_count} / {roy_alert_prepare_po_count}</strong><span class="delta neutral"><span class="lang-en">{roy_lead_time_configured_alert_count} with lead time</span><span class="lang-sk hidden">{roy_lead_time_configured_alert_count} s lead time</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">Excluded alert noise</span><span class="lang-sk hidden">Vyluceny alert noise</span></small><strong>{roy_alert_excluded_count}</strong><span class="delta neutral"><span class="lang-en">{_format_mini_value_html(roy_bundle_component_adjustment_30d_units, kind="number", decimals=1)} bundle units shifted</span><span class="lang-sk hidden">{_format_mini_value_html(roy_bundle_component_adjustment_30d_units, kind="number", decimals=1)} bundle kusov presunutych</span></span></div>
                             <div class="mini-card"><small><span class="lang-en">Revenue at risk 30d</span><span class="lang-sk hidden">Trzby v riziku 30 dni</span></small><strong>{_format_mini_value_html(roy_revenue_at_risk_30d, kind="currency")}</strong><span class="delta neutral">{_format_mini_value_html(roy_profit_at_risk_30d, kind="currency")}</span></div>
                             <div class="mini-card"><small><span class="lang-en">Revenue at risk 45d</span><span class="lang-sk hidden">Trzby v riziku 45 dni</span></small><strong>{_format_mini_value_html(roy_revenue_at_risk_45d, kind="currency")}</strong><span class="delta neutral">{_format_mini_value_html(roy_profit_at_risk_45d, kind="currency")}</span></div>
                             <div class="mini-card"><small><span class="lang-en">Dead stock value</span><span class="lang-sk hidden">Hodnota dead stocku</span></small><strong>{_format_mini_value_html(roy_dead_stock_cost_value, kind="currency")}</strong><span class="delta neutral"><span class="lang-en">{roy_dead_stock_count} products</span><span class="lang-sk hidden">{roy_dead_stock_count} produktov</span></span></div>
@@ -2272,6 +2334,13 @@ def generate_modern_dashboard(
                             <div class="mini-card"><small><span class="lang-en">Backtested SKUs</span><span class="lang-sk hidden">Backtestovane SKU</span></small><strong>{roy_forecast_backtest_products}</strong><span class="delta neutral">{_format_mini_value_html(roy_forecast_backtest_median_accuracy_pct, kind="percent")}</span></div>
                         </div>
                         {roy_inventory_status_note_html}
+                    </div>
+                    <div class="panel table-card" style="margin-top:18px;">
+                        <div class="card-head"><div><h3><span class="lang-en">Actionable inventory alerts</span><span class="lang-sk hidden">Akcne skladove alerty</span></h3><p><span class="lang-en">This is the operational {roy_alert_delivery_horizon_days}-day alert bucket that should drive daily replenishment decisions and morning email alerts.</span><span class="lang-sk hidden">Toto je operativny {roy_alert_delivery_horizon_days}-dnovy alert bucket, ktory ma riadit denny replenishment a ranne emailove upozornenia.</span></p></div></div>
+                        <table>
+                            <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Hero</span><span class="lang-sk hidden">Hero</span></th><th><span class="lang-en">Risk</span><span class="lang-sk hidden">Riziko</span></th><th><span class="lang-en">On hand</span><span class="lang-sk hidden">Na sklade</span></th><th><span class="lang-en">Alert units</span><span class="lang-sk hidden">Alert kusy</span></th><th><span class="lang-en">Days of cover</span><span class="lang-sk hidden">Dni pokrytia</span></th><th><span class="lang-en">Lead time</span><span class="lang-sk hidden">Lead time</span></th><th><span class="lang-en">Reorder by</span><span class="lang-sk hidden">Objednat do</span></th><th><span class="lang-en">Suggested reorder</span><span class="lang-sk hidden">Odporucane doobjednanie</span></th><th><span class="lang-en">Action</span><span class="lang-sk hidden">Akcia</span></th><th><span class="lang-en">Revenue at risk</span><span class="lang-sk hidden">Trzby v riziku</span></th></tr></thead>
+                            <tbody>{roy_alert_rows_html}</tbody>
+                        </table>
                     </div>
                     <div class="grid-2" style="margin-top:18px;">
                         <div class="panel table-card">

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -613,6 +613,13 @@ def generate_modern_dashboard(
     embedded_period_reports: Optional[dict] = None,
 ) -> str:
     raw_title = (report_title or "BizniWeb reporting").strip()
+    project_key = str((source_health or {}).get("project") or "").strip().lower()
+    if not project_key:
+        lowered_title = raw_title.lower()
+        if "roy" in lowered_title:
+            project_key = "roy"
+        elif "vevo" in lowered_title:
+            project_key = "vevo"
     title = escape(raw_title)
     brand_mark = escape((raw_title[:1] or "B").upper())
     series = _series(date_agg)
@@ -1438,6 +1445,10 @@ def generate_modern_dashboard(
         ],
         limit=12,
     )
+    if project_key == "roy":
+        sample_funnel_summary = {}
+        sample_funnel_window_rows = []
+        sample_funnel_entry_rows = []
     refill_cohort_summary = (refill_cohort_analysis or {}).get("summary", {}) if refill_cohort_analysis else {}
     refill_cohort_bucket_rows = _frame_rows(
         (refill_cohort_analysis or {}).get("bucket_rows"),
@@ -2721,6 +2732,38 @@ def generate_modern_dashboard(
         f"<tr><td>{escape(str(row.get('item_name') or '-'))}</td><td>{int(round(_num(row.get('entry_customers'))))}</td><td>{_num(row.get('repeat_30d_pct')):.1f}%</td><td>{_num(row.get('fullsize_any_30d_pct')):.1f}%</td><td>{_num(row.get('fullsize_any_60d_pct')):.1f}%</td><td>{_num(row.get('fullsize_200_60d_pct')):.1f}%</td><td>{_num(row.get('fullsize_500_60d_pct')):.1f}%</td></tr>"
         for row in sample_funnel_entry_rows
     ) or '<tr><td colspan="7"><span class="lang-en">No sample funnel data available.</span><span class="lang-sk hidden">Sample funnel data nie su dostupne.</span></td></tr>'
+    show_sample_funnel = project_key != "roy" and bool(
+        sample_summary or sample_funnel_window_rows or sample_funnel_entry_rows
+    )
+    sample_funnel_section_html = ""
+    if show_sample_funnel:
+        sample_funnel_section_html = f"""
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel chart-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Sample funnel</span><span class="lang-sk hidden">Sample funnel</span></h3><p><span class="lang-en">First-order sample customers tracked into repeat and full-size conversion windows.</span><span class="lang-sk hidden">Zakaznici vstupujuci cez sample v prvej objednavke sledovani do repeat a full-size konverznych okien.</span></p></div></div>
+                            <div class="mini-grid">
+                                <div class="mini-card"><small><span class="lang-en">Entry customers</span><span class="lang-sk hidden">Vstupni zakaznici</span></small><strong>{sample_entry_customers}</strong></div>
+                                <div class="mini-card"><small><span class="lang-en">Repeat 30d</span><span class="lang-sk hidden">Repeat 30 dni</span></small><strong>{_format_mini_value_html(sample_repeat_30d, kind="percent", decimals=1)}</strong></div>
+                                <div class="mini-card"><small><span class="lang-en">Full-size 30d</span><span class="lang-sk hidden">Full-size 30 dni</span></small><strong>{_format_mini_value_html(sample_fullsize_30d, kind="percent", decimals=1)}</strong></div>
+                                <div class="mini-card"><small><span class="lang-en">Full-size 60d</span><span class="lang-sk hidden">Full-size 60 dni</span></small><strong>{_format_mini_value_html(sample_fullsize_60d, kind="percent", decimals=1)}</strong></div>
+                            </div>
+                            <div class="mini-grid" style="margin-top:12px;">
+                                <div class="mini-card"><small><span class="lang-en">Median days to full-size</span><span class="lang-sk hidden">Median dni do full-size</span></small><strong>{(f"{sample_median_days_fullsize:.0f}" if sample_median_days_fullsize is not None else "N/A")}</strong></div>
+                                <div class="mini-card"><small><span class="lang-en">Top entry product</span><span class="lang-sk hidden">Top vstupny produkt</span></small><strong>{sample_top_entry_product}</strong></div>
+                                <div class="mini-card"><small><span class="lang-en">Entry revenue</span><span class="lang-sk hidden">Vstupne trzby</span></small><strong>{_format_mini_value_html(sample_summary.get("entry_revenue"), kind="currency")}</strong></div>
+                                <div class="mini-card"><small><span class="lang-en">Sample first-order share</span><span class="lang-sk hidden">Podiel sample prvej objednavky</span></small><strong>{_format_mini_value_html(sample_summary.get("sample_first_order_share_pct"), kind="percent", decimals=1)}</strong></div>
+                            </div>
+                            <div class="chart-shell"><canvas id="sampleFunnelChart"></canvas></div>
+                        </div>
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Sample entry product quality</span><span class="lang-sk hidden">Kvalita sample vstupnych produktov</span></h3><p><span class="lang-en">Top sample entry products ranked by 30d and 60d conversion into repeat and full-size orders.</span><span class="lang-sk hidden">Top sample vstupne produkty podla 30d a 60d konverzie do repeat a full-size objednavok.</span></p></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Sample</span><span class="lang-sk hidden">Sample</span></th><th><span class="lang-en">Customers</span><span class="lang-sk hidden">Zakaznici</span></th><th><span class="lang-en">Repeat 30d</span><span class="lang-sk hidden">Repeat 30d</span></th><th><span class="lang-en">Full-size 30d</span><span class="lang-sk hidden">Full-size 30d</span></th><th><span class="lang-en">Full-size 60d</span><span class="lang-sk hidden">Full-size 60d</span></th><th>200ml 60d</th><th>500ml 60d</th></tr></thead>
+                                <tbody>{sample_entry_rows_html}</tbody>
+                            </table>
+                        </div>
+                    </div>
+        """
     refill_summary = refill_cohort_summary or {}
     refill_entry_customers = int(round(_num(refill_summary.get("entry_customers"))))
     refill_sample_60d = _maybe_num(refill_summary.get("sample_refill_60d_pct"))
@@ -3346,31 +3389,7 @@ def generate_modern_dashboard(
                             <div class="mini-card"><small><span class="lang-en">Top 10% revenue share</span><span class="lang-sk hidden">Podiel top 10% zakaznikov</span></small><strong>{top_10_share:.1f}%</strong></div>
                         </div>
                     </div>
-                    <div class="grid-2" style="margin-top:18px;">
-                        <div class="panel chart-card">
-                            <div class="card-head"><div><h3><span class="lang-en">Sample funnel</span><span class="lang-sk hidden">Sample funnel</span></h3><p><span class="lang-en">First-order sample customers tracked into repeat and full-size conversion windows.</span><span class="lang-sk hidden">Zakaznici vstupujuci cez sample v prvej objednavke sledovani do repeat a full-size konverznych okien.</span></p></div></div>
-                            <div class="mini-grid">
-                                <div class="mini-card"><small><span class="lang-en">Entry customers</span><span class="lang-sk hidden">Vstupni zakaznici</span></small><strong>{sample_entry_customers}</strong></div>
-                                <div class="mini-card"><small><span class="lang-en">Repeat 30d</span><span class="lang-sk hidden">Repeat 30 dni</span></small><strong>{_format_mini_value_html(sample_repeat_30d, kind="percent", decimals=1)}</strong></div>
-                                <div class="mini-card"><small><span class="lang-en">Full-size 30d</span><span class="lang-sk hidden">Full-size 30 dni</span></small><strong>{_format_mini_value_html(sample_fullsize_30d, kind="percent", decimals=1)}</strong></div>
-                                <div class="mini-card"><small><span class="lang-en">Full-size 60d</span><span class="lang-sk hidden">Full-size 60 dni</span></small><strong>{_format_mini_value_html(sample_fullsize_60d, kind="percent", decimals=1)}</strong></div>
-                            </div>
-                            <div class="mini-grid" style="margin-top:12px;">
-                                <div class="mini-card"><small><span class="lang-en">Median days to full-size</span><span class="lang-sk hidden">Median dni do full-size</span></small><strong>{(f"{sample_median_days_fullsize:.0f}" if sample_median_days_fullsize is not None else "N/A")}</strong></div>
-                                <div class="mini-card"><small><span class="lang-en">Top entry product</span><span class="lang-sk hidden">Top vstupny produkt</span></small><strong>{sample_top_entry_product}</strong></div>
-                                <div class="mini-card"><small><span class="lang-en">Entry revenue</span><span class="lang-sk hidden">Vstupne trzby</span></small><strong>{_format_mini_value_html(sample_summary.get("entry_revenue"), kind="currency")}</strong></div>
-                                <div class="mini-card"><small><span class="lang-en">Sample first-order share</span><span class="lang-sk hidden">Podiel sample prvej objednavky</span></small><strong>{_format_mini_value_html(sample_summary.get("sample_first_order_share_pct"), kind="percent", decimals=1)}</strong></div>
-                            </div>
-                            <div class="chart-shell"><canvas id="sampleFunnelChart"></canvas></div>
-                        </div>
-                        <div class="panel table-card">
-                            <div class="card-head"><div><h3><span class="lang-en">Sample entry product quality</span><span class="lang-sk hidden">Kvalita sample vstupnych produktov</span></h3><p><span class="lang-en">Top sample entry products ranked by 30d and 60d conversion into repeat and full-size orders.</span><span class="lang-sk hidden">Top sample vstupne produkty podla 30d a 60d konverzie do repeat a full-size objednavok.</span></p></div></div>
-                            <table>
-                                <thead><tr><th><span class="lang-en">Sample</span><span class="lang-sk hidden">Sample</span></th><th><span class="lang-en">Customers</span><span class="lang-sk hidden">Zakaznici</span></th><th><span class="lang-en">Repeat 30d</span><span class="lang-sk hidden">Repeat 30d</span></th><th><span class="lang-en">Full-size 30d</span><span class="lang-sk hidden">Full-size 30d</span></th><th><span class="lang-en">Full-size 60d</span><span class="lang-sk hidden">Full-size 60d</span></th><th>200ml 60d</th><th>500ml 60d</th></tr></thead>
-                                <tbody>{sample_entry_rows_html}</tbody>
-                            </table>
-                        </div>
-                    </div>
+                    {sample_funnel_section_html}
                     <div class="grid-2">
                         <div class="panel chart-card">
                             <div class="card-head"><div><h3><span class="lang-en">Refill cohort timing</span><span class="lang-sk hidden">Casovanie refill kohort</span></h3><p><span class="lang-en">Second-order refill speed by first-order entry bucket so refill timing is measured by cohort, not only global repeat rate.</span><span class="lang-sk hidden">Rychlost druhej objednavky podla vstupneho bucketu prvej objednavky, aby sa refill meral kohortne a nie len globalnym repeat rate.</span></p></div></div>

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1155,14 +1155,71 @@ def generate_modern_dashboard(
             "sku",
             "product",
             "recent_30d_revenue",
+            "recent_30d_units",
             "forecast_30d_revenue",
             "forecast_30d_units",
+            "available_quantity",
+            "days_of_cover",
+            "projected_stockout_date",
+            "stock_risk_level",
+            "inventory_cost_value",
+            "inventory_retail_value",
+            "cost_coverage_pct",
             "forecast_delta_pct",
             "confidence",
             "weeks_used",
             "days_since_last_sale",
         ],
         limit=10,
+    )
+    roy_inventory_rows = _frame_rows(
+        (roy_product_demand or {}).get("inventory_rows"),
+        [
+            "sku",
+            "product",
+            "active",
+            "available_quantity",
+            "mapped_available_quantity",
+            "cost_per_unit",
+            "inventory_cost_value",
+            "inventory_retail_value",
+            "cost_coverage_pct",
+            "days_since_last_sale",
+            "days_of_cover",
+            "stock_risk_level",
+        ],
+        limit=12,
+    )
+    roy_stock_risk_rows = _frame_rows(
+        (roy_product_demand or {}).get("stock_risk_rows"),
+        [
+            "sku",
+            "product",
+            "available_quantity",
+            "recent_30d_units",
+            "forecast_30d_units",
+            "alert_30d_units",
+            "days_of_cover",
+            "projected_stockout_date",
+            "stock_risk_level",
+            "forecast_confidence",
+            "inventory_cost_value",
+        ],
+        limit=12,
+    )
+    roy_dead_stock_rows = _frame_rows(
+        (roy_product_demand or {}).get("dead_stock_rows"),
+        [
+            "sku",
+            "product",
+            "active",
+            "available_quantity",
+            "inventory_cost_value",
+            "inventory_retail_value",
+            "days_since_last_sale",
+            "cost_coverage_pct",
+        ],
+        limit=12,
     )
     roy_brand_revenue_rows = _frame_rows(
         (roy_product_demand or {}).get("brand_revenue_rows"),
@@ -1689,6 +1746,9 @@ def generate_modern_dashboard(
             "declining_rows": roy_declining_rows,
             "seasonality_rows": roy_seasonality_rows,
             "forecast_rows": roy_forecast_rows,
+            "inventory_rows": roy_inventory_rows,
+            "stock_risk_rows": roy_stock_risk_rows,
+            "dead_stock_rows": roy_dead_stock_rows,
             "brand_revenue_rows": roy_brand_revenue_rows,
             "brand_profit_rows": roy_brand_profit_rows,
         },
@@ -1755,6 +1815,48 @@ def generate_modern_dashboard(
     payload_json = _json_script_content(payload)
     roy_trend_window_weeks = max(2, int(round(_num(roy_product_demand_summary.get("trend_window_weeks"))))) if roy_product_demand_summary else 4
     roy_forecast_horizon_days = max(1, int(round(_num(roy_product_demand_summary.get("forecast_horizon_days"))))) if roy_product_demand_summary else 30
+    roy_inventory_cost_value = _num(roy_product_demand_summary.get("inventory_cost_value"))
+    roy_inventory_retail_value = _num(roy_product_demand_summary.get("inventory_retail_value"))
+    roy_inventory_available_units = _num(roy_product_demand_summary.get("inventory_available_units"))
+    roy_inventory_cost_coverage_units_pct = _num(roy_product_demand_summary.get("inventory_cost_coverage_units_pct"))
+    roy_inventory_cost_coverage_retail_pct = _num(roy_product_demand_summary.get("inventory_cost_coverage_retail_pct"))
+    roy_stock_risk_critical_count = int(round(_num(roy_product_demand_summary.get("stock_risk_critical_count"))))
+    roy_stock_risk_30d_count = int(round(_num(roy_product_demand_summary.get("stock_risk_30d_count"))))
+    roy_dead_stock_count = int(round(_num(roy_product_demand_summary.get("dead_stock_count"))))
+    roy_dead_stock_cost_value = _num(roy_product_demand_summary.get("dead_stock_cost_value"))
+    roy_out_of_stock_recent_demand_count = int(round(_num(roy_product_demand_summary.get("out_of_stock_recent_demand_count"))))
+    roy_inventory_snapshot_date = escape(str(roy_product_demand_summary.get("inventory_snapshot_date") or "-"))
+    roy_inventory_status = str(roy_product_demand_summary.get("inventory_status") or "unavailable").strip().lower()
+    roy_inventory_fetch_error = escape(str(roy_product_demand_summary.get("inventory_fetch_error") or ""))
+    if roy_inventory_status == "ok":
+        roy_inventory_status_note_html = (
+            f'<p class="muted-note"><span class="lang-en">Live Biznisweb inventory snapshot from {roy_inventory_snapshot_date}. '
+            f'Cost mapping covers {_format_mini_value_html(roy_inventory_cost_coverage_units_pct, kind="percent")} of on-hand units '
+            f'and {_format_mini_value_html(roy_inventory_cost_coverage_retail_pct, kind="percent")} of retail-value exposure.</span>'
+            f'<span class="lang-sk hidden">Live Biznisweb snapshot skladu z {roy_inventory_snapshot_date}. '
+            f'Coverage nakupnych cien pokryva {_format_mini_value_html(roy_inventory_cost_coverage_units_pct, kind="percent")} skladovych kusov '
+            f'a {_format_mini_value_html(roy_inventory_cost_coverage_retail_pct, kind="percent")} retail hodnoty skladu.</span></p>'
+        )
+    elif roy_inventory_status == "empty":
+        roy_inventory_status_note_html = (
+            f'<p class="muted-note"><span class="lang-en">Biznisweb returned an empty inventory snapshot on {roy_inventory_snapshot_date}.</span>'
+            f'<span class="lang-sk hidden">Biznisweb vratil prazdny inventory snapshot k datumu {roy_inventory_snapshot_date}.</span></p>'
+        )
+    elif roy_inventory_status == "error":
+        roy_inventory_status_note_html = (
+            f'<p class="muted-note"><span class="lang-en">Inventory snapshot failed: {roy_inventory_fetch_error or "unknown error"}.</span>'
+            f'<span class="lang-sk hidden">Nacitanie inventory snapshotu zlyhalo: {roy_inventory_fetch_error or "neznamy problem"}.</span></p>'
+        )
+    elif roy_inventory_status == "disabled":
+        roy_inventory_status_note_html = (
+            '<p class="muted-note"><span class="lang-en">Inventory snapshot is disabled in the project settings.</span>'
+            '<span class="lang-sk hidden">Inventory snapshot je vypnuty v project settings.</span></p>'
+        )
+    else:
+        roy_inventory_status_note_html = (
+            '<p class="muted-note"><span class="lang-en">Inventory snapshot is not available for this render.</span>'
+            '<span class="lang-sk hidden">Inventory snapshot pre tento render nie je dostupny.</span></p>'
+        )
 
     product_rows_html = "".join(
         (
@@ -1821,12 +1923,54 @@ def generate_modern_dashboard(
             f"<td>&euro;{_num(row.get('recent_30d_revenue')):,.2f}</td>"
             f"<td>&euro;{_num(row.get('forecast_30d_revenue')):,.2f}</td>"
             f"<td>{_num(row.get('forecast_30d_units')):.1f}</td>"
+            f"<td>{_num(row.get('available_quantity')):.1f}</td>"
+            f"<td>{_num(row.get('days_of_cover')):.1f}</td>"
+            f"<td>{escape(str(row.get('projected_stockout_date') or '-'))}</td>"
+            f"<td>{escape(str(row.get('stock_risk_level') or '-'))}</td>"
             f"<td>{_num(row.get('forecast_delta_pct')):+.1f}%</td>"
             f"<td>{escape(str(row.get('confidence') or '-'))}</td>"
             "</tr>"
         )
         for row in roy_forecast_rows
-    ) or '<tr><td colspan="6"><span class="lang-en">Not enough stable product history for product-level sales forecasting yet.</span><span class="lang-sk hidden">Na forecast predaja na urovni produktu zatial nie je dost stabilnej historie.</span></td></tr>'
+    ) or '<tr><td colspan="10"><span class="lang-en">Not enough stable product history for product-level sales forecasting yet.</span><span class="lang-sk hidden">Na forecast predaja na urovni produktu zatial nie je dost stabilnej historie.</span></td></tr>'
+    roy_inventory_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>{_num(row.get('available_quantity')):.1f}</td>"
+            f"<td>&euro;{_num(row.get('inventory_cost_value')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('inventory_retail_value')):,.2f}</td>"
+            f"<td>{_num(row.get('cost_coverage_pct')):.1f}%</td>"
+            f"<td>{_num(row.get('days_since_last_sale')):.0f}</td>"
+            "</tr>"
+        )
+        for row in roy_inventory_rows
+    ) or '<tr><td colspan="6"><span class="lang-en">No inventory valuation rows available.</span><span class="lang-sk hidden">Ocenenie skladu zatial nie je dostupne.</span></td></tr>'
+    roy_stock_risk_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>{_num(row.get('available_quantity')):.1f}</td>"
+            f"<td>{_num(row.get('alert_30d_units')):.1f}</td>"
+            f"<td>{_num(row.get('days_of_cover')):.1f}</td>"
+            f"<td>{escape(str(row.get('projected_stockout_date') or '-'))}</td>"
+            f"<td>{escape(str(row.get('stock_risk_level') or '-'))}</td>"
+            "</tr>"
+        )
+        for row in roy_stock_risk_rows
+    ) or '<tr><td colspan="6"><span class="lang-en">No immediate stock-risk products detected from recent demand.</span><span class="lang-sk hidden">Na zaklade posledneho dopytu zatial nevidno bezprostredne rizikove skladove pozicie.</span></td></tr>'
+    roy_dead_stock_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>{_num(row.get('available_quantity')):.1f}</td>"
+            f"<td>&euro;{_num(row.get('inventory_cost_value')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('inventory_retail_value')):,.2f}</td>"
+            f"<td>{_num(row.get('days_since_last_sale')):.0f}</td>"
+            "</tr>"
+        )
+        for row in roy_dead_stock_rows
+    ) or '<tr><td colspan="5"><span class="lang-en">No dead-stock products detected from the current cutoff.</span><span class="lang-sk hidden">Podla aktualneho cut-offu sa nenasiel dead stock.</span></td></tr>'
     roy_brand_revenue_rows_html = "".join(
         (
             "<tr>"
@@ -1854,7 +1998,17 @@ def generate_modern_dashboard(
         for row in roy_brand_profit_rows
     ) or '<tr><td colspan="6"><span class="lang-en">No brand profit data available.</span><span class="lang-sk hidden">Data o ziskovosti znaciek nie su dostupne.</span></td></tr>'
     roy_product_demand_section_html = ""
-    if any([roy_growing_rows, roy_declining_rows, roy_seasonality_rows, roy_forecast_rows, roy_brand_revenue_rows, roy_brand_profit_rows]):
+    if any([
+        roy_growing_rows,
+        roy_declining_rows,
+        roy_seasonality_rows,
+        roy_forecast_rows,
+        roy_inventory_rows,
+        roy_stock_risk_rows,
+        roy_dead_stock_rows,
+        roy_brand_revenue_rows,
+        roy_brand_profit_rows,
+    ]):
         roy_product_demand_section_html = f"""
                     <div class="grid-2" style="margin-top:18px;">
                         <div class="panel chart-card">
@@ -1903,10 +2057,47 @@ def generate_modern_dashboard(
                         <div class="panel table-card">
                             <div class="card-head"><div><h3><span class="lang-en">Forecast table</span><span class="lang-sk hidden">Tabulka forecastu</span></h3></div></div>
                             <table>
-                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Recent 30d revenue</span><span class="lang-sk hidden">Trzby poslednych 30 dni</span></th><th><span class="lang-en">Forecast {roy_forecast_horizon_days}d</span><span class="lang-sk hidden">Forecast {roy_forecast_horizon_days}d</span></th><th><span class="lang-en">Forecast units</span><span class="lang-sk hidden">Forecast kusov</span></th><th><span class="lang-en">Delta</span><span class="lang-sk hidden">Delta</span></th><th><span class="lang-en">Confidence</span><span class="lang-sk hidden">Istota</span></th></tr></thead>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Recent 30d revenue</span><span class="lang-sk hidden">Trzby poslednych 30 dni</span></th><th><span class="lang-en">Forecast {roy_forecast_horizon_days}d</span><span class="lang-sk hidden">Forecast {roy_forecast_horizon_days}d</span></th><th><span class="lang-en">Forecast units</span><span class="lang-sk hidden">Forecast kusov</span></th><th><span class="lang-en">On hand</span><span class="lang-sk hidden">Na sklade</span></th><th><span class="lang-en">Days of cover</span><span class="lang-sk hidden">Dni pokrytia</span></th><th><span class="lang-en">Projected stockout</span><span class="lang-sk hidden">Odhad vypredania</span></th><th><span class="lang-en">Stock risk</span><span class="lang-sk hidden">Skladove riziko</span></th><th><span class="lang-en">Delta</span><span class="lang-sk hidden">Delta</span></th><th><span class="lang-en">Confidence</span><span class="lang-sk hidden">Istota</span></th></tr></thead>
                                 <tbody>{roy_forecast_rows_html}</tbody>
                             </table>
                         </div>
+                    </div>
+                    <div class="panel table-card" style="margin-top:18px;">
+                        <div class="card-head"><div><h3><span class="lang-en">Inventory snapshot</span><span class="lang-sk hidden">Skladovy snapshot</span></h3><p><span class="lang-en">Live Biznisweb stock position joined with Roy product demand and cost mapping.</span><span class="lang-sk hidden">Live Biznisweb stav skladu prepojeny s Roy product demand a cost mappingom.</span></p></div></div>
+                        <div class="mini-grid">
+                            <div class="mini-card"><small><span class="lang-en">Inventory cost value</span><span class="lang-sk hidden">Hodnota skladu v nakupnych cenach</span></small><strong>{_format_mini_value_html(roy_inventory_cost_value, kind="currency")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Inventory retail value</span><span class="lang-sk hidden">Retail hodnota skladu</span></small><strong>{_format_mini_value_html(roy_inventory_retail_value, kind="currency")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Available units</span><span class="lang-sk hidden">Dostupne kusy</span></small><strong>{_format_mini_value_html(roy_inventory_available_units, kind="number", decimals=0)}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Cost coverage units</span><span class="lang-sk hidden">Coverage nakupnych cien kusy</span></small><strong>{_format_mini_value_html(roy_inventory_cost_coverage_units_pct, kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Cost coverage retail</span><span class="lang-sk hidden">Coverage nakupnych cien retail</span></small><strong>{_format_mini_value_html(roy_inventory_cost_coverage_retail_pct, kind="percent")}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">Critical / OOS</span><span class="lang-sk hidden">Kriticke / vypredane</span></small><strong>{roy_stock_risk_critical_count}</strong></div>
+                            <div class="mini-card"><small><span class="lang-en">30d risk count</span><span class="lang-sk hidden">Riziko do 30 dni</span></small><strong>{roy_stock_risk_30d_count}</strong><span class="delta neutral"><span class="lang-en">{roy_out_of_stock_recent_demand_count} already out</span><span class="lang-sk hidden">{roy_out_of_stock_recent_demand_count} uz vypredane</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">Dead stock value</span><span class="lang-sk hidden">Hodnota dead stocku</span></small><strong>{_format_mini_value_html(roy_dead_stock_cost_value, kind="currency")}</strong><span class="delta neutral"><span class="lang-en">{roy_dead_stock_count} products</span><span class="lang-sk hidden">{roy_dead_stock_count} produktov</span></span></div>
+                        </div>
+                        {roy_inventory_status_note_html}
+                    </div>
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Inventory valuation</span><span class="lang-sk hidden">Ocenenie skladu</span></h3><p><span class="lang-en">Largest on-hand positions ranked by mapped cost value.</span><span class="lang-sk hidden">Najvacsie skladove pozicie zoradene podla hodnoty v mapovanych nakupnych cenach.</span></p></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Available qty</span><span class="lang-sk hidden">Dostupne kusy</span></th><th><span class="lang-en">Cost value</span><span class="lang-sk hidden">Hodnota v nakupnych cenach</span></th><th><span class="lang-en">Retail value</span><span class="lang-sk hidden">Retail hodnota</span></th><th><span class="lang-en">Coverage</span><span class="lang-sk hidden">Coverage</span></th><th><span class="lang-en">Days since sale</span><span class="lang-sk hidden">Dni od predaja</span></th></tr></thead>
+                                <tbody>{roy_inventory_rows_html}</tbody>
+                            </table>
+                        </div>
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Stock risk watchlist</span><span class="lang-sk hidden">Watchlist skladoveho rizika</span></h3><p><span class="lang-en">Products likely to run out first based on recent demand and the current forecast.</span><span class="lang-sk hidden">Produkty, ktore sa maju sancu minut ako prve podla posledneho dopytu a aktualneho forecastu.</span></p></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">On hand</span><span class="lang-sk hidden">Na sklade</span></th><th><span class="lang-en">30d alert units</span><span class="lang-sk hidden">Alert 30d kusy</span></th><th><span class="lang-en">Days of cover</span><span class="lang-sk hidden">Dni pokrytia</span></th><th><span class="lang-en">Projected stockout</span><span class="lang-sk hidden">Odhad vypredania</span></th><th><span class="lang-en">Risk</span><span class="lang-sk hidden">Riziko</span></th></tr></thead>
+                                <tbody>{roy_stock_risk_rows_html}</tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="panel table-card" style="margin-top:18px;">
+                        <div class="card-head"><div><h3><span class="lang-en">Dead stock candidates</span><span class="lang-sk hidden">Kandidati na dead stock</span></h3><p><span class="lang-en">Products with stock still on hand but no recent demand signal inside the configured cutoff.</span><span class="lang-sk hidden">Produkty, ktore este maju sklad, ale v nastavenom cut-offe uz nemaju zmysluplny dopyt.</span></p></div></div>
+                        <table>
+                            <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Available qty</span><span class="lang-sk hidden">Dostupne kusy</span></th><th><span class="lang-en">Cost value</span><span class="lang-sk hidden">Hodnota v nakupnych cenach</span></th><th><span class="lang-en">Retail value</span><span class="lang-sk hidden">Retail hodnota</span></th><th><span class="lang-en">Days since sale</span><span class="lang-sk hidden">Dni od predaja</span></th></tr></thead>
+                            <tbody>{roy_dead_stock_rows_html}</tbody>
+                        </table>
                     </div>
                     <div class="grid-2" style="margin-top:18px;">
                         <div class="panel table-card">

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1221,6 +1221,97 @@ def generate_modern_dashboard(
         ],
         limit=12,
     )
+    roy_restock_priority_rows = _frame_rows(
+        (roy_product_demand or {}).get("restock_priority_rows"),
+        [
+            "sku",
+            "product",
+            "restock_priority_score",
+            "restock_priority_bucket",
+            "stock_risk_level",
+            "available_quantity",
+            "alert_30d_units",
+            "days_of_cover",
+            "alert_30d_revenue",
+            "recent_margin_with_fixed_pct",
+            "projected_stockout_date",
+            "cost_coverage_pct",
+        ],
+        limit=12,
+    )
+    roy_revenue_at_risk_rows = _frame_rows(
+        (roy_product_demand or {}).get("revenue_at_risk_rows"),
+        [
+            "sku",
+            "product",
+            "stock_risk_level",
+            "available_quantity",
+            "alert_30d_units",
+            "alert_30d_revenue",
+            "alert_30d_profit_estimate",
+            "days_of_cover",
+            "projected_stockout_date",
+        ],
+        limit=12,
+    )
+    roy_brand_turn_rows = _frame_rows(
+        (roy_product_demand or {}).get("brand_turn_rows"),
+        [
+            "group_key",
+            "group_label",
+            "products",
+            "products_with_stock",
+            "available_quantity",
+            "inventory_cost_value",
+            "inventory_retail_value",
+            "recent_90d_revenue",
+            "inventory_turns_annualized",
+            "days_in_inventory_estimate",
+            "dead_stock_share_pct",
+            "risk_30d_count",
+            "critical_count",
+        ],
+        limit=12,
+    )
+    roy_family_turn_rows = _frame_rows(
+        (roy_product_demand or {}).get("family_turn_rows"),
+        [
+            "group_key",
+            "group_label",
+            "products",
+            "products_with_stock",
+            "available_quantity",
+            "inventory_cost_value",
+            "inventory_retail_value",
+            "recent_90d_revenue",
+            "inventory_turns_annualized",
+            "days_in_inventory_estimate",
+            "dead_stock_share_pct",
+            "risk_30d_count",
+            "critical_count",
+        ],
+        limit=12,
+    )
+    roy_forecast_accuracy_rows = _frame_rows(
+        (roy_product_demand or {}).get("forecast_accuracy_rows"),
+        [
+            "sku",
+            "product",
+            "backtest_window_start",
+            "backtest_window_end",
+            "actual_30d_revenue",
+            "forecast_30d_revenue",
+            "actual_30d_units",
+            "forecast_30d_units",
+            "revenue_error_abs_pct",
+            "units_error_abs_pct",
+            "revenue_accuracy_pct",
+            "bias_label",
+            "confidence",
+            "weeks_used",
+        ],
+        limit=12,
+    )
     roy_brand_revenue_rows = _frame_rows(
         (roy_product_demand or {}).get("brand_revenue_rows"),
         [
@@ -1749,6 +1840,11 @@ def generate_modern_dashboard(
             "inventory_rows": roy_inventory_rows,
             "stock_risk_rows": roy_stock_risk_rows,
             "dead_stock_rows": roy_dead_stock_rows,
+            "restock_priority_rows": roy_restock_priority_rows,
+            "revenue_at_risk_rows": roy_revenue_at_risk_rows,
+            "brand_turn_rows": roy_brand_turn_rows,
+            "family_turn_rows": roy_family_turn_rows,
+            "forecast_accuracy_rows": roy_forecast_accuracy_rows,
             "brand_revenue_rows": roy_brand_revenue_rows,
             "brand_profit_rows": roy_brand_profit_rows,
         },
@@ -1822,9 +1918,24 @@ def generate_modern_dashboard(
     roy_inventory_cost_coverage_retail_pct = _num(roy_product_demand_summary.get("inventory_cost_coverage_retail_pct"))
     roy_stock_risk_critical_count = int(round(_num(roy_product_demand_summary.get("stock_risk_critical_count"))))
     roy_stock_risk_30d_count = int(round(_num(roy_product_demand_summary.get("stock_risk_30d_count"))))
+    roy_stock_risk_45d_count = int(round(_num(roy_product_demand_summary.get("stock_risk_45d_count"))))
+    roy_negative_stock_count = int(round(_num(roy_product_demand_summary.get("negative_stock_count"))))
+    roy_negative_stock_units_gap = _num(roy_product_demand_summary.get("negative_stock_units_gap"))
     roy_dead_stock_count = int(round(_num(roy_product_demand_summary.get("dead_stock_count"))))
     roy_dead_stock_cost_value = _num(roy_product_demand_summary.get("dead_stock_cost_value"))
+    roy_dead_stock_cost_share_pct = _num(roy_product_demand_summary.get("dead_stock_cost_share_pct"))
+    roy_dead_stock_units_share_pct = _num(roy_product_demand_summary.get("dead_stock_units_share_pct"))
     roy_out_of_stock_recent_demand_count = int(round(_num(roy_product_demand_summary.get("out_of_stock_recent_demand_count"))))
+    roy_revenue_at_risk_30d = _num(roy_product_demand_summary.get("revenue_at_risk_30d"))
+    roy_profit_at_risk_30d = _num(roy_product_demand_summary.get("profit_at_risk_30d"))
+    roy_revenue_at_risk_45d = _num(roy_product_demand_summary.get("revenue_at_risk_45d"))
+    roy_profit_at_risk_45d = _num(roy_product_demand_summary.get("profit_at_risk_45d"))
+    roy_restock_priority_urgent_count = int(round(_num(roy_product_demand_summary.get("restock_priority_urgent_count"))))
+    roy_restock_priority_high_count = int(round(_num(roy_product_demand_summary.get("restock_priority_high_count"))))
+    roy_forecast_backtest_products = int(round(_num(roy_product_demand_summary.get("forecast_backtest_products"))))
+    roy_forecast_backtest_wape_pct = _num(roy_product_demand_summary.get("forecast_backtest_wape_pct"))
+    roy_forecast_backtest_median_accuracy_pct = _num(roy_product_demand_summary.get("forecast_backtest_median_accuracy_pct"))
+    roy_forecast_backtest_within_20_pct = _num(roy_product_demand_summary.get("forecast_backtest_within_20_pct"))
     roy_inventory_snapshot_date = escape(str(roy_product_demand_summary.get("inventory_snapshot_date") or "-"))
     roy_inventory_status = str(roy_product_demand_summary.get("inventory_status") or "unavailable").strip().lower()
     roy_inventory_fetch_error = escape(str(roy_product_demand_summary.get("inventory_fetch_error") or ""))
@@ -1971,6 +2082,79 @@ def generate_modern_dashboard(
         )
         for row in roy_dead_stock_rows
     ) or '<tr><td colspan="5"><span class="lang-en">No dead-stock products detected from the current cutoff.</span><span class="lang-sk hidden">Podla aktualneho cut-offu sa nenasiel dead stock.</span></td></tr>'
+    roy_restock_priority_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>{_num(row.get('restock_priority_score')):.1f}</td>"
+            f"<td>{escape(str(row.get('restock_priority_bucket') or '-'))}</td>"
+            f"<td>{escape(str(row.get('stock_risk_level') or '-'))}</td>"
+            f"<td>{_num(row.get('available_quantity')):.1f}</td>"
+            f"<td>{_num(row.get('alert_30d_units')):.1f}</td>"
+            f"<td>{_num(row.get('days_of_cover')):.1f}</td>"
+            f"<td>&euro;{_num(row.get('alert_30d_revenue')):,.2f}</td>"
+            "</tr>"
+        )
+        for row in roy_restock_priority_rows
+    ) or '<tr><td colspan="8"><span class="lang-en">No restock-priority rows available yet.</span><span class="lang-sk hidden">Restock priority riadky zatial nie su dostupne.</span></td></tr>'
+    roy_revenue_at_risk_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>{escape(str(row.get('stock_risk_level') or '-'))}</td>"
+            f"<td>{_num(row.get('available_quantity')):.1f}</td>"
+            f"<td>{_num(row.get('alert_30d_units')):.1f}</td>"
+            f"<td>&euro;{_num(row.get('alert_30d_revenue')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('alert_30d_profit_estimate')):,.2f}</td>"
+            f"<td>{escape(str(row.get('projected_stockout_date') or '-'))}</td>"
+            "</tr>"
+        )
+        for row in roy_revenue_at_risk_rows
+    ) or '<tr><td colspan="7"><span class="lang-en">No revenue-at-risk rows available.</span><span class="lang-sk hidden">Riadky revenue at risk nie su dostupne.</span></td></tr>'
+    roy_brand_turn_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('group_label') or 'Unknown'))}</td>"
+            f"<td>{int(round(_num(row.get('products_with_stock'))))}</td>"
+            f"<td>&euro;{_num(row.get('inventory_cost_value')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('recent_90d_revenue')):,.2f}</td>"
+            f"<td>{_num(row.get('inventory_turns_annualized')):.2f}x</td>"
+            f"<td>{_num(row.get('days_in_inventory_estimate')):.0f}</td>"
+            f"<td>{_num(row.get('dead_stock_share_pct')):.1f}%</td>"
+            f"<td>{int(round(_num(row.get('risk_30d_count'))))}</td>"
+            "</tr>"
+        )
+        for row in roy_brand_turn_rows
+    ) or '<tr><td colspan="8"><span class="lang-en">No brand inventory-turn rows available.</span><span class="lang-sk hidden">Brand inventory turns zatial nie su dostupne.</span></td></tr>'
+    roy_family_turn_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('group_label') or 'Unknown'))}</td>"
+            f"<td>{int(round(_num(row.get('products_with_stock'))))}</td>"
+            f"<td>&euro;{_num(row.get('inventory_cost_value')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('recent_90d_revenue')):,.2f}</td>"
+            f"<td>{_num(row.get('inventory_turns_annualized')):.2f}x</td>"
+            f"<td>{_num(row.get('days_in_inventory_estimate')):.0f}</td>"
+            f"<td>{_num(row.get('dead_stock_share_pct')):.1f}%</td>"
+            f"<td>{int(round(_num(row.get('risk_30d_count'))))}</td>"
+            "</tr>"
+        )
+        for row in roy_family_turn_rows
+    ) or '<tr><td colspan="8"><span class="lang-en">No family inventory-turn rows available.</span><span class="lang-sk hidden">Family inventory turns zatial nie su dostupne.</span></td></tr>'
+    roy_forecast_accuracy_rows_html = "".join(
+        (
+            "<tr>"
+            f"<td>{escape(str(row.get('product') or 'Unknown'))}</td>"
+            f"<td>{escape(str(row.get('backtest_window_start') or '-'))} - {escape(str(row.get('backtest_window_end') or '-'))}</td>"
+            f"<td>&euro;{_num(row.get('actual_30d_revenue')):,.2f}</td>"
+            f"<td>&euro;{_num(row.get('forecast_30d_revenue')):,.2f}</td>"
+            f"<td>{_num(row.get('revenue_error_abs_pct')):.1f}%</td>"
+            f"<td>{_num(row.get('revenue_accuracy_pct')):.1f}%</td>"
+            f"<td>{escape(str(row.get('bias_label') or '-'))}</td>"
+            "</tr>"
+        )
+        for row in roy_forecast_accuracy_rows
+    ) or '<tr><td colspan="7"><span class="lang-en">Forecast backtest rows are not available yet.</span><span class="lang-sk hidden">Forecast backtest riadky zatial nie su dostupne.</span></td></tr>'
     roy_brand_revenue_rows_html = "".join(
         (
             "<tr>"
@@ -2006,6 +2190,11 @@ def generate_modern_dashboard(
         roy_inventory_rows,
         roy_stock_risk_rows,
         roy_dead_stock_rows,
+        roy_restock_priority_rows,
+        roy_revenue_at_risk_rows,
+        roy_brand_turn_rows,
+        roy_family_turn_rows,
+        roy_forecast_accuracy_rows,
         roy_brand_revenue_rows,
         roy_brand_profit_rows,
     ]):
@@ -2072,7 +2261,15 @@ def generate_modern_dashboard(
                             <div class="mini-card"><small><span class="lang-en">Cost coverage retail</span><span class="lang-sk hidden">Coverage nakupnych cien retail</span></small><strong>{_format_mini_value_html(roy_inventory_cost_coverage_retail_pct, kind="percent")}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">Critical / OOS</span><span class="lang-sk hidden">Kriticke / vypredane</span></small><strong>{roy_stock_risk_critical_count}</strong></div>
                             <div class="mini-card"><small><span class="lang-en">30d risk count</span><span class="lang-sk hidden">Riziko do 30 dni</span></small><strong>{roy_stock_risk_30d_count}</strong><span class="delta neutral"><span class="lang-en">{roy_out_of_stock_recent_demand_count} already out</span><span class="lang-sk hidden">{roy_out_of_stock_recent_demand_count} uz vypredane</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">45d risk count</span><span class="lang-sk hidden">Riziko do 45 dni</span></small><strong>{roy_stock_risk_45d_count}</strong><span class="delta neutral"><span class="lang-en">{roy_negative_stock_count} negative stock</span><span class="lang-sk hidden">{roy_negative_stock_count} negativny sklad</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">Revenue at risk 30d</span><span class="lang-sk hidden">Trzby v riziku 30 dni</span></small><strong>{_format_mini_value_html(roy_revenue_at_risk_30d, kind="currency")}</strong><span class="delta neutral">{_format_mini_value_html(roy_profit_at_risk_30d, kind="currency")}</span></div>
+                            <div class="mini-card"><small><span class="lang-en">Revenue at risk 45d</span><span class="lang-sk hidden">Trzby v riziku 45 dni</span></small><strong>{_format_mini_value_html(roy_revenue_at_risk_45d, kind="currency")}</strong><span class="delta neutral">{_format_mini_value_html(roy_profit_at_risk_45d, kind="currency")}</span></div>
                             <div class="mini-card"><small><span class="lang-en">Dead stock value</span><span class="lang-sk hidden">Hodnota dead stocku</span></small><strong>{_format_mini_value_html(roy_dead_stock_cost_value, kind="currency")}</strong><span class="delta neutral"><span class="lang-en">{roy_dead_stock_count} products</span><span class="lang-sk hidden">{roy_dead_stock_count} produktov</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">Dead stock share</span><span class="lang-sk hidden">Podiel dead stocku</span></small><strong>{_format_mini_value_html(roy_dead_stock_cost_share_pct, kind="percent")}</strong><span class="delta neutral">{_format_mini_value_html(roy_dead_stock_units_share_pct, kind="percent")}</span></div>
+                            <div class="mini-card"><small><span class="lang-en">Negative stock gap</span><span class="lang-sk hidden">Gap negativneho skladu</span></small><strong>{_format_mini_value_html(roy_negative_stock_units_gap, kind="number", decimals=1)}</strong><span class="delta neutral"><span class="lang-en">units below zero</span><span class="lang-sk hidden">kusov pod nulou</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">Restock urgent / high</span><span class="lang-sk hidden">Restock urgent / high</span></small><strong>{roy_restock_priority_urgent_count} / {roy_restock_priority_high_count}</strong><span class="delta neutral"><span class="lang-en">scored watchlist</span><span class="lang-sk hidden">scored watchlist</span></span></div>
+                            <div class="mini-card"><small><span class="lang-en">Forecast WAPE</span><span class="lang-sk hidden">Forecast WAPE</span></small><strong>{_format_mini_value_html(roy_forecast_backtest_wape_pct, kind="percent")}</strong><span class="delta neutral">{_format_mini_value_html(roy_forecast_backtest_within_20_pct, kind="percent")}</span></div>
+                            <div class="mini-card"><small><span class="lang-en">Backtested SKUs</span><span class="lang-sk hidden">Backtestovane SKU</span></small><strong>{roy_forecast_backtest_products}</strong><span class="delta neutral">{_format_mini_value_html(roy_forecast_backtest_median_accuracy_pct, kind="percent")}</span></div>
                         </div>
                         {roy_inventory_status_note_html}
                     </div>
@@ -2097,6 +2294,45 @@ def generate_modern_dashboard(
                         <table>
                             <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Available qty</span><span class="lang-sk hidden">Dostupne kusy</span></th><th><span class="lang-en">Cost value</span><span class="lang-sk hidden">Hodnota v nakupnych cenach</span></th><th><span class="lang-en">Retail value</span><span class="lang-sk hidden">Retail hodnota</span></th><th><span class="lang-en">Days since sale</span><span class="lang-sk hidden">Dni od predaja</span></th></tr></thead>
                             <tbody>{roy_dead_stock_rows_html}</tbody>
+                        </table>
+                    </div>
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Revenue at risk</span><span class="lang-sk hidden">Trzby v riziku</span></h3><p><span class="lang-en">Expected next-30-day revenue and profit exposure on products already inside the 45-day stock-risk bucket.</span><span class="lang-sk hidden">Odhad dalsej 30-dnovej trzby a zisku na produktoch, ktore uz spadli do 45-dnoveho stock-risk bucketu.</span></p></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Risk</span><span class="lang-sk hidden">Riziko</span></th><th><span class="lang-en">On hand</span><span class="lang-sk hidden">Na sklade</span></th><th><span class="lang-en">Alert units</span><span class="lang-sk hidden">Alert kusy</span></th><th><span class="lang-en">Revenue at risk</span><span class="lang-sk hidden">Trzby v riziku</span></th><th><span class="lang-en">Profit at risk</span><span class="lang-sk hidden">Zisk v riziku</span></th><th><span class="lang-en">Projected stockout</span><span class="lang-sk hidden">Odhad vypredania</span></th></tr></thead>
+                                <tbody>{roy_revenue_at_risk_rows_html}</tbody>
+                            </table>
+                        </div>
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Restock priority</span><span class="lang-sk hidden">Restock priorita</span></h3><p><span class="lang-en">Priority score combines cover scarcity, expected demand and recent margin quality.</span><span class="lang-sk hidden">Prioritne score kombinuje nedostatok coveru, ocakavany dopyt a kvalitu nedavnej marze.</span></p></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Score</span><span class="lang-sk hidden">Score</span></th><th><span class="lang-en">Bucket</span><span class="lang-sk hidden">Bucket</span></th><th><span class="lang-en">Risk</span><span class="lang-sk hidden">Riziko</span></th><th><span class="lang-en">On hand</span><span class="lang-sk hidden">Na sklade</span></th><th><span class="lang-en">Alert units</span><span class="lang-sk hidden">Alert kusy</span></th><th><span class="lang-en">Days of cover</span><span class="lang-sk hidden">Dni pokrytia</span></th><th><span class="lang-en">Revenue at risk</span><span class="lang-sk hidden">Trzby v riziku</span></th></tr></thead>
+                                <tbody>{roy_restock_priority_rows_html}</tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="grid-2" style="margin-top:18px;">
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Inventory turns by family</span><span class="lang-sk hidden">Inventory turns podla family</span></h3><p><span class="lang-en">Run-rate estimate from recent 90d sell-through against current inventory cost.</span><span class="lang-sk hidden">Run-rate odhad z posledneho 90d sell-through oproti aktualnej hodnote skladu v nakupnych cenach.</span></p></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Family</span><span class="lang-sk hidden">Family</span></th><th><span class="lang-en">Products</span><span class="lang-sk hidden">Produkty</span></th><th><span class="lang-en">Inventory cost</span><span class="lang-sk hidden">Hodnota skladu</span></th><th><span class="lang-en">Recent 90d rev.</span><span class="lang-sk hidden">Poslednych 90d trzby</span></th><th><span class="lang-en">Turns</span><span class="lang-sk hidden">Turns</span></th><th><span class="lang-en">Days in inventory</span><span class="lang-sk hidden">Dni v sklade</span></th><th><span class="lang-en">Dead-stock share</span><span class="lang-sk hidden">Podiel dead stocku</span></th><th><span class="lang-en">30d risks</span><span class="lang-sk hidden">30d rizika</span></th></tr></thead>
+                                <tbody>{roy_family_turn_rows_html}</tbody>
+                            </table>
+                        </div>
+                        <div class="panel table-card">
+                            <div class="card-head"><div><h3><span class="lang-en">Inventory turns by brand</span><span class="lang-sk hidden">Inventory turns podla znacky</span></h3><p><span class="lang-en">Shows where capital is sitting versus where the current run-rate is rotating fastest.</span><span class="lang-sk hidden">Ukazuje, kde stoji kapital oproti tomu, kde sa aktualny run-rate otaca najrychlejsie.</span></p></div></div>
+                            <table>
+                                <thead><tr><th><span class="lang-en">Brand</span><span class="lang-sk hidden">Znacka</span></th><th><span class="lang-en">Products</span><span class="lang-sk hidden">Produkty</span></th><th><span class="lang-en">Inventory cost</span><span class="lang-sk hidden">Hodnota skladu</span></th><th><span class="lang-en">Recent 90d rev.</span><span class="lang-sk hidden">Poslednych 90d trzby</span></th><th><span class="lang-en">Turns</span><span class="lang-sk hidden">Turns</span></th><th><span class="lang-en">Days in inventory</span><span class="lang-sk hidden">Dni v sklade</span></th><th><span class="lang-en">Dead-stock share</span><span class="lang-sk hidden">Podiel dead stocku</span></th><th><span class="lang-en">30d risks</span><span class="lang-sk hidden">30d rizika</span></th></tr></thead>
+                                <tbody>{roy_brand_turn_rows_html}</tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="panel table-card" style="margin-top:18px;">
+                        <div class="card-head"><div><h3><span class="lang-en">Forecast backtest accuracy</span><span class="lang-sk hidden">Presnost forecast backtestu</span></h3><p><span class="lang-en">Recent holdout check: forecast the last 4 weeks from earlier history and compare with what actually happened.</span><span class="lang-sk hidden">Recent holdout check: forecast poslednych 4 tyzdnov z predchadzajucej historie a porovnanie s realitou.</span></p></div></div>
+                        <table>
+                            <thead><tr><th><span class="lang-en">Product</span><span class="lang-sk hidden">Produkt</span></th><th><span class="lang-en">Backtest window</span><span class="lang-sk hidden">Backtest okno</span></th><th><span class="lang-en">Actual 30d</span><span class="lang-sk hidden">Realnych 30d</span></th><th><span class="lang-en">Forecast 30d</span><span class="lang-sk hidden">Forecast 30d</span></th><th><span class="lang-en">Abs error</span><span class="lang-sk hidden">Absolutna chyba</span></th><th><span class="lang-en">Accuracy</span><span class="lang-sk hidden">Presnost</span></th><th><span class="lang-en">Bias</span><span class="lang-sk hidden">Bias</span></th></tr></thead>
+                            <tbody>{roy_forecast_accuracy_rows_html}</tbody>
                         </table>
                     </div>
                     <div class="grid-2" style="margin-top:18px;">

--- a/export_orders.py
+++ b/export_orders.py
@@ -8283,6 +8283,7 @@ class BizniWebExporter:
                 "inventory_rows": pd.DataFrame(),
                 "stock_risk_rows": pd.DataFrame(),
                 "dead_stock_rows": pd.DataFrame(),
+                "alert_rows": pd.DataFrame(),
                 "restock_priority_rows": pd.DataFrame(),
                 "revenue_at_risk_rows": pd.DataFrame(),
                 "brand_turn_rows": pd.DataFrame(),
@@ -8307,6 +8308,7 @@ class BizniWebExporter:
                 "inventory_rows": pd.DataFrame(),
                 "stock_risk_rows": pd.DataFrame(),
                 "dead_stock_rows": pd.DataFrame(),
+                "alert_rows": pd.DataFrame(),
                 "restock_priority_rows": pd.DataFrame(),
                 "revenue_at_risk_rows": pd.DataFrame(),
                 "brand_turn_rows": pd.DataFrame(),
@@ -8329,6 +8331,7 @@ class BizniWebExporter:
                 "inventory_rows": pd.DataFrame(),
                 "stock_risk_rows": pd.DataFrame(),
                 "dead_stock_rows": pd.DataFrame(),
+                "alert_rows": pd.DataFrame(),
                 "restock_priority_rows": pd.DataFrame(),
                 "revenue_at_risk_rows": pd.DataFrame(),
                 "brand_turn_rows": pd.DataFrame(),
@@ -8434,6 +8437,46 @@ class BizniWebExporter:
         warning_days_of_cover = max(critical_days_of_cover, int(inventory_config.get("warning_days_of_cover", 30) or 30))
         watch_days_of_cover = max(warning_days_of_cover, int(inventory_config.get("watch_days_of_cover", 45) or 45))
         dead_stock_days = max(watch_days_of_cover, int(inventory_config.get("dead_stock_days", 90) or 90))
+        alert_delivery_horizon_days = max(
+            1,
+            int(inventory_config.get("alert_delivery_horizon_days", warning_days_of_cover) or warning_days_of_cover),
+        )
+        primary_value_basis = str(inventory_config.get("primary_value_basis", "cost")).strip().lower() or "cost"
+        secondary_value_basis = str(inventory_config.get("secondary_value_basis", "retail")).strip().lower() or "retail"
+        reorder_cover_days = max(
+            alert_delivery_horizon_days,
+            int(inventory_config.get("reorder_cover_days", warning_days_of_cover) or warning_days_of_cover),
+        )
+        hero_reorder_cover_days = max(
+            reorder_cover_days,
+            int(inventory_config.get("hero_reorder_cover_days", watch_days_of_cover) or watch_days_of_cover),
+        )
+        forecast_uplift_weights_raw = inventory_config.get("forecast_uplift_weights") or {}
+        forecast_uplift_weights = {
+            "high": float(forecast_uplift_weights_raw.get("high", 0.5) or 0.5),
+            "medium": float(forecast_uplift_weights_raw.get("medium", 0.3) or 0.3),
+            "low": float(forecast_uplift_weights_raw.get("low", 0.15) or 0.15),
+        }
+        hero_brand_keys = {
+            str(value).strip().lower()
+            for value in (inventory_config.get("hero_brand_keys") or [])
+            if str(value).strip()
+        }
+        lead_time_working_days_by_brand = {
+            str(key).strip().lower(): max(0, int(value or 0))
+            for key, value in (inventory_config.get("lead_time_working_days_by_brand") or {}).items()
+            if str(key).strip()
+        }
+        alert_exclusion_patterns = [
+            str(pattern).strip()
+            for pattern in (inventory_config.get("alert_exclusion_label_patterns") or [])
+            if str(pattern).strip()
+        ]
+        bundle_component_rules = inventory_config.get("bundle_component_rules") or []
+        bundle_component_rules = bundle_component_rules if isinstance(bundle_component_rules, list) else []
+        inbound_stock_config = inventory_config.get("inbound_stock") or {}
+        inbound_stock_enabled = bool(inbound_stock_config.get("enabled"))
+        inbound_stock_source = str(inbound_stock_config.get("source") or "").strip() or "not_modeled"
         trend_window_weeks = min(4, max(2, len(week_index) // 2)) if len(week_index) >= 4 else 0
         forecast_horizon_weeks = 4
         growing_rows: List[Dict[str, Any]] = []
@@ -8451,6 +8494,7 @@ class BizniWebExporter:
             .agg(
                 recent_30d_units=("item_quantity", "sum"),
                 recent_30d_revenue=("item_total_without_tax", "sum"),
+                recent_30d_profit_without_fixed=("cm2_profit", "sum"),
                 recent_30d_profit_with_fixed=("cm3_profit", "sum"),
             )
             .reset_index()
@@ -8461,6 +8505,7 @@ class BizniWebExporter:
             .agg(
                 recent_90d_units=("item_quantity", "sum"),
                 recent_90d_revenue=("item_total_without_tax", "sum"),
+                recent_90d_profit_without_fixed=("cm2_profit", "sum"),
                 recent_90d_profit_with_fixed=("cm3_profit", "sum"),
             )
             .reset_index()
@@ -8757,6 +8802,7 @@ class BizniWebExporter:
         inventory_rows_df = pd.DataFrame()
         stock_risk_rows_df = pd.DataFrame()
         dead_stock_rows_df = pd.DataFrame()
+        alert_rows_df = pd.DataFrame()
         restock_priority_rows_df = pd.DataFrame()
         revenue_at_risk_rows_df = pd.DataFrame()
         brand_turn_rows_df = pd.DataFrame()
@@ -8764,6 +8810,7 @@ class BizniWebExporter:
         inventory_products_df = pd.DataFrame()
         inventory_status = "disabled" if not inventory_enabled else "unavailable"
         inventory_fetch_error = None
+        matched_bundle_rule_count = 0
 
         inventory_frame = pd.DataFrame()
         if inventory_enabled:
@@ -8895,9 +8942,11 @@ class BizniWebExporter:
                 "profit_with_fixed",
                 "recent_30d_units",
                 "recent_30d_revenue",
+                "recent_30d_profit_without_fixed",
                 "recent_30d_profit_with_fixed",
                 "recent_90d_units",
                 "recent_90d_revenue",
+                "recent_90d_profit_without_fixed",
                 "recent_90d_profit_with_fixed",
                 "forecast_30d_revenue",
                 "forecast_30d_units",
@@ -8910,6 +8959,99 @@ class BizniWebExporter:
 
             inventory_products_df["last_sale"] = pd.to_datetime(inventory_products_df["last_sale"], errors="coerce")
             inventory_products_df["first_sale"] = pd.to_datetime(inventory_products_df["first_sale"], errors="coerce")
+            inventory_products_df["forecast_confidence"] = (
+                inventory_products_df["forecast_confidence"]
+                .fillna("Low")
+                .astype(str)
+                .replace({"nan": "Low", "": "Low"})
+            )
+            inventory_products_df[["brand_key", "brand_label"]] = inventory_products_df["product"].apply(
+                lambda value: pd.Series(self._extract_product_brand(value))
+            )
+            inventory_products_df[["family_key", "family_label"]] = inventory_products_df["product"].apply(
+                lambda value: pd.Series(self._extract_product_family(value))
+            )
+            inventory_products_df["strategic_stock_flag"] = inventory_products_df["brand_key"].isin(hero_brand_keys)
+            inventory_products_df["lead_time_working_days"] = (
+                inventory_products_df["brand_key"]
+                .astype(str)
+                .str.strip()
+                .str.lower()
+                .map(lead_time_working_days_by_brand)
+                .fillna(0)
+                .astype(int)
+            )
+            inventory_products_df["lead_time_calendar_days"] = np.ceil(
+                inventory_products_df["lead_time_working_days"] * (7.0 / 5.0)
+            ).astype(int)
+            inventory_products_df["inbound_units"] = 0.0
+            inventory_products_df["inbound_status"] = (
+                inbound_stock_source if inbound_stock_enabled else "not_modeled"
+            )
+            inventory_products_df["net_available_quantity"] = (
+                inventory_products_df["available_quantity"] + inventory_products_df["inbound_units"]
+            )
+            inventory_products_df["bundle_sku_flag"] = False
+            inventory_products_df["exclude_bundle_from_alerts_flag"] = False
+            inventory_products_df["bundle_component_recent_30d_units"] = 0.0
+            inventory_products_df["bundle_component_recent_90d_units"] = 0.0
+            inventory_products_df["bundle_component_forecast_30d_units"] = 0.0
+
+            if bundle_component_rules:
+                for rule in bundle_component_rules:
+                    bundle_patterns = [
+                        str(pattern).strip()
+                        for pattern in (rule.get("bundle_patterns") or [])
+                        if str(pattern).strip()
+                    ]
+                    component_rules = rule.get("components") or []
+                    if not bundle_patterns or not component_rules:
+                        continue
+                    bundle_mask = inventory_products_df["product"].apply(
+                        lambda value: self._matches_patterns(value, bundle_patterns)
+                    )
+                    if not bundle_mask.any():
+                        continue
+                    matched_bundle_rule_count += 1
+                    inventory_products_df.loc[bundle_mask, "bundle_sku_flag"] = True
+                    if bool(rule.get("exclude_bundle_from_alerts", False)):
+                        inventory_products_df.loc[bundle_mask, "exclude_bundle_from_alerts_flag"] = True
+                    bundle_recent_30d_units = float(
+                        inventory_products_df.loc[bundle_mask, "recent_30d_units"].sum()
+                    )
+                    bundle_recent_90d_units = float(
+                        inventory_products_df.loc[bundle_mask, "recent_90d_units"].sum()
+                    )
+                    bundle_forecast_30d_units = float(
+                        inventory_products_df.loc[bundle_mask, "forecast_30d_units"].sum()
+                    )
+                    for component_rule in component_rules:
+                        component_patterns = [
+                            str(pattern).strip()
+                            for pattern in (component_rule.get("component_patterns") or [])
+                            if str(pattern).strip()
+                        ]
+                        component_qty = float(component_rule.get("quantity") or 1.0)
+                        if not component_patterns or component_qty <= 0:
+                            continue
+                        component_mask = inventory_products_df["product"].apply(
+                            lambda value: self._matches_patterns(value, component_patterns)
+                        )
+                        if not component_mask.any():
+                            continue
+                        inventory_products_df.loc[
+                            component_mask,
+                            "bundle_component_recent_30d_units",
+                        ] += bundle_recent_30d_units * component_qty
+                        inventory_products_df.loc[
+                            component_mask,
+                            "bundle_component_recent_90d_units",
+                        ] += bundle_recent_90d_units * component_qty
+                        inventory_products_df.loc[
+                            component_mask,
+                            "bundle_component_forecast_30d_units",
+                        ] += bundle_forecast_30d_units * component_qty
+
             inventory_products_df["margin_without_fixed_pct"] = np.where(
                 inventory_products_df["revenue"] != 0,
                 (inventory_products_df["profit_without_fixed"] / inventory_products_df["revenue"]) * 100.0,
@@ -8925,30 +9067,77 @@ class BizniWebExporter:
                 (inventory_products_df["recent_90d_profit_with_fixed"] / inventory_products_df["recent_90d_revenue"]) * 100.0,
                 inventory_products_df["margin_with_fixed_pct"],
             )
+            inventory_products_df["recent_margin_without_fixed_pct"] = np.where(
+                inventory_products_df["recent_90d_revenue"] > 0,
+                (inventory_products_df["recent_90d_profit_without_fixed"] / inventory_products_df["recent_90d_revenue"]) * 100.0,
+                inventory_products_df["margin_without_fixed_pct"],
+            )
             inventory_products_df["days_since_last_sale"] = np.where(
                 inventory_products_df["last_sale"].notna(),
                 (snapshot_ts.normalize() - inventory_products_df["last_sale"].dt.normalize()).dt.days,
                 np.nan,
             )
-            inventory_products_df["alert_30d_units"] = np.maximum(
-                inventory_products_df["recent_30d_units"],
-                inventory_products_df["forecast_30d_units"],
+            inventory_products_df["effective_recent_30d_units"] = (
+                inventory_products_df["recent_30d_units"]
+                + inventory_products_df["bundle_component_recent_30d_units"]
+            )
+            inventory_products_df["effective_recent_90d_units"] = (
+                inventory_products_df["recent_90d_units"]
+                + inventory_products_df["bundle_component_recent_90d_units"]
+            )
+            inventory_products_df["effective_forecast_30d_units"] = (
+                inventory_products_df["forecast_30d_units"]
+                + inventory_products_df["bundle_component_forecast_30d_units"]
+            )
+            inventory_products_df["forecast_uplift_weight"] = (
+                inventory_products_df["forecast_confidence"]
+                .astype(str)
+                .str.strip()
+                .str.lower()
+                .map(forecast_uplift_weights)
+                .fillna(forecast_uplift_weights["low"])
+            )
+            positive_unit_uplift = np.maximum(
+                inventory_products_df["effective_forecast_30d_units"]
+                - inventory_products_df["effective_recent_30d_units"],
+                0.0,
+            )
+            inventory_products_df["alert_30d_units"] = (
+                inventory_products_df["effective_recent_30d_units"]
+                + positive_unit_uplift * inventory_products_df["forecast_uplift_weight"]
+            )
+            no_recent_units_mask = inventory_products_df["effective_recent_30d_units"] <= 0
+            inventory_products_df.loc[no_recent_units_mask, "alert_30d_units"] = (
+                inventory_products_df.loc[no_recent_units_mask, "effective_forecast_30d_units"]
+                * inventory_products_df.loc[no_recent_units_mask, "forecast_uplift_weight"]
             )
             inventory_products_df["daily_units_for_alert"] = inventory_products_df["alert_30d_units"] / 30.0
             inventory_products_df["days_of_cover"] = np.where(
                 inventory_products_df["daily_units_for_alert"] > 0,
-                inventory_products_df["available_quantity"] / inventory_products_df["daily_units_for_alert"],
+                inventory_products_df["net_available_quantity"] / inventory_products_df["daily_units_for_alert"],
                 np.nan,
             )
-            inventory_products_df["alert_30d_revenue"] = np.maximum(
-                inventory_products_df["recent_30d_revenue"],
-                inventory_products_df["forecast_30d_revenue"],
+            positive_revenue_uplift = np.maximum(
+                inventory_products_df["forecast_30d_revenue"] - inventory_products_df["recent_30d_revenue"],
+                0.0,
+            )
+            inventory_products_df["alert_30d_revenue"] = (
+                inventory_products_df["recent_30d_revenue"]
+                + positive_revenue_uplift * inventory_products_df["forecast_uplift_weight"]
+            )
+            no_recent_revenue_mask = inventory_products_df["recent_30d_revenue"] <= 0
+            inventory_products_df.loc[no_recent_revenue_mask, "alert_30d_revenue"] = (
+                inventory_products_df.loc[no_recent_revenue_mask, "forecast_30d_revenue"]
+                * inventory_products_df.loc[no_recent_revenue_mask, "forecast_uplift_weight"]
             )
             inventory_products_df["alert_30d_profit_estimate"] = (
                 inventory_products_df["alert_30d_revenue"] * inventory_products_df["recent_margin_with_fixed_pct"] / 100.0
             )
+            inventory_products_df["alert_30d_contribution_estimate"] = (
+                inventory_products_df["alert_30d_revenue"] * inventory_products_df["recent_margin_without_fixed_pct"] / 100.0
+            )
             inventory_products_df["recent_90d_cost_of_sales"] = (
-                inventory_products_df["recent_90d_units"] * inventory_products_df["cost_per_unit"].fillna(0.0)
+                inventory_products_df["effective_recent_90d_units"] * inventory_products_df["cost_per_unit"].fillna(0.0)
             )
             inventory_products_df["annualized_recent_90d_cost_of_sales"] = (
                 inventory_products_df["recent_90d_cost_of_sales"] * (365.0 / 90.0)
@@ -8981,7 +9170,7 @@ class BizniWebExporter:
                 & (
                     inventory_products_df["last_sale"].isna()
                     | (inventory_products_df["days_since_last_sale"] >= dead_stock_days)
-                    | (inventory_products_df["recent_90d_units"] <= 0)
+                    | (inventory_products_df["effective_recent_90d_units"] <= 0)
                 )
             )
 
@@ -9042,16 +9231,89 @@ class BizniWebExporter:
                 0.0,
             )
             inventory_products_df["has_stock_flag"] = inventory_products_df["available_quantity"] > 0
-            inventory_products_df[["brand_key", "brand_label"]] = inventory_products_df["product"].apply(
-                lambda value: pd.Series(self._extract_product_brand(value))
+            alert_exclusion_reason = pd.Series("", index=inventory_products_df.index, dtype="object")
+            if alert_exclusion_patterns:
+                pattern_exclusion_mask = inventory_products_df["product"].apply(
+                    lambda value: self._matches_patterns(value, alert_exclusion_patterns)
+                )
+                alert_exclusion_reason.loc[pattern_exclusion_mask] = "Excluded by inventory alert pattern"
+            bundle_alert_exclusion_mask = (
+                inventory_products_df["bundle_sku_flag"]
+                & inventory_products_df["exclude_bundle_from_alerts_flag"]
             )
-            inventory_products_df[["family_key", "family_label"]] = inventory_products_df["product"].apply(
-                lambda value: pd.Series(self._extract_product_family(value))
+            alert_exclusion_reason.loc[
+                (alert_exclusion_reason == "") & bundle_alert_exclusion_mask
+            ] = "Bundle demand is shifted to configured components"
+            inventory_products_df["alert_excluded_flag"] = alert_exclusion_reason != ""
+            inventory_products_df["alert_excluded_reason"] = alert_exclusion_reason.replace("", None)
+            inventory_products_df["lead_time_demand_units"] = (
+                inventory_products_df["daily_units_for_alert"]
+                * inventory_products_df["lead_time_calendar_days"]
+            )
+            inventory_products_df["reorder_target_cover_days"] = (
+                inventory_products_df["lead_time_calendar_days"]
+                + np.where(
+                    inventory_products_df["strategic_stock_flag"],
+                    hero_reorder_cover_days,
+                    reorder_cover_days,
+                )
+            )
+            inventory_products_df["suggested_reorder_units"] = np.ceil(
+                np.maximum(
+                    (
+                        inventory_products_df["daily_units_for_alert"]
+                        * inventory_products_df["reorder_target_cover_days"]
+                    ) - inventory_products_df["net_available_quantity"],
+                    0.0,
+                )
+            )
+            reorder_by_dt = pd.Series(pd.NaT, index=inventory_products_df.index, dtype="datetime64[ns]")
+            reorder_deadline_mask = stockout_dt.notna() & (inventory_products_df["lead_time_working_days"] > 0)
+            for idx in inventory_products_df.index[reorder_deadline_mask]:
+                reorder_by_dt.at[idx] = stockout_dt.at[idx] - pd.offsets.BDay(
+                    int(inventory_products_df.at[idx, "lead_time_working_days"])
+                )
+            inventory_products_df["reorder_by_date"] = reorder_by_dt.dt.strftime("%Y-%m-%d")
+            inventory_products_df.loc[reorder_by_dt.isna(), "reorder_by_date"] = None
+            inventory_products_df["days_until_reorder"] = np.where(
+                reorder_by_dt.notna(),
+                (reorder_by_dt.dt.normalize() - snapshot_ts.normalize()).dt.days,
+                np.nan,
+            )
+            inventory_products_df["lead_time_breach_flag"] = (
+                (inventory_products_df["lead_time_calendar_days"] > 0)
+                & inventory_products_df["days_of_cover"].notna()
+                & (inventory_products_df["days_of_cover"] <= inventory_products_df["lead_time_calendar_days"])
+            )
+            inventory_products_df["reorder_now_flag"] = (
+                inventory_products_df["risk_30d_flag"]
+                & (
+                    (inventory_products_df["lead_time_working_days"] <= 0)
+                    | reorder_by_dt.isna()
+                    | (reorder_by_dt.dt.normalize() <= snapshot_ts.normalize())
+                )
+            )
+            inventory_products_df["prepare_po_flag"] = (
+                inventory_products_df["risk_30d_flag"]
+                & ~inventory_products_df["reorder_now_flag"]
+                & inventory_products_df["days_until_reorder"].notna()
+                & (inventory_products_df["days_until_reorder"] <= 7)
+            )
+            inventory_products_df["reorder_action_label"] = np.select(
+                [
+                    inventory_products_df["alert_excluded_flag"],
+                    inventory_products_df["reorder_now_flag"],
+                    inventory_products_df["prepare_po_flag"],
+                    inventory_products_df["risk_30d_flag"],
+                    inventory_products_df["risk_45d_flag"],
+                ],
+                ["Excluded", "Order now", "Prepare PO", "30d alert", "45d watch"],
+                default="Monitor",
             )
 
             demand_reference = max(float(inventory_products_df["alert_30d_units"].quantile(0.9)), 1.0)
             margin_reference = max(
-                float(inventory_products_df["recent_margin_with_fixed_pct"].clip(lower=0).quantile(0.9)),
+                float(inventory_products_df["recent_margin_without_fixed_pct"].clip(lower=0).quantile(0.9)),
                 10.0,
             )
             inventory_products_df["scarcity_score"] = np.where(
@@ -9070,9 +9332,14 @@ class BizniWebExporter:
                 1.0,
             )
             inventory_products_df["margin_score"] = np.clip(
-                inventory_products_df["recent_margin_with_fixed_pct"].clip(lower=0.0) / margin_reference,
+                inventory_products_df["recent_margin_without_fixed_pct"].clip(lower=0.0) / margin_reference,
                 0.0,
                 1.0,
+            )
+            inventory_products_df["strategic_score_bonus"] = np.where(
+                inventory_products_df["strategic_stock_flag"],
+                0.05,
+                0.0,
             )
             inventory_products_df["restock_status_bonus"] = inventory_products_df["stock_risk_level"].map(
                 {
@@ -9088,6 +9355,7 @@ class BizniWebExporter:
                     inventory_products_df["scarcity_score"] * 0.50
                     + inventory_products_df["demand_score"] * 0.35
                     + inventory_products_df["margin_score"] * 0.15
+                    + inventory_products_df["strategic_score_bonus"]
                     + inventory_products_df["restock_status_bonus"]
                 ) * 100.0,
                 0.0,
@@ -9103,13 +9371,17 @@ class BizniWebExporter:
                 default="Monitor",
             )
 
+            value_sort_column = "inventory_retail_value" if primary_value_basis == "retail" else "inventory_cost_value"
+            secondary_value_sort_column = (
+                "inventory_cost_value" if value_sort_column == "inventory_retail_value" else "inventory_retail_value"
+            )
             inventory_rows_df = (
                 inventory_products_df.loc[
                     (inventory_products_df["available_quantity"] > 0)
                     | (inventory_products_df["inventory_cost_value"] > 0)
                     | (inventory_products_df["inventory_retail_value"] > 0)
                 ]
-                .sort_values(["inventory_cost_value", "inventory_retail_value"], ascending=[False, False])
+                .sort_values([value_sort_column, secondary_value_sort_column], ascending=[False, False])
                 .reset_index(drop=True)
             )
             stock_risk_rows_df = (
@@ -9123,21 +9395,43 @@ class BizniWebExporter:
             )
             dead_stock_rows_df = (
                 inventory_products_df.loc[inventory_products_df["dead_stock_flag"]]
-                .sort_values(["inventory_cost_value", "inventory_retail_value"], ascending=[False, False])
+                .sort_values([value_sort_column, secondary_value_sort_column], ascending=[False, False])
+                .reset_index(drop=True)
+            )
+            alert_rows_df = (
+                inventory_products_df.loc[
+                    inventory_products_df["risk_30d_flag"]
+                    & ~inventory_products_df["alert_excluded_flag"]
+                    & (inventory_products_df["alert_30d_units"] > 0)
+                ]
+                .sort_values(
+                    [
+                        "reorder_now_flag",
+                        "strategic_stock_flag",
+                        "stock_risk_rank",
+                        "restock_priority_score",
+                        "alert_30d_revenue",
+                    ],
+                    ascending=[False, False, True, False, False],
+                )
                 .reset_index(drop=True)
             )
             revenue_at_risk_rows_df = (
                 inventory_products_df.loc[
-                    inventory_products_df["risk_45d_flag"] & (inventory_products_df["alert_30d_revenue"] > 0)
+                    inventory_products_df["risk_45d_flag"]
+                    & ~inventory_products_df["alert_excluded_flag"]
+                    & (inventory_products_df["alert_30d_revenue"] > 0)
                 ]
-                .sort_values(["stock_risk_rank", "alert_30d_revenue"], ascending=[True, False])
+                .sort_values(["reorder_now_flag", "stock_risk_rank", "alert_30d_revenue"], ascending=[False, True, False])
                 .reset_index(drop=True)
             )
             restock_priority_rows_df = (
                 inventory_products_df.loc[
-                    inventory_products_df["risk_45d_flag"] & (inventory_products_df["alert_30d_units"] > 0)
+                    inventory_products_df["risk_45d_flag"]
+                    & ~inventory_products_df["alert_excluded_flag"]
+                    & (inventory_products_df["alert_30d_units"] > 0)
                 ]
-                .sort_values(["restock_priority_score", "alert_30d_revenue"], ascending=[False, False])
+                .sort_values(["reorder_now_flag", "restock_priority_score", "alert_30d_revenue"], ascending=[False, False, False])
                 .reset_index(drop=True)
             )
 
@@ -9152,7 +9446,7 @@ class BizniWebExporter:
                         available_quantity=("available_quantity", "sum"),
                         inventory_cost_value=("inventory_cost_value", "sum"),
                         inventory_retail_value=("inventory_retail_value", "sum"),
-                        recent_90d_units=("recent_90d_units", "sum"),
+                        recent_90d_units=("effective_recent_90d_units", "sum"),
                         recent_90d_revenue=("recent_90d_revenue", "sum"),
                         recent_90d_cost_of_sales=("recent_90d_cost_of_sales", "sum"),
                         alert_30d_revenue=("alert_30d_revenue", "sum"),
@@ -9230,6 +9524,8 @@ class BizniWebExporter:
                 "inventory_available_units": round(float(inventory_products_df["available_quantity"].sum()), 1) if not inventory_products_df.empty else 0.0,
                 "inventory_cost_value": round(float(inventory_products_df["inventory_cost_value"].sum()), 2) if not inventory_products_df.empty else 0.0,
                 "inventory_retail_value": round(float(inventory_products_df["inventory_retail_value"].sum()), 2) if not inventory_products_df.empty else 0.0,
+                "inventory_primary_value_basis": primary_value_basis,
+                "inventory_secondary_value_basis": secondary_value_basis,
                 "inventory_cost_coverage_units_pct": round(
                     float(inventory_products_df["mapped_available_quantity"].sum()) / float(inventory_products_df["available_quantity"].sum()) * 100.0,
                     2,
@@ -9265,30 +9561,42 @@ class BizniWebExporter:
                     2,
                 ) if not dead_stock_rows_df.empty and not inventory_products_df.empty and float(inventory_products_df["available_quantity"].sum()) > 0 else 0.0,
                 "revenue_at_risk_30d": round(
-                    float(inventory_products_df.loc[inventory_products_df["risk_30d_flag"], "alert_30d_revenue"].sum()),
+                    float(alert_rows_df["alert_30d_revenue"].sum()),
                     2,
-                ) if not inventory_products_df.empty else 0.0,
+                ) if not alert_rows_df.empty else 0.0,
                 "profit_at_risk_30d": round(
-                    float(inventory_products_df.loc[inventory_products_df["risk_30d_flag"], "alert_30d_profit_estimate"].sum()),
+                    float(alert_rows_df["alert_30d_profit_estimate"].sum()),
                     2,
-                ) if not inventory_products_df.empty else 0.0,
+                ) if not alert_rows_df.empty else 0.0,
                 "revenue_at_risk_45d": round(
-                    float(inventory_products_df.loc[inventory_products_df["risk_45d_flag"], "alert_30d_revenue"].sum()),
+                    float(revenue_at_risk_rows_df["alert_30d_revenue"].sum()),
                     2,
-                ) if not inventory_products_df.empty else 0.0,
+                ) if not revenue_at_risk_rows_df.empty else 0.0,
                 "profit_at_risk_45d": round(
-                    float(inventory_products_df.loc[inventory_products_df["risk_45d_flag"], "alert_30d_profit_estimate"].sum()),
+                    float(revenue_at_risk_rows_df["alert_30d_profit_estimate"].sum()),
                     2,
-                ) if not inventory_products_df.empty else 0.0,
+                ) if not revenue_at_risk_rows_df.empty else 0.0,
                 "restock_priority_urgent_count": int(
-                    (inventory_products_df["restock_priority_score"] >= 80).sum()
-                ) if not inventory_products_df.empty else 0,
+                    (restock_priority_rows_df["restock_priority_score"] >= 80).sum()
+                ) if not restock_priority_rows_df.empty else 0,
                 "restock_priority_high_count": int(
                     (
-                        (inventory_products_df["restock_priority_score"] >= 60)
-                        & (inventory_products_df["restock_priority_score"] < 80)
+                        (restock_priority_rows_df["restock_priority_score"] >= 60)
+                        & (restock_priority_rows_df["restock_priority_score"] < 80)
                     ).sum()
-                ) if not inventory_products_df.empty else 0,
+                ) if not restock_priority_rows_df.empty else 0,
+                "alert_delivery_horizon_days": int(alert_delivery_horizon_days),
+                "alert_delivery_count": int(len(alert_rows_df)),
+                "alert_delivery_hero_count": int(alert_rows_df["strategic_stock_flag"].sum()) if not alert_rows_df.empty else 0,
+                "alert_reorder_now_count": int(alert_rows_df["reorder_now_flag"].sum()) if not alert_rows_df.empty else 0,
+                "alert_prepare_po_count": int(alert_rows_df["prepare_po_flag"].sum()) if not alert_rows_df.empty else 0,
+                "alert_excluded_count": int(inventory_products_df["alert_excluded_flag"].sum()) if not inventory_products_df.empty else 0,
+                "lead_time_configured_alert_count": int((alert_rows_df["lead_time_working_days"] > 0).sum()) if not alert_rows_df.empty else 0,
+                "bundle_component_rule_count": int(matched_bundle_rule_count),
+                "bundle_component_adjustment_30d_units": round(float(inventory_products_df["bundle_component_recent_30d_units"].sum()), 1) if not inventory_products_df.empty else 0.0,
+                "bundle_component_adjustment_90d_units": round(float(inventory_products_df["bundle_component_recent_90d_units"].sum()), 1) if not inventory_products_df.empty else 0.0,
+                "inbound_stock_status": "configured" if inbound_stock_enabled else "not_modeled",
+                "inbound_stock_source": inbound_stock_source,
                 "brand_turn_groups": int(len(brand_turn_rows_df)),
                 "family_turn_groups": int(len(family_turn_rows_df)),
                 "forecast_backtest_products": int(len(forecast_accuracy_rows_df)),
@@ -9319,6 +9627,7 @@ class BizniWebExporter:
             "inventory_rows": inventory_rows_df,
             "stock_risk_rows": stock_risk_rows_df,
             "dead_stock_rows": dead_stock_rows_df,
+            "alert_rows": alert_rows_df,
             "restock_priority_rows": restock_priority_rows_df,
             "revenue_at_risk_rows": revenue_at_risk_rows_df,
             "brand_turn_rows": brand_turn_rows_df,
@@ -9330,7 +9639,8 @@ class BizniWebExporter:
         print(
             f"Roy product demand analytics complete: growing={len(growing_rows_df)}, "
             f"declining={len(declining_rows_df)}, forecasted={len(forecast_rows_df)}, "
-            f"inventory_rows={len(inventory_rows_df)}, restock_rows={len(restock_priority_rows_df)}, "
+            f"inventory_rows={len(inventory_rows_df)}, alert_rows={len(alert_rows_df)}, "
+            f"restock_rows={len(restock_priority_rows_df)}, "
             f"forecast_backtests={len(forecast_accuracy_rows_df)}, brands={len(brand_summary)}"
         )
         return result

--- a/export_orders.py
+++ b/export_orders.py
@@ -3945,7 +3945,11 @@ class BizniWebExporter:
         first_item_retention = self.analyze_retention_by_first_order_item(analytics_df)
         same_item_repurchase = self.analyze_same_item_repurchase(analytics_df)
         time_to_nth_by_first_item = self.analyze_time_to_nth_by_first_item(analytics_df)
-        sample_funnel_analysis = self.analyze_sample_funnel(analytics_df)
+        sample_funnel_analysis = (
+            self.analyze_sample_funnel(analytics_df)
+            if self.project_name != "roy"
+            else {"summary": {}, "window_conversion": pd.DataFrame(), "entry_product_conversion": pd.DataFrame()}
+        )
         refill_cohort_analysis = self.analyze_refill_cohorts(analytics_df)
 
         # Customer email segmentation analysis

--- a/export_orders.py
+++ b/export_orders.py
@@ -387,6 +387,60 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
 }
 """)
 
+PRODUCT_INVENTORY_QUERY = gql("""
+query GetProductInventory($lang_code: CountryCodeAlpha2!, $params: ProductParams) {
+  getProductList(lang_code: $lang_code, params: $params) {
+    data {
+      id
+      title
+      active
+      ean
+      import_code
+      price {
+        value
+        currency {
+          code
+        }
+      }
+      final_price {
+        value
+        currency {
+          code
+        }
+      }
+      warehouse_items {
+        id
+        warehouse_number
+        quantity
+        available_quantity
+        status {
+          id
+          name
+        }
+        price {
+          value
+          currency {
+            code
+          }
+        }
+        final_price {
+          value
+          currency {
+            code
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      nextCursor
+      pageIndex
+      totalPages
+    }
+  }
+}
+""")
+
 
 class BizniWebExporter:
     def __init__(
@@ -1711,12 +1765,176 @@ class BizniWebExporter:
         groups = self.project_settings.get("brand_groups") or []
         return groups if isinstance(groups, list) else []
 
+    def _inventory_model_config(self) -> Dict[str, Any]:
+        config = self.project_settings.get("inventory_model") or {}
+        return config if isinstance(config, dict) else {}
+
     def _extract_product_brand(self, label: Any) -> Tuple[str, str]:
         brand_key, brand_label = self._match_named_group(label, self._brand_groups_config())
         if brand_key:
             return brand_key, brand_label
 
         return "other_unknown", "Other / unknown"
+
+    def fetch_product_inventory_snapshot(self, lang_code: str = "SK", page_limit: int = 30) -> pd.DataFrame:
+        """Fetch current product inventory snapshot from BizniWeb."""
+        print("\nFetching product inventory snapshot...")
+
+        def _safe_float(value: Any) -> float:
+            parsed = pd.to_numeric(value, errors="coerce")
+            return float(parsed) if pd.notna(parsed) else 0.0
+
+        normalized_lang_code = str(lang_code or "SK").strip().upper() or "SK"
+        limit = max(1, min(int(page_limit or 30), 30))
+        cursor = None
+        has_next_page = True
+        page_delay = 0.1
+        retry_delay = 5
+        max_retries = 3
+        page_count = 0
+        rows: List[Dict[str, Any]] = []
+
+        while has_next_page:
+            variables = {
+                "lang_code": normalized_lang_code,
+                "params": {
+                    "limit": limit,
+                },
+            }
+            if cursor is not None:
+                variables["params"]["cursor"] = int(cursor)
+
+            retry_count = 0
+            result = None
+            while retry_count < max_retries:
+                try:
+                    result = self.client.execute(PRODUCT_INVENTORY_QUERY, variable_values=variables)
+                    break
+                except Exception as exc:
+                    retry_count += 1
+                    if retry_count >= max_retries:
+                        raise
+                    logger.warning(
+                        "Inventory fetch page failed (attempt %s/%s): %s",
+                        retry_count,
+                        max_retries,
+                        str(exc)[:200],
+                    )
+                    time.sleep(retry_delay)
+
+            product_block = ((result or {}).get("getProductList")) or {}
+            products = product_block.get("data") or []
+            page_count += 1
+
+            for product in products:
+                title = str(product.get("title") or "").strip() or "Unknown"
+                active = bool(product.get("active", False))
+                ean = str(product.get("ean") or "").strip()
+                import_code = str(product.get("import_code") or "").strip()
+                raw_product_sku = self.get_product_sku(ean, title)
+                reporting_product = self.canonicalize_reporting_product_label(title) or title
+                reporting_sku = self.get_product_sku("", reporting_product or "Unknown")
+
+                product_price = product.get("price") or {}
+                product_final_price = product.get("final_price") or {}
+                product_price_eur = self.convert_to_eur(
+                    product_price.get("value", 0) or 0,
+                    ((product_price.get("currency") or {}).get("code") or "EUR"),
+                )
+                product_final_price_eur = self.convert_to_eur(
+                    product_final_price.get("value", 0) or 0,
+                    ((product_final_price.get("currency") or {}).get("code") or "EUR"),
+                )
+
+                warehouse_items = product.get("warehouse_items") or [{}]
+                for warehouse_item in warehouse_items:
+                    warehouse_number = str((warehouse_item or {}).get("warehouse_number") or "").strip()
+                    quantity_raw = _safe_float((warehouse_item or {}).get("quantity"))
+                    available_quantity_raw = _safe_float(
+                        (warehouse_item or {}).get("available_quantity")
+                        if (warehouse_item or {}).get("available_quantity") is not None
+                        else quantity_raw
+                    )
+                    quantity = max(quantity_raw, 0.0)
+                    available_quantity = max(available_quantity_raw, 0.0)
+                    warehouse_status = (warehouse_item or {}).get("status") or {}
+                    status_name = str(warehouse_status.get("name") or "").strip() or "No warehouse row"
+
+                    warehouse_price = (warehouse_item or {}).get("price") or {}
+                    warehouse_final_price = (warehouse_item or {}).get("final_price") or {}
+                    warehouse_price_eur = self.convert_to_eur(
+                        warehouse_price.get("value", 0) or 0,
+                        ((warehouse_price.get("currency") or {}).get("code") or "EUR"),
+                    )
+                    warehouse_final_price_eur = self.convert_to_eur(
+                        warehouse_final_price.get("value", 0) or 0,
+                        ((warehouse_final_price.get("currency") or {}).get("code") or "EUR"),
+                    )
+                    retail_unit_price_eur = (
+                        warehouse_final_price_eur
+                        or product_final_price_eur
+                        or warehouse_price_eur
+                        or product_price_eur
+                    )
+
+                    cost_per_unit, cost_source = self._resolve_product_expense(
+                        raw_product_sku,
+                        title,
+                        import_code=import_code,
+                        warehouse_number=warehouse_number,
+                    )
+                    inventory_cost_value = (
+                        round(float(cost_per_unit) * available_quantity, 2)
+                        if cost_per_unit is not None
+                        else np.nan
+                    )
+                    inventory_retail_value = round(retail_unit_price_eur * available_quantity, 2)
+                    mapped_available_quantity = available_quantity if cost_per_unit is not None else 0.0
+                    mapped_inventory_retail_value = inventory_retail_value if cost_per_unit is not None else 0.0
+
+                    rows.append(
+                        {
+                            "product_id": str(product.get("id") or "").strip(),
+                            "product_title": title,
+                            "reporting_product": reporting_product,
+                            "reporting_sku": reporting_sku,
+                            "raw_product_sku": raw_product_sku,
+                            "active": active,
+                            "ean": ean,
+                            "import_code": import_code,
+                            "warehouse_item_id": str((warehouse_item or {}).get("id") or "").strip(),
+                            "warehouse_number": warehouse_number,
+                            "stock_status_name": status_name,
+                            "quantity_raw": quantity_raw,
+                            "available_quantity_raw": available_quantity_raw,
+                            "quantity": quantity,
+                            "available_quantity": available_quantity,
+                            "retail_unit_price_eur": round(retail_unit_price_eur, 4),
+                            "cost_per_unit": float(cost_per_unit) if cost_per_unit is not None else np.nan,
+                            "cost_source": cost_source or "unmapped",
+                            "inventory_cost_value": inventory_cost_value,
+                            "inventory_retail_value": inventory_retail_value,
+                            "mapped_available_quantity": mapped_available_quantity,
+                            "mapped_inventory_retail_value": mapped_inventory_retail_value,
+                        }
+                    )
+
+            page_info = product_block.get("pageInfo") or {}
+            has_next_page = bool(page_info.get("hasNextPage"))
+            cursor = page_info.get("nextCursor")
+            if page_count % 10 == 0 or not has_next_page:
+                print(f"  Inventory pages fetched: {page_count}, rows: {len(rows)}")
+            if has_next_page and cursor is not None:
+                time.sleep(page_delay)
+            else:
+                has_next_page = False
+
+        inventory_df = pd.DataFrame(rows)
+        print(
+            f"Inventory snapshot fetch complete: {page_count} pages, "
+            f"{len(inventory_df)} warehouse rows"
+        )
+        return inventory_df
 
     def _build_growth_order_item_frames(
         self,
@@ -8055,6 +8273,9 @@ class BizniWebExporter:
                 "declining_rows": pd.DataFrame(),
                 "seasonality_rows": pd.DataFrame(),
                 "forecast_rows": pd.DataFrame(),
+                "inventory_rows": pd.DataFrame(),
+                "stock_risk_rows": pd.DataFrame(),
+                "dead_stock_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
             }
@@ -8071,6 +8292,9 @@ class BizniWebExporter:
                 "declining_rows": pd.DataFrame(),
                 "seasonality_rows": pd.DataFrame(),
                 "forecast_rows": pd.DataFrame(),
+                "inventory_rows": pd.DataFrame(),
+                "stock_risk_rows": pd.DataFrame(),
+                "dead_stock_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
             }
@@ -8085,6 +8309,9 @@ class BizniWebExporter:
                 "declining_rows": pd.DataFrame(),
                 "seasonality_rows": pd.DataFrame(),
                 "forecast_rows": pd.DataFrame(),
+                "inventory_rows": pd.DataFrame(),
+                "stock_risk_rows": pd.DataFrame(),
+                "dead_stock_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
             }
@@ -8171,12 +8398,41 @@ class BizniWebExporter:
                 end=weekly["week_start"].max(),
                 freq="W-MON",
             )
+        inventory_config = self._inventory_model_config()
+        inventory_enabled = bool(inventory_config.get("enabled", True))
+        inventory_lang_code = str(inventory_config.get("lang_code", "SK")).strip().upper() or "SK"
+        critical_days_of_cover = max(1, int(inventory_config.get("critical_days_of_cover", 14) or 14))
+        warning_days_of_cover = max(critical_days_of_cover, int(inventory_config.get("warning_days_of_cover", 30) or 30))
+        watch_days_of_cover = max(warning_days_of_cover, int(inventory_config.get("watch_days_of_cover", 45) or 45))
+        dead_stock_days = max(watch_days_of_cover, int(inventory_config.get("dead_stock_days", 90) or 90))
         trend_window_weeks = min(4, max(2, len(week_index) // 2)) if len(week_index) >= 4 else 0
         forecast_horizon_weeks = 4
         growing_rows: List[Dict[str, Any]] = []
         declining_rows: List[Dict[str, Any]] = []
         forecast_rows: List[Dict[str, Any]] = []
         latest_sale = pd.to_datetime(demand_df["purchase_datetime"]).max()
+        snapshot_ts = pd.Timestamp(datetime.now())
+        demand_anchor = latest_sale.normalize() if pd.notna(latest_sale) else snapshot_ts.normalize()
+        recent_30d_cutoff = demand_anchor - pd.Timedelta(days=29)
+        recent_90d_cutoff = demand_anchor - pd.Timedelta(days=89)
+        recent_30d_summary = (
+            demand_df.loc[demand_df["purchase_datetime"] >= recent_30d_cutoff]
+            .groupby("product_sku")
+            .agg(
+                recent_30d_units=("item_quantity", "sum"),
+                recent_30d_revenue=("item_total_without_tax", "sum"),
+            )
+            .reset_index()
+        )
+        recent_90d_summary = (
+            demand_df.loc[demand_df["purchase_datetime"] >= recent_90d_cutoff]
+            .groupby("product_sku")
+            .agg(
+                recent_90d_units=("item_quantity", "sum"),
+                recent_90d_revenue=("item_total_without_tax", "sum"),
+            )
+            .reset_index()
+        )
 
         if trend_window_weeks >= 2 and len(week_index) >= trend_window_weeks * 2:
             for row in product_summary.itertuples(index=False):
@@ -8236,11 +8492,13 @@ class BizniWebExporter:
                 recent_revenue_30d = float(recent_series[-min(4, recent_series.size):].sum()) * (30.0 / recent_window_days)
                 forecast_revenue_30d = float(forecast_rev_weeks.sum()) * (30.0 / (forecast_horizon_weeks * 7.0))
                 forecast_units_30d = float(forecast_units_weeks.sum()) * (30.0 / (forecast_horizon_weeks * 7.0))
+                recent_units_30d = float(recent_units_series[-min(4, recent_units_series.size):].sum()) * (30.0 / recent_window_days)
                 forecast_rows.append(
                     {
                         "sku": row.product_sku,
                         "product": row.product,
                         "recent_30d_revenue": round(recent_revenue_30d, 2),
+                        "recent_30d_units": round(recent_units_30d, 1),
                         "forecast_30d_revenue": round(forecast_revenue_30d, 2),
                         "forecast_30d_units": round(forecast_units_30d, 1),
                         "forecast_delta_pct": round(_growth_pct(recent_revenue_30d, forecast_revenue_30d), 1),
@@ -8262,6 +8520,21 @@ class BizniWebExporter:
             pd.DataFrame(forecast_rows).sort_values(["forecast_30d_revenue", "forecast_delta_pct"], ascending=[False, False]).reset_index(drop=True)
             if forecast_rows else pd.DataFrame()
         )
+        if forecast_rows_df.empty:
+            forecast_rows_df = pd.DataFrame(
+                columns=[
+                    "sku",
+                    "product",
+                    "recent_30d_revenue",
+                    "recent_30d_units",
+                    "forecast_30d_revenue",
+                    "forecast_30d_units",
+                    "forecast_delta_pct",
+                    "confidence",
+                    "weeks_used",
+                    "days_since_last_sale",
+                ]
+            )
 
         full_months = pd.PeriodIndex([], freq="M")
         seasonality_rows_df = pd.DataFrame()
@@ -8385,6 +8658,265 @@ class BizniWebExporter:
             if not brand_display_summary.empty else pd.DataFrame()
         )
 
+        inventory_rows_df = pd.DataFrame()
+        stock_risk_rows_df = pd.DataFrame()
+        dead_stock_rows_df = pd.DataFrame()
+        inventory_products_df = pd.DataFrame()
+        inventory_status = "disabled" if not inventory_enabled else "unavailable"
+        inventory_fetch_error = None
+
+        inventory_frame = pd.DataFrame()
+        if inventory_enabled:
+            try:
+                inventory_frame = self.fetch_product_inventory_snapshot(lang_code=inventory_lang_code)
+                inventory_status = "ok" if not inventory_frame.empty else "empty"
+            except Exception as exc:
+                inventory_frame = pd.DataFrame()
+                inventory_status = "error"
+                inventory_fetch_error = str(exc)[:240]
+                logger.warning("Roy inventory snapshot unavailable: %s", inventory_fetch_error)
+
+        if not inventory_frame.empty:
+            inventory_frame["inventory_cost_value"] = pd.to_numeric(
+                inventory_frame["inventory_cost_value"],
+                errors="coerce",
+            ).fillna(0.0)
+            inventory_frame["inventory_retail_value"] = pd.to_numeric(
+                inventory_frame["inventory_retail_value"],
+                errors="coerce",
+            ).fillna(0.0)
+            inventory_frame["mapped_inventory_retail_value"] = pd.to_numeric(
+                inventory_frame["mapped_inventory_retail_value"],
+                errors="coerce",
+            ).fillna(0.0)
+            inventory_frame["available_quantity"] = pd.to_numeric(
+                inventory_frame["available_quantity"],
+                errors="coerce",
+            ).fillna(0.0)
+            inventory_frame["available_quantity_raw"] = pd.to_numeric(
+                inventory_frame["available_quantity_raw"],
+                errors="coerce",
+            ).fillna(0.0)
+            inventory_frame["quantity"] = pd.to_numeric(
+                inventory_frame["quantity"],
+                errors="coerce",
+            ).fillna(0.0)
+            inventory_frame["quantity_raw"] = pd.to_numeric(
+                inventory_frame["quantity_raw"],
+                errors="coerce",
+            ).fillna(0.0)
+            inventory_frame["mapped_available_quantity"] = pd.to_numeric(
+                inventory_frame["mapped_available_quantity"],
+                errors="coerce",
+            ).fillna(0.0)
+
+            inventory_products_df = (
+                inventory_frame.groupby("reporting_sku")
+                .agg(
+                    product=("reporting_product", "first"),
+                    active=("active", "max"),
+                    warehouse_rows=("reporting_sku", "size"),
+                    available_quantity=("available_quantity", "sum"),
+                    available_quantity_raw=("available_quantity_raw", "sum"),
+                    quantity=("quantity", "sum"),
+                    quantity_raw=("quantity_raw", "sum"),
+                    mapped_available_quantity=("mapped_available_quantity", "sum"),
+                    inventory_cost_value=("inventory_cost_value", "sum"),
+                    inventory_retail_value=("inventory_retail_value", "sum"),
+                    mapped_inventory_retail_value=("mapped_inventory_retail_value", "sum"),
+                )
+                .reset_index()
+                .rename(columns={"reporting_sku": "sku"})
+            )
+
+            inventory_products_df["cost_per_unit"] = np.where(
+                inventory_products_df["mapped_available_quantity"] > 0,
+                inventory_products_df["inventory_cost_value"] / inventory_products_df["mapped_available_quantity"],
+                np.nan,
+            )
+            inventory_products_df["cost_coverage_pct"] = np.where(
+                inventory_products_df["available_quantity"] > 0,
+                (inventory_products_df["mapped_available_quantity"] / inventory_products_df["available_quantity"]) * 100.0,
+                0.0,
+            )
+
+            inventory_products_df = inventory_products_df.merge(
+                product_summary[
+                    [
+                        "product_sku",
+                        "orders",
+                        "units",
+                        "revenue",
+                        "first_sale",
+                        "last_sale",
+                    ]
+                ],
+                left_on="sku",
+                right_on="product_sku",
+                how="left",
+            ).drop(columns=["product_sku"])
+            inventory_products_df = inventory_products_df.merge(
+                recent_30d_summary,
+                left_on="sku",
+                right_on="product_sku",
+                how="left",
+            ).drop(columns=["product_sku"], errors="ignore")
+            inventory_products_df = inventory_products_df.merge(
+                recent_90d_summary,
+                left_on="sku",
+                right_on="product_sku",
+                how="left",
+            ).drop(columns=["product_sku"], errors="ignore")
+            inventory_products_df = inventory_products_df.merge(
+                forecast_rows_df[
+                    [
+                        "sku",
+                        "recent_30d_units",
+                        "forecast_30d_units",
+                        "forecast_delta_pct",
+                        "confidence",
+                    ]
+                ].rename(
+                    columns={
+                        "recent_30d_units": "forecast_recent_30d_units",
+                        "confidence": "forecast_confidence",
+                    }
+                ),
+                on="sku",
+                how="left",
+            )
+
+            for column in (
+                "orders",
+                "units",
+                "revenue",
+                "recent_30d_units",
+                "recent_30d_revenue",
+                "recent_90d_units",
+                "recent_90d_revenue",
+                "forecast_recent_30d_units",
+                "forecast_30d_units",
+                "forecast_delta_pct",
+            ):
+                inventory_products_df[column] = pd.to_numeric(
+                    inventory_products_df[column],
+                    errors="coerce",
+                ).fillna(0.0)
+
+            inventory_products_df["last_sale"] = pd.to_datetime(inventory_products_df["last_sale"], errors="coerce")
+            inventory_products_df["first_sale"] = pd.to_datetime(inventory_products_df["first_sale"], errors="coerce")
+            inventory_products_df["days_since_last_sale"] = np.where(
+                inventory_products_df["last_sale"].notna(),
+                (snapshot_ts.normalize() - inventory_products_df["last_sale"].dt.normalize()).dt.days,
+                np.nan,
+            )
+            inventory_products_df["alert_30d_units"] = np.maximum(
+                inventory_products_df["recent_30d_units"],
+                inventory_products_df["forecast_30d_units"],
+            )
+            inventory_products_df["daily_units_for_alert"] = inventory_products_df["alert_30d_units"] / 30.0
+            inventory_products_df["days_of_cover"] = np.where(
+                inventory_products_df["daily_units_for_alert"] > 0,
+                inventory_products_df["available_quantity"] / inventory_products_df["daily_units_for_alert"],
+                np.nan,
+            )
+            stockout_dt = pd.Series(pd.NaT, index=inventory_products_df.index, dtype="datetime64[ns]")
+            max_stockout_days = 3650
+            stockout_mask = (
+                inventory_products_df["days_of_cover"].notna()
+                & (inventory_products_df["days_of_cover"] > 0)
+                & (inventory_products_df["days_of_cover"] <= max_stockout_days)
+            )
+            stockout_dt.loc[stockout_mask] = snapshot_ts.normalize() + pd.to_timedelta(
+                np.ceil(inventory_products_df.loc[stockout_mask, "days_of_cover"]),
+                unit="D",
+            )
+            inventory_products_df["projected_stockout_date"] = stockout_dt.dt.strftime("%Y-%m-%d")
+            inventory_products_df.loc[stockout_dt.isna(), "projected_stockout_date"] = None
+            inventory_products_df["dead_stock_flag"] = (
+                (inventory_products_df["available_quantity"] > 0)
+                & (
+                    inventory_products_df["last_sale"].isna()
+                    | (inventory_products_df["days_since_last_sale"] >= dead_stock_days)
+                    | (inventory_products_df["recent_90d_units"] <= 0)
+                )
+            )
+
+            def _inventory_risk_label(row: pd.Series) -> str:
+                available_raw = float(row.get("available_quantity_raw") or 0.0)
+                demand_30d = float(row.get("alert_30d_units") or 0.0)
+                days_of_cover = row.get("days_of_cover")
+                if available_raw < 0:
+                    return "Negative stock"
+                if demand_30d > 0 and available_raw <= 0:
+                    return "Out of stock"
+                if pd.notna(days_of_cover):
+                    if days_of_cover <= critical_days_of_cover:
+                        return "Critical"
+                    if days_of_cover <= warning_days_of_cover:
+                        return "Low"
+                    if days_of_cover <= watch_days_of_cover:
+                        return "Watch"
+                    return "Healthy"
+                if float(row.get("available_quantity") or 0.0) > 0:
+                    return "Dormant"
+                return "No demand signal"
+
+            risk_rank = {
+                "Negative stock": 0,
+                "Out of stock": 1,
+                "Critical": 2,
+                "Low": 3,
+                "Watch": 4,
+                "Dormant": 5,
+                "Healthy": 6,
+                "No demand signal": 7,
+            }
+            inventory_products_df["stock_risk_level"] = inventory_products_df.apply(_inventory_risk_label, axis=1)
+            inventory_products_df["stock_risk_rank"] = inventory_products_df["stock_risk_level"].map(risk_rank).fillna(99).astype(int)
+
+            inventory_rows_df = (
+                inventory_products_df.loc[
+                    (inventory_products_df["available_quantity"] > 0)
+                    | (inventory_products_df["inventory_cost_value"] > 0)
+                    | (inventory_products_df["inventory_retail_value"] > 0)
+                ]
+                .sort_values(["inventory_cost_value", "inventory_retail_value"], ascending=[False, False])
+                .reset_index(drop=True)
+            )
+            stock_risk_rows_df = (
+                inventory_products_df.loc[
+                    inventory_products_df["stock_risk_level"].isin(
+                        ["Negative stock", "Out of stock", "Critical", "Low", "Watch"]
+                    )
+                ]
+                .sort_values(["stock_risk_rank", "days_of_cover", "inventory_cost_value"], ascending=[True, True, False])
+                .reset_index(drop=True)
+            )
+            dead_stock_rows_df = (
+                inventory_products_df.loc[inventory_products_df["dead_stock_flag"]]
+                .sort_values(["inventory_cost_value", "inventory_retail_value"], ascending=[False, False])
+                .reset_index(drop=True)
+            )
+
+            if not forecast_rows_df.empty:
+                forecast_rows_df = forecast_rows_df.merge(
+                    inventory_products_df[
+                        [
+                            "sku",
+                            "available_quantity",
+                            "inventory_cost_value",
+                            "inventory_retail_value",
+                            "days_of_cover",
+                            "projected_stockout_date",
+                            "stock_risk_level",
+                            "cost_coverage_pct",
+                        ]
+                    ],
+                    on="sku",
+                    how="left",
+                )
+
         result = {
             "summary": {
                 "trend_window_weeks": int(trend_window_weeks),
@@ -8395,17 +8927,57 @@ class BizniWebExporter:
                 "declining_count": int(len(declining_rows_df)),
                 "forecast_count": int(len(forecast_rows_df)),
                 "brand_count": int(len(brand_display_summary)),
+                "inventory_status": inventory_status,
+                "inventory_fetch_error": inventory_fetch_error,
+                "inventory_snapshot_date": snapshot_ts.strftime("%Y-%m-%d"),
+                "inventory_products_total": int(len(inventory_products_df)),
+                "inventory_products_with_stock": int((inventory_products_df["available_quantity"] > 0).sum()) if not inventory_products_df.empty else 0,
+                "inventory_active_products_with_stock": int(
+                    ((inventory_products_df["active"] == True) & (inventory_products_df["available_quantity"] > 0)).sum()
+                ) if not inventory_products_df.empty else 0,
+                "inventory_available_units": round(float(inventory_products_df["available_quantity"].sum()), 1) if not inventory_products_df.empty else 0.0,
+                "inventory_cost_value": round(float(inventory_products_df["inventory_cost_value"].sum()), 2) if not inventory_products_df.empty else 0.0,
+                "inventory_retail_value": round(float(inventory_products_df["inventory_retail_value"].sum()), 2) if not inventory_products_df.empty else 0.0,
+                "inventory_cost_coverage_units_pct": round(
+                    float(inventory_products_df["mapped_available_quantity"].sum()) / float(inventory_products_df["available_quantity"].sum()) * 100.0,
+                    2,
+                ) if not inventory_products_df.empty and float(inventory_products_df["available_quantity"].sum()) > 0 else 0.0,
+                "inventory_cost_coverage_retail_pct": round(
+                    float(inventory_products_df["mapped_inventory_retail_value"].sum()) / float(inventory_products_df["inventory_retail_value"].sum()) * 100.0,
+                    2,
+                ) if not inventory_products_df.empty and float(inventory_products_df["inventory_retail_value"].sum()) > 0 else 0.0,
+                "stock_risk_critical_count": int(
+                    inventory_products_df["stock_risk_level"].isin(["Negative stock", "Out of stock", "Critical"]).sum()
+                ) if not inventory_products_df.empty else 0,
+                "stock_risk_30d_count": int(
+                    inventory_products_df["stock_risk_level"].isin(["Negative stock", "Out of stock", "Critical", "Low"]).sum()
+                ) if not inventory_products_df.empty else 0,
+                "stock_risk_45d_count": int(
+                    inventory_products_df["stock_risk_level"].isin(["Negative stock", "Out of stock", "Critical", "Low", "Watch"]).sum()
+                ) if not inventory_products_df.empty else 0,
+                "out_of_stock_recent_demand_count": int(
+                    (inventory_products_df["stock_risk_level"] == "Out of stock").sum()
+                ) if not inventory_products_df.empty else 0,
+                "negative_stock_count": int(
+                    (inventory_products_df["stock_risk_level"] == "Negative stock").sum()
+                ) if not inventory_products_df.empty else 0,
+                "dead_stock_count": int(dead_stock_rows_df.shape[0]) if not dead_stock_rows_df.empty else 0,
+                "dead_stock_cost_value": round(float(dead_stock_rows_df["inventory_cost_value"].sum()), 2) if not dead_stock_rows_df.empty else 0.0,
             },
             "growing_rows": growing_rows_df,
             "declining_rows": declining_rows_df,
             "seasonality_rows": seasonality_rows_df,
             "forecast_rows": forecast_rows_df,
+            "inventory_rows": inventory_rows_df,
+            "stock_risk_rows": stock_risk_rows_df,
+            "dead_stock_rows": dead_stock_rows_df,
             "brand_revenue_rows": brand_revenue_rows_df,
             "brand_profit_rows": brand_profit_rows_df,
         }
         print(
             f"Roy product demand analytics complete: growing={len(growing_rows_df)}, "
-            f"declining={len(declining_rows_df)}, forecasted={len(forecast_rows_df)}, brands={len(brand_summary)}"
+            f"declining={len(declining_rows_df)}, forecasted={len(forecast_rows_df)}, "
+            f"inventory_rows={len(inventory_rows_df)}, brands={len(brand_summary)}"
         )
         return result
 

--- a/export_orders.py
+++ b/export_orders.py
@@ -1776,6 +1776,13 @@ class BizniWebExporter:
 
         return "other_unknown", "Other / unknown"
 
+    def _extract_product_family(self, label: Any) -> Tuple[str, str]:
+        family_key, family_label = self._match_named_group(label, self._product_family_groups_config())
+        if family_key:
+            return family_key, family_label
+
+        return "other_unclassified", "Other / unclassified"
+
     def fetch_product_inventory_snapshot(self, lang_code: str = "SK", page_limit: int = 30) -> pd.DataFrame:
         """Fetch current product inventory snapshot from BizniWeb."""
         print("\nFetching product inventory snapshot...")
@@ -8276,6 +8283,11 @@ class BizniWebExporter:
                 "inventory_rows": pd.DataFrame(),
                 "stock_risk_rows": pd.DataFrame(),
                 "dead_stock_rows": pd.DataFrame(),
+                "restock_priority_rows": pd.DataFrame(),
+                "revenue_at_risk_rows": pd.DataFrame(),
+                "brand_turn_rows": pd.DataFrame(),
+                "family_turn_rows": pd.DataFrame(),
+                "forecast_accuracy_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
             }
@@ -8295,6 +8307,11 @@ class BizniWebExporter:
                 "inventory_rows": pd.DataFrame(),
                 "stock_risk_rows": pd.DataFrame(),
                 "dead_stock_rows": pd.DataFrame(),
+                "restock_priority_rows": pd.DataFrame(),
+                "revenue_at_risk_rows": pd.DataFrame(),
+                "brand_turn_rows": pd.DataFrame(),
+                "family_turn_rows": pd.DataFrame(),
+                "forecast_accuracy_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
             }
@@ -8312,6 +8329,11 @@ class BizniWebExporter:
                 "inventory_rows": pd.DataFrame(),
                 "stock_risk_rows": pd.DataFrame(),
                 "dead_stock_rows": pd.DataFrame(),
+                "restock_priority_rows": pd.DataFrame(),
+                "revenue_at_risk_rows": pd.DataFrame(),
+                "brand_turn_rows": pd.DataFrame(),
+                "family_turn_rows": pd.DataFrame(),
+                "forecast_accuracy_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
             }
@@ -8391,6 +8413,13 @@ class BizniWebExporter:
                 return "Medium"
             return "Low"
 
+        def _forecast_abs_pct_error(actual_value: float, forecast_value: float) -> float:
+            actual = float(actual_value or 0.0)
+            forecast = float(forecast_value or 0.0)
+            if actual <= 0:
+                return 0.0 if forecast <= 0 else 100.0
+            return abs(forecast - actual) / actual * 100.0
+
         week_index = pd.DatetimeIndex([])
         if not weekly.empty:
             week_index = pd.date_range(
@@ -8410,6 +8439,7 @@ class BizniWebExporter:
         growing_rows: List[Dict[str, Any]] = []
         declining_rows: List[Dict[str, Any]] = []
         forecast_rows: List[Dict[str, Any]] = []
+        forecast_accuracy_rows: List[Dict[str, Any]] = []
         latest_sale = pd.to_datetime(demand_df["purchase_datetime"]).max()
         snapshot_ts = pd.Timestamp(datetime.now())
         demand_anchor = latest_sale.normalize() if pd.notna(latest_sale) else snapshot_ts.normalize()
@@ -8421,6 +8451,7 @@ class BizniWebExporter:
             .agg(
                 recent_30d_units=("item_quantity", "sum"),
                 recent_30d_revenue=("item_total_without_tax", "sum"),
+                recent_30d_profit_with_fixed=("cm3_profit", "sum"),
             )
             .reset_index()
         )
@@ -8430,6 +8461,7 @@ class BizniWebExporter:
             .agg(
                 recent_90d_units=("item_quantity", "sum"),
                 recent_90d_revenue=("item_total_without_tax", "sum"),
+                recent_90d_profit_with_fixed=("cm3_profit", "sum"),
             )
             .reset_index()
         )
@@ -8507,6 +8539,45 @@ class BizniWebExporter:
                         "days_since_last_sale": int((latest_sale - row.last_sale).days),
                     }
                 )
+                if recent_series.size >= (forecast_horizon_weeks + 6):
+                    history_revenue_series = recent_series[:-forecast_horizon_weeks]
+                    history_units_series = recent_units_series[:-forecast_horizon_weeks]
+                    actual_revenue_weeks = recent_series[-forecast_horizon_weeks:]
+                    actual_units_weeks = recent_units_series[-forecast_horizon_weeks:]
+                    backtest_revenue_weeks = _forecast_series(history_revenue_series, horizon=forecast_horizon_weeks)
+                    backtest_units_weeks = _forecast_series(history_units_series, horizon=forecast_horizon_weeks)
+                    backtest_scale = 30.0 / (forecast_horizon_weeks * 7.0)
+                    actual_revenue_backtest = float(actual_revenue_weeks.sum()) * backtest_scale
+                    forecast_revenue_backtest = float(backtest_revenue_weeks.sum()) * backtest_scale
+                    actual_units_backtest = float(actual_units_weeks.sum()) * backtest_scale
+                    forecast_units_backtest = float(backtest_units_weeks.sum()) * backtest_scale
+                    revenue_error_abs_pct = _forecast_abs_pct_error(actual_revenue_backtest, forecast_revenue_backtest)
+                    units_error_abs_pct = _forecast_abs_pct_error(actual_units_backtest, forecast_units_backtest)
+                    if actual_revenue_backtest > 0 or forecast_revenue_backtest > 0:
+                        forecast_accuracy_rows.append(
+                            {
+                                "sku": row.product_sku,
+                                "product": row.product,
+                                "backtest_window_start": series.index[-forecast_horizon_weeks].strftime("%Y-%m-%d"),
+                                "backtest_window_end": series.index[-1].strftime("%Y-%m-%d"),
+                                "actual_30d_revenue": round(actual_revenue_backtest, 2),
+                                "forecast_30d_revenue": round(forecast_revenue_backtest, 2),
+                                "actual_30d_units": round(actual_units_backtest, 1),
+                                "forecast_30d_units": round(forecast_units_backtest, 1),
+                                "revenue_error_abs_pct": round(revenue_error_abs_pct, 1),
+                                "units_error_abs_pct": round(units_error_abs_pct, 1),
+                                "revenue_accuracy_pct": round(max(0.0, 100.0 - min(revenue_error_abs_pct, 100.0)), 1),
+                                "bias_label": (
+                                    "Over forecast"
+                                    if forecast_revenue_backtest > (actual_revenue_backtest * 1.1)
+                                    else "Under forecast"
+                                    if forecast_revenue_backtest < (actual_revenue_backtest * 0.9)
+                                    else "On target"
+                                ),
+                                "confidence": _forecast_confidence(history_revenue_series),
+                                "weeks_used": int(history_revenue_series.size),
+                            }
+                        )
 
         growing_rows_df = (
             pd.DataFrame(growing_rows).sort_values(["revenue_delta", "recent_window_revenue"], ascending=[False, False]).reset_index(drop=True)
@@ -8519,6 +8590,12 @@ class BizniWebExporter:
         forecast_rows_df = (
             pd.DataFrame(forecast_rows).sort_values(["forecast_30d_revenue", "forecast_delta_pct"], ascending=[False, False]).reset_index(drop=True)
             if forecast_rows else pd.DataFrame()
+        )
+        forecast_accuracy_rows_df = (
+            pd.DataFrame(forecast_accuracy_rows)
+            .sort_values(["actual_30d_revenue", "revenue_accuracy_pct"], ascending=[False, False])
+            .reset_index(drop=True)
+            if forecast_accuracy_rows else pd.DataFrame()
         )
         if forecast_rows_df.empty:
             forecast_rows_df = pd.DataFrame(
@@ -8533,6 +8610,25 @@ class BizniWebExporter:
                     "confidence",
                     "weeks_used",
                     "days_since_last_sale",
+                ]
+            )
+        if forecast_accuracy_rows_df.empty:
+            forecast_accuracy_rows_df = pd.DataFrame(
+                columns=[
+                    "sku",
+                    "product",
+                    "backtest_window_start",
+                    "backtest_window_end",
+                    "actual_30d_revenue",
+                    "forecast_30d_revenue",
+                    "actual_30d_units",
+                    "forecast_30d_units",
+                    "revenue_error_abs_pct",
+                    "units_error_abs_pct",
+                    "revenue_accuracy_pct",
+                    "bias_label",
+                    "confidence",
+                    "weeks_used",
                 ]
             )
 
@@ -8661,6 +8757,10 @@ class BizniWebExporter:
         inventory_rows_df = pd.DataFrame()
         stock_risk_rows_df = pd.DataFrame()
         dead_stock_rows_df = pd.DataFrame()
+        restock_priority_rows_df = pd.DataFrame()
+        revenue_at_risk_rows_df = pd.DataFrame()
+        brand_turn_rows_df = pd.DataFrame()
+        family_turn_rows_df = pd.DataFrame()
         inventory_products_df = pd.DataFrame()
         inventory_status = "disabled" if not inventory_enabled else "unavailable"
         inventory_fetch_error = None
@@ -8747,6 +8847,8 @@ class BizniWebExporter:
                         "orders",
                         "units",
                         "revenue",
+                        "profit_without_fixed",
+                        "profit_with_fixed",
                         "first_sale",
                         "last_sale",
                     ]
@@ -8771,14 +8873,13 @@ class BizniWebExporter:
                 forecast_rows_df[
                     [
                         "sku",
-                        "recent_30d_units",
+                        "forecast_30d_revenue",
                         "forecast_30d_units",
                         "forecast_delta_pct",
                         "confidence",
                     ]
                 ].rename(
                     columns={
-                        "recent_30d_units": "forecast_recent_30d_units",
                         "confidence": "forecast_confidence",
                     }
                 ),
@@ -8790,11 +8891,15 @@ class BizniWebExporter:
                 "orders",
                 "units",
                 "revenue",
+                "profit_without_fixed",
+                "profit_with_fixed",
                 "recent_30d_units",
                 "recent_30d_revenue",
+                "recent_30d_profit_with_fixed",
                 "recent_90d_units",
                 "recent_90d_revenue",
-                "forecast_recent_30d_units",
+                "recent_90d_profit_with_fixed",
+                "forecast_30d_revenue",
                 "forecast_30d_units",
                 "forecast_delta_pct",
             ):
@@ -8805,6 +8910,21 @@ class BizniWebExporter:
 
             inventory_products_df["last_sale"] = pd.to_datetime(inventory_products_df["last_sale"], errors="coerce")
             inventory_products_df["first_sale"] = pd.to_datetime(inventory_products_df["first_sale"], errors="coerce")
+            inventory_products_df["margin_without_fixed_pct"] = np.where(
+                inventory_products_df["revenue"] != 0,
+                (inventory_products_df["profit_without_fixed"] / inventory_products_df["revenue"]) * 100.0,
+                0.0,
+            )
+            inventory_products_df["margin_with_fixed_pct"] = np.where(
+                inventory_products_df["revenue"] != 0,
+                (inventory_products_df["profit_with_fixed"] / inventory_products_df["revenue"]) * 100.0,
+                0.0,
+            )
+            inventory_products_df["recent_margin_with_fixed_pct"] = np.where(
+                inventory_products_df["recent_90d_revenue"] > 0,
+                (inventory_products_df["recent_90d_profit_with_fixed"] / inventory_products_df["recent_90d_revenue"]) * 100.0,
+                inventory_products_df["margin_with_fixed_pct"],
+            )
             inventory_products_df["days_since_last_sale"] = np.where(
                 inventory_products_df["last_sale"].notna(),
                 (snapshot_ts.normalize() - inventory_products_df["last_sale"].dt.normalize()).dt.days,
@@ -8818,6 +8938,29 @@ class BizniWebExporter:
             inventory_products_df["days_of_cover"] = np.where(
                 inventory_products_df["daily_units_for_alert"] > 0,
                 inventory_products_df["available_quantity"] / inventory_products_df["daily_units_for_alert"],
+                np.nan,
+            )
+            inventory_products_df["alert_30d_revenue"] = np.maximum(
+                inventory_products_df["recent_30d_revenue"],
+                inventory_products_df["forecast_30d_revenue"],
+            )
+            inventory_products_df["alert_30d_profit_estimate"] = (
+                inventory_products_df["alert_30d_revenue"] * inventory_products_df["recent_margin_with_fixed_pct"] / 100.0
+            )
+            inventory_products_df["recent_90d_cost_of_sales"] = (
+                inventory_products_df["recent_90d_units"] * inventory_products_df["cost_per_unit"].fillna(0.0)
+            )
+            inventory_products_df["annualized_recent_90d_cost_of_sales"] = (
+                inventory_products_df["recent_90d_cost_of_sales"] * (365.0 / 90.0)
+            )
+            inventory_products_df["inventory_turns_annualized"] = np.where(
+                inventory_products_df["inventory_cost_value"] > 0,
+                inventory_products_df["annualized_recent_90d_cost_of_sales"] / inventory_products_df["inventory_cost_value"],
+                np.nan,
+            )
+            inventory_products_df["days_in_inventory_estimate"] = np.where(
+                inventory_products_df["inventory_turns_annualized"] > 0,
+                365.0 / inventory_products_df["inventory_turns_annualized"],
                 np.nan,
             )
             stockout_dt = pd.Series(pd.NaT, index=inventory_products_df.index, dtype="datetime64[ns]")
@@ -8874,6 +9017,91 @@ class BizniWebExporter:
             }
             inventory_products_df["stock_risk_level"] = inventory_products_df.apply(_inventory_risk_label, axis=1)
             inventory_products_df["stock_risk_rank"] = inventory_products_df["stock_risk_level"].map(risk_rank).fillna(99).astype(int)
+            inventory_products_df["negative_stock_units_gap"] = np.where(
+                inventory_products_df["available_quantity_raw"] < 0,
+                np.abs(inventory_products_df["available_quantity_raw"]),
+                0.0,
+            )
+            inventory_products_df["risk_30d_flag"] = inventory_products_df["stock_risk_level"].isin(
+                ["Negative stock", "Out of stock", "Critical", "Low"]
+            )
+            inventory_products_df["risk_45d_flag"] = inventory_products_df["stock_risk_level"].isin(
+                ["Negative stock", "Out of stock", "Critical", "Low", "Watch"]
+            )
+            inventory_products_df["critical_flag"] = inventory_products_df["stock_risk_level"].isin(
+                ["Negative stock", "Out of stock", "Critical"]
+            )
+            inventory_products_df["dead_stock_cost_component"] = np.where(
+                inventory_products_df["dead_stock_flag"],
+                inventory_products_df["inventory_cost_value"],
+                0.0,
+            )
+            inventory_products_df["dead_stock_units_component"] = np.where(
+                inventory_products_df["dead_stock_flag"],
+                inventory_products_df["available_quantity"],
+                0.0,
+            )
+            inventory_products_df["has_stock_flag"] = inventory_products_df["available_quantity"] > 0
+            inventory_products_df[["brand_key", "brand_label"]] = inventory_products_df["product"].apply(
+                lambda value: pd.Series(self._extract_product_brand(value))
+            )
+            inventory_products_df[["family_key", "family_label"]] = inventory_products_df["product"].apply(
+                lambda value: pd.Series(self._extract_product_family(value))
+            )
+
+            demand_reference = max(float(inventory_products_df["alert_30d_units"].quantile(0.9)), 1.0)
+            margin_reference = max(
+                float(inventory_products_df["recent_margin_with_fixed_pct"].clip(lower=0).quantile(0.9)),
+                10.0,
+            )
+            inventory_products_df["scarcity_score"] = np.where(
+                inventory_products_df["stock_risk_level"].isin(["Negative stock", "Out of stock"]),
+                1.0,
+                np.clip(
+                    (watch_days_of_cover - inventory_products_df["days_of_cover"].fillna(watch_days_of_cover))
+                    / max(float(watch_days_of_cover), 1.0),
+                    0.0,
+                    1.0,
+                ),
+            )
+            inventory_products_df["demand_score"] = np.clip(
+                inventory_products_df["alert_30d_units"] / demand_reference,
+                0.0,
+                1.0,
+            )
+            inventory_products_df["margin_score"] = np.clip(
+                inventory_products_df["recent_margin_with_fixed_pct"].clip(lower=0.0) / margin_reference,
+                0.0,
+                1.0,
+            )
+            inventory_products_df["restock_status_bonus"] = inventory_products_df["stock_risk_level"].map(
+                {
+                    "Negative stock": 0.18,
+                    "Out of stock": 0.18,
+                    "Critical": 0.10,
+                    "Low": 0.05,
+                    "Watch": 0.02,
+                }
+            ).fillna(0.0)
+            inventory_products_df["restock_priority_score"] = np.clip(
+                (
+                    inventory_products_df["scarcity_score"] * 0.50
+                    + inventory_products_df["demand_score"] * 0.35
+                    + inventory_products_df["margin_score"] * 0.15
+                    + inventory_products_df["restock_status_bonus"]
+                ) * 100.0,
+                0.0,
+                100.0,
+            )
+            inventory_products_df["restock_priority_bucket"] = np.select(
+                [
+                    inventory_products_df["restock_priority_score"] >= 80,
+                    inventory_products_df["restock_priority_score"] >= 60,
+                    inventory_products_df["restock_priority_score"] >= 40,
+                ],
+                ["Urgent", "High", "Plan"],
+                default="Monitor",
+            )
 
             inventory_rows_df = (
                 inventory_products_df.loc[
@@ -8898,6 +9126,70 @@ class BizniWebExporter:
                 .sort_values(["inventory_cost_value", "inventory_retail_value"], ascending=[False, False])
                 .reset_index(drop=True)
             )
+            revenue_at_risk_rows_df = (
+                inventory_products_df.loc[
+                    inventory_products_df["risk_45d_flag"] & (inventory_products_df["alert_30d_revenue"] > 0)
+                ]
+                .sort_values(["stock_risk_rank", "alert_30d_revenue"], ascending=[True, False])
+                .reset_index(drop=True)
+            )
+            restock_priority_rows_df = (
+                inventory_products_df.loc[
+                    inventory_products_df["risk_45d_flag"] & (inventory_products_df["alert_30d_units"] > 0)
+                ]
+                .sort_values(["restock_priority_score", "alert_30d_revenue"], ascending=[False, False])
+                .reset_index(drop=True)
+            )
+
+            def _inventory_turn_rows(frame: pd.DataFrame, key_col: str, label_col: str) -> pd.DataFrame:
+                if frame.empty:
+                    return pd.DataFrame()
+                grouped = (
+                    frame.groupby([key_col, label_col], as_index=False)
+                    .agg(
+                        products=("sku", "nunique"),
+                        products_with_stock=("has_stock_flag", "sum"),
+                        available_quantity=("available_quantity", "sum"),
+                        inventory_cost_value=("inventory_cost_value", "sum"),
+                        inventory_retail_value=("inventory_retail_value", "sum"),
+                        recent_90d_units=("recent_90d_units", "sum"),
+                        recent_90d_revenue=("recent_90d_revenue", "sum"),
+                        recent_90d_cost_of_sales=("recent_90d_cost_of_sales", "sum"),
+                        alert_30d_revenue=("alert_30d_revenue", "sum"),
+                        risk_30d_count=("risk_30d_flag", "sum"),
+                        critical_count=("critical_flag", "sum"),
+                        negative_stock_units_gap=("negative_stock_units_gap", "sum"),
+                        dead_stock_cost_value=("dead_stock_cost_component", "sum"),
+                    )
+                )
+                grouped = grouped.loc[
+                    (grouped["available_quantity"] > 0)
+                    | (grouped["inventory_cost_value"] > 0)
+                    | (grouped["inventory_retail_value"] > 0)
+                ].copy()
+                grouped["inventory_turns_annualized"] = np.where(
+                    grouped["inventory_cost_value"] > 0,
+                    (grouped["recent_90d_cost_of_sales"] * (365.0 / 90.0)) / grouped["inventory_cost_value"],
+                    np.nan,
+                )
+                grouped["days_in_inventory_estimate"] = np.where(
+                    grouped["inventory_turns_annualized"] > 0,
+                    365.0 / grouped["inventory_turns_annualized"],
+                    np.nan,
+                )
+                grouped["dead_stock_share_pct"] = np.where(
+                    grouped["inventory_cost_value"] > 0,
+                    (grouped["dead_stock_cost_value"] / grouped["inventory_cost_value"]) * 100.0,
+                    0.0,
+                )
+                return (
+                    grouped.rename(columns={key_col: "group_key", label_col: "group_label"})
+                    .sort_values(["inventory_cost_value", "alert_30d_revenue"], ascending=[False, False])
+                    .reset_index(drop=True)
+                )
+
+            brand_turn_rows_df = _inventory_turn_rows(inventory_products_df, "brand_key", "brand_label")
+            family_turn_rows_df = _inventory_turn_rows(inventory_products_df, "family_key", "family_label")
 
             if not forecast_rows_df.empty:
                 forecast_rows_df = forecast_rows_df.merge(
@@ -8961,8 +9253,64 @@ class BizniWebExporter:
                 "negative_stock_count": int(
                     (inventory_products_df["stock_risk_level"] == "Negative stock").sum()
                 ) if not inventory_products_df.empty else 0,
+                "negative_stock_units_gap": round(float(inventory_products_df["negative_stock_units_gap"].sum()), 1) if not inventory_products_df.empty else 0.0,
                 "dead_stock_count": int(dead_stock_rows_df.shape[0]) if not dead_stock_rows_df.empty else 0,
                 "dead_stock_cost_value": round(float(dead_stock_rows_df["inventory_cost_value"].sum()), 2) if not dead_stock_rows_df.empty else 0.0,
+                "dead_stock_cost_share_pct": round(
+                    float(dead_stock_rows_df["inventory_cost_value"].sum()) / float(inventory_products_df["inventory_cost_value"].sum()) * 100.0,
+                    2,
+                ) if not dead_stock_rows_df.empty and not inventory_products_df.empty and float(inventory_products_df["inventory_cost_value"].sum()) > 0 else 0.0,
+                "dead_stock_units_share_pct": round(
+                    float(dead_stock_rows_df["available_quantity"].sum()) / float(inventory_products_df["available_quantity"].sum()) * 100.0,
+                    2,
+                ) if not dead_stock_rows_df.empty and not inventory_products_df.empty and float(inventory_products_df["available_quantity"].sum()) > 0 else 0.0,
+                "revenue_at_risk_30d": round(
+                    float(inventory_products_df.loc[inventory_products_df["risk_30d_flag"], "alert_30d_revenue"].sum()),
+                    2,
+                ) if not inventory_products_df.empty else 0.0,
+                "profit_at_risk_30d": round(
+                    float(inventory_products_df.loc[inventory_products_df["risk_30d_flag"], "alert_30d_profit_estimate"].sum()),
+                    2,
+                ) if not inventory_products_df.empty else 0.0,
+                "revenue_at_risk_45d": round(
+                    float(inventory_products_df.loc[inventory_products_df["risk_45d_flag"], "alert_30d_revenue"].sum()),
+                    2,
+                ) if not inventory_products_df.empty else 0.0,
+                "profit_at_risk_45d": round(
+                    float(inventory_products_df.loc[inventory_products_df["risk_45d_flag"], "alert_30d_profit_estimate"].sum()),
+                    2,
+                ) if not inventory_products_df.empty else 0.0,
+                "restock_priority_urgent_count": int(
+                    (inventory_products_df["restock_priority_score"] >= 80).sum()
+                ) if not inventory_products_df.empty else 0,
+                "restock_priority_high_count": int(
+                    (
+                        (inventory_products_df["restock_priority_score"] >= 60)
+                        & (inventory_products_df["restock_priority_score"] < 80)
+                    ).sum()
+                ) if not inventory_products_df.empty else 0,
+                "brand_turn_groups": int(len(brand_turn_rows_df)),
+                "family_turn_groups": int(len(family_turn_rows_df)),
+                "forecast_backtest_products": int(len(forecast_accuracy_rows_df)),
+                "forecast_backtest_wape_pct": round(
+                    float(
+                        np.abs(
+                            forecast_accuracy_rows_df["forecast_30d_revenue"]
+                            - forecast_accuracy_rows_df["actual_30d_revenue"]
+                        ).sum()
+                        / float(forecast_accuracy_rows_df["actual_30d_revenue"].sum())
+                        * 100.0
+                    ),
+                    2,
+                ) if not forecast_accuracy_rows_df.empty and float(forecast_accuracy_rows_df["actual_30d_revenue"].sum()) > 0 else 0.0,
+                "forecast_backtest_median_accuracy_pct": round(
+                    float(forecast_accuracy_rows_df["revenue_accuracy_pct"].median()),
+                    2,
+                ) if not forecast_accuracy_rows_df.empty else 0.0,
+                "forecast_backtest_within_20_pct": round(
+                    float((forecast_accuracy_rows_df["revenue_error_abs_pct"] <= 20.0).mean() * 100.0),
+                    2,
+                ) if not forecast_accuracy_rows_df.empty else 0.0,
             },
             "growing_rows": growing_rows_df,
             "declining_rows": declining_rows_df,
@@ -8971,13 +9319,19 @@ class BizniWebExporter:
             "inventory_rows": inventory_rows_df,
             "stock_risk_rows": stock_risk_rows_df,
             "dead_stock_rows": dead_stock_rows_df,
+            "restock_priority_rows": restock_priority_rows_df,
+            "revenue_at_risk_rows": revenue_at_risk_rows_df,
+            "brand_turn_rows": brand_turn_rows_df,
+            "family_turn_rows": family_turn_rows_df,
+            "forecast_accuracy_rows": forecast_accuracy_rows_df,
             "brand_revenue_rows": brand_revenue_rows_df,
             "brand_profit_rows": brand_profit_rows_df,
         }
         print(
             f"Roy product demand analytics complete: growing={len(growing_rows_df)}, "
             f"declining={len(declining_rows_df)}, forecasted={len(forecast_rows_df)}, "
-            f"inventory_rows={len(inventory_rows_df)}, brands={len(brand_summary)}"
+            f"inventory_rows={len(inventory_rows_df)}, restock_rows={len(restock_priority_rows_df)}, "
+            f"forecast_backtests={len(forecast_accuracy_rows_df)}, brands={len(brand_summary)}"
         )
         return result
 

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -13,7 +13,78 @@
     "critical_days_of_cover": 14,
     "warning_days_of_cover": 30,
     "watch_days_of_cover": 45,
-    "dead_stock_days": 90
+    "dead_stock_days": 90,
+    "alert_delivery_horizon_days": 30,
+    "primary_value_basis": "cost",
+    "secondary_value_basis": "retail",
+    "forecast_uplift_weights": {
+      "high": 0.5,
+      "medium": 0.3,
+      "low": 0.15
+    },
+    "reorder_cover_days": 30,
+    "hero_reorder_cover_days": 45,
+    "hero_brand_keys": [
+      "wachman",
+      "maco_stop"
+    ],
+    "lead_time_working_days_by_brand": {
+      "maco_stop": 10,
+      "wachman": 20,
+      "roy": 50
+    },
+    "alert_exclusion_label_patterns": [
+      "reklamacia",
+      "reklamace",
+      "warranty claim",
+      "pozarucny servis",
+      "servis",
+      "darcek",
+      "zadarmo",
+      "nahradny diel",
+      "nahradne diely",
+      "testovaci",
+      "testovacie",
+      "update fw",
+      "poistenie balika",
+      "licencia",
+      "maketa",
+      "atrapa",
+      "set mini"
+    ],
+    "bundle_component_rules": [
+      {
+        "bundle_patterns": [
+          "set maco stop velky",
+          "set proti medvedom velky",
+          "set proti medvedom",
+          "set sprej na medveda 300ml s kapsickou",
+          "set proti medvedom velky (miesto maleho)"
+        ],
+        "exclude_bundle_from_alerts": true,
+        "components": [
+          {
+            "component_patterns": [
+              "maco stop extreme 300ml",
+              "najsilnejsi sprej na medvede maco stop extreme 300ml",
+              "a legerosebb medve spray maco stop extreme 300ml"
+            ],
+            "quantity": 1
+          },
+          {
+            "component_patterns": [
+              "puzdro maco stop na sprej 300ml",
+              "puzdro na spreje 300ml univerzal"
+            ],
+            "quantity": 1
+          }
+        ]
+      }
+    ],
+    "inbound_stock": {
+      "enabled": false,
+      "source": "todo"
+    }
   },
   "excluded_order_statuses": [
     "Stripe - cancelled",

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -7,6 +7,14 @@
   "packaging_cost_per_order": 0.05,
   "shipping_net_per_order": -0.2,
   "fixed_monthly_cost": 5500,
+  "inventory_model": {
+    "enabled": true,
+    "lang_code": "SK",
+    "critical_days_of_cover": 14,
+    "warning_days_of_cover": 30,
+    "watch_days_of_cover": 45,
+    "dead_stock_days": 90
+  },
   "excluded_order_statuses": [
     "Stripe - cancelled",
     "Stripe - expired",

--- a/templates/reporting-client/settings.template.json
+++ b/templates/reporting-client/settings.template.json
@@ -14,7 +14,25 @@
     "critical_days_of_cover": 14,
     "warning_days_of_cover": 30,
     "watch_days_of_cover": 45,
-    "dead_stock_days": 90
+    "dead_stock_days": 90,
+    "alert_delivery_horizon_days": 30,
+    "primary_value_basis": "cost",
+    "secondary_value_basis": "retail",
+    "forecast_uplift_weights": {
+      "high": 0.5,
+      "medium": 0.3,
+      "low": 0.15
+    },
+    "reorder_cover_days": 30,
+    "hero_reorder_cover_days": 45,
+    "hero_brand_keys": [],
+    "lead_time_working_days_by_brand": {},
+    "alert_exclusion_label_patterns": [],
+    "bundle_component_rules": [],
+    "inbound_stock": {
+      "enabled": false,
+      "source": ""
+    }
   },
   "excluded_order_statuses": [],
   "weather": {

--- a/templates/reporting-client/settings.template.json
+++ b/templates/reporting-client/settings.template.json
@@ -8,6 +8,14 @@
   "shipping_net_per_order": 0.0,
   "fixed_monthly_cost": 0,
   "fixed_daily_cost": 0,
+  "inventory_model": {
+    "enabled": false,
+    "lang_code": "SK",
+    "critical_days_of_cover": 14,
+    "warning_days_of_cover": 30,
+    "watch_days_of_cover": 45,
+    "dead_stock_days": 90
+  },
   "excluded_order_statuses": [],
   "weather": {
     "enabled": false,


### PR DESCRIPTION
## Summary
- add live Biznisweb inventory snapshot ingestion for Roy products
- compute inventory value, stock risk, projected stockout and dead-stock candidates
- render the new Roy inventory section in the modern dashboard and document the verified live metrics

## Verification
- python -m py_compile export_orders.py dashboard_modern.py
- python export_orders.py --project roy --from-date 2025-09-24 --to-date 2026-04-14 --output-tag inventory_probe