### PR TITLE
Clarify VEVO post-ad profit KPI naming

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -185,6 +185,10 @@ Bootstrap entrypoints:
 ## 9) Change Log
 
 ### 2026-04-16
+- Clarified the top KPI meaning for VEVO/modern reporting:
+  - the existing top-level `Profit` KPI is the absolute post-ad profit layer (`contribution_profit` / `post_ad_contribution_profit`), not net profit after fixed overhead
+  - renamed the exposed label to `Post-ad profit (€)` / `Post-ad zisk (€)` in the active dashboard payload, modern metric library, legacy CFO top-card renderer, and live dashboard context view
+  - added smoke coverage asserting the KPI payload now exposes the explicit post-ad profit label
 - Applied the agreed ROY inventory business rules in config:
   - thresholds confirmed for `Critical <= 14d`, `Low <= 30d`, `Watch <= 45d`, `Dead stock >= 90d`
   - alert delivery narrowed to the 30-day bucket, 45-day rows kept as watchlist only

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -16,7 +16,7 @@ import pandas as pd
 
 METRIC_LABELS = {
     "revenue": {"en": "Revenue (net)", "sk": "Tržby (netto)"},
-    "profit": {"en": "Profit", "sk": "Zisk"},
+    "profit": {"en": "Post-ad profit (€)", "sk": "Post-ad zisk (€)"},
     "orders": {"en": "Orders", "sk": "Objednávky"},
     "aov": {"en": "AOV (net)", "sk": "Priemerná objednávka (netto)"},
     "cac": {"en": "CAC", "sk": "CAC"},
@@ -1755,7 +1755,7 @@ def generate_modern_dashboard(
         {"en": "Pre-ad contribution profit", "sk": "Pre-ad contribution profit", "value": _maybe_num((financial_metrics or {}).get("pre_ad_contribution_profit")), "kind": "currency", "tone": "positive"},
         {"en": "Pre-ad contribution margin", "sk": "Pre-ad contribution marza", "value": _maybe_num((financial_metrics or {}).get("pre_ad_contribution_margin_pct")), "kind": "percent", "tone": "positive"},
         {"en": "Pre-ad contribution / order", "sk": "Pre-ad contribution / objednavka", "value": _maybe_num((financial_metrics or {}).get("pre_ad_contribution_per_order")), "kind": "currency", "tone": "positive", "note_en": "Break-even order contribution", "note_sk": "Break-even contribution na objednavku"},
-        {"en": "Post-ad contribution profit", "sk": "Post-ad contribution profit", "value": _maybe_num((financial_metrics or {}).get("post_ad_contribution_profit")), "kind": "currency", "tone": "positive"},
+        {"en": "Post-ad profit (€)", "sk": "Post-ad zisk (€)", "value": _maybe_num((financial_metrics or {}).get("post_ad_contribution_profit")), "kind": "currency", "tone": "positive", "note_en": "Excludes fixed overhead", "note_sk": "Bez fixneho overheadu"},
         {"en": "Post-ad contribution margin", "sk": "Post-ad contribution marza", "value": _maybe_num((financial_metrics or {}).get("post_ad_contribution_margin_pct")), "kind": "percent", "tone": "positive"},
         {"en": "Post-ad contribution / order", "sk": "Post-ad contribution / objednavka", "value": _maybe_num((financial_metrics or {}).get("post_ad_contribution_profit_per_order")), "kind": "currency", "tone": "positive", "note_en": "Excludes fixed overhead", "note_sk": "Bez fixneho overheadu"},
         {"en": "Break-even CAC", "sk": "Break-even CAC", "value": break_even_cac, "kind": "currency", "tone": "positive"},

--- a/html_report_generator.py
+++ b/html_report_generator.py
@@ -501,7 +501,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
         )
         cfo_top_cards = [
             ("revenue", "Revenue", "Obrat"),
-            ("profit", "Profit", "Zisk"),
+            ("profit", "Post-ad profit (€)", "Post-ad zisk (€)"),
             ("orders", "Orders", "Objednavky"),
             ("aov", "AOV", "Priemerna hodnota objednavky"),
             ("cac", "CAC", "CAC"),
@@ -1892,7 +1892,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                 <div style="color: #718096; font-size: 0.8rem;">Base for payback (order-level)</div>
             </div>
             <div class="card">
-                <div class="card-title">Post-Ad Contribution Profit</div>
+                <div class="card-title">Post-Ad Profit (€)</div>
                 <div class="card-value {'profit' if post_ad_contribution_profit > 0 else 'cost'}">&#8364;{post_ad_contribution_profit:,.2f}</div>
                 <div style="color: #718096; font-size: 0.8rem;">Excludes fixed overhead</div>
             </div>

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -413,7 +413,7 @@ def build_live_dashboard_html(projects: List[str], initial_project: str, initial
         renderCards('contextGrid', [
           { label:text(windowPayload.label_en, 'Current window'), value:text(windowPayload.label_sk, ''), note:'Window definition from generated report', raw:0, className:'value' },
           { label:'Revenue', value:formatMoney(metrics.revenue), note:'Window metric', raw:metrics.revenue },
-          { label:'Profit (pre-fixed)', value:formatMoney(metrics.profit), note:'Window metric', raw:metrics.profit },
+          { label:'Post-ad profit (€)', value:formatMoney(metrics.profit), note:'Excludes fixed overhead', raw:metrics.profit },
           { label:'Orders', value:formatInt(metrics.orders), note:'Window metric', raw:metrics.orders },
           { label:'AOV', value:formatMoney(metrics.aov), note:'Window metric', raw:metrics.aov },
           { label:'CAC', value:formatMoney(metrics.cac), note:'Window metric', raw:metrics.cac ? -metrics.cac : 0 },

--- a/reporting_core/cfo_kpis.py
+++ b/reporting_core/cfo_kpis.py
@@ -339,7 +339,7 @@ def build_cfo_kpi_payload(
 
     metric_defs = [
         {"key": "revenue", "label": "Revenue", "direction": "up"},
-        {"key": "profit", "label": "Profit", "direction": "up"},
+        {"key": "profit", "label": "Post-ad profit (€)", "direction": "up"},
         {"key": "orders", "label": "Orders", "direction": "up"},
         {"key": "aov", "label": "AOV", "direction": "up"},
         {"key": "cac", "label": "CAC", "direction": "down"},

--- a/scripts/reporting_qa_smoke.py
+++ b/scripts/reporting_qa_smoke.py
@@ -349,12 +349,14 @@ def assert_dashboard_consistency_payload_mapping() -> None:
     assert match, "dashboard payload script missing"
     payload = json.loads(match.group(1))
     consistency = payload["consistency"]
+    profit_metric = next(metric for metric in payload["kpis"]["metric_defs"] if metric["key"] == "profit")
     assert math.isclose(float(consistency["roas_delta"]), 0.1234, rel_tol=1e-9, abs_tol=1e-9), consistency
     assert math.isclose(float(consistency["margin_delta"]), -0.02, rel_tol=1e-9, abs_tol=1e-9), consistency
     assert math.isclose(float(consistency["cac_delta"]), 0.56, rel_tol=1e-9, abs_tol=1e-9), consistency
     assert consistency["roas_ok"] is False, consistency
     assert consistency["margin_ok"] is True, consistency
     assert consistency["cac_ok"] is False, consistency
+    assert profit_metric["label_en"] == "Post-ad profit (€)", profit_metric
 
 
 def assert_roy_fixed_cost_source_of_truth() -> None:


### PR DESCRIPTION
## Summary
- clarify that the top KPI profit metric is the absolute post-ad profit layer
- rename the VEVO KPI card and related surfaces to explicit post-ad profit wording
- add smoke coverage for the KPI payload label

## Verification
- python -m py_compile dashboard_modern.py html_report_generator.py reporting_core\\cfo_kpis.py live_dashboard_server.py scripts\\reporting_qa_smoke.py
- python scripts\\reporting_qa_smoke.py