### PR TITLE
Add project-scoped ad spend EUR conversion

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -91,7 +91,8 @@ Bootstrap entrypoints:
   - Google spend retrieval succeeds in the current production report run
 - VEVO production ads connectivity was re-verified on `2026-04-24`:
   - Meta account `Wachman` reports `EUR`
-  - Google Ads initialization currently fails with `invalid_grant`, so VEVO Google spend is not reliable until the secret/auth issue is fixed
+  - Google Ads account `Vevo.sk` reports `EUR`
+  - Google spend retrieval succeeds again after syncing the runtime Google Ads secret with the valid local VEVO project env
 - Fixed `html_report_generator.py` period-switcher syntax so `Env Check` / `reporting_qa_smoke.py` pass again on GitHub Actions and on local Python 3.11.
 - VEVO runtime now supports explicit `fixed_daily_cost`, and March 2026 verification confirms `CM3` now diverges from `CM2` once fixed overhead is applied (`fixed_daily_cost = 70 EUR`).
 - VEVO modern dashboard now surfaces practical marketing decision metrics:
@@ -164,7 +165,6 @@ Bootstrap entrypoints:
 - VEVO now resolves ambiguous shared-EAN fragrance SKUs by exact item label / compound key before identifier fallback, so Natural vs Premium 500ml/200ml lines no longer collapse onto the same cost.
 - ROY now supports project-configured excluded order statuses for realized revenue filtering, so non-revenue final states can be removed without hardcoded edits in `export_orders.py`.
 - Foreign-market ad spend was previously only correct when the ad platform account itself used `EUR`; project-scoped FX conversion is now implemented on branch `codex/ads-currency-by-project`, but it is not production-active until that branch is merged/deployed.
-- VEVO Google Ads production auth is currently the remaining live blocker for complete ad reporting because the runtime hits `invalid_grant` during client initialization.
 - ROY dashboard now exposes product-demand analytics in the active modern report:
   - growing products
   - declining products
@@ -193,7 +193,7 @@ Bootstrap entrypoints:
   - detected account currency per source
   - converted `total_eur`
   - warning/error if a source currency mismatches project config or lacks a conversion rate
-- In parallel, rotate/fix the VEVO Google Ads refresh-token/auth secret, then rerun the VEVO production-equivalent report until Google Ads connects cleanly and daily spend loads again
+- After deploy, rerun the first VEVO and ROY production-equivalent reports and confirm the foreign-market FX path from live source-health output, not only from unit tests
 
 ## 9) Change Log
 
@@ -223,9 +223,22 @@ Bootstrap entrypoints:
   - `vevo-daily-report-email` is enabled at `21:00 Europe/Bratislava`
   - `roy-daily-report-email` is enabled at `21:30 Europe/Bratislava`
   - VEVO Meta account `Wachman` reports `EUR`
-  - VEVO Google Ads client still fails `invalid_grant`
   - ROY Meta account `Roy` reports `EUR`
   - ROY Google Ads account `Roy.sk` reports `EUR` and returns daily spend data
+- Remediated the live VEVO Google Ads runtime secret on `2026-04-24`:
+  - AWS `vevo/reporting/runtime-env` differed from the valid local VEVO project env in:
+    - `GOOGLE_ADS_REFRESH_TOKEN`
+    - `GOOGLE_ADS_LOGIN_CUSTOMER_ID`
+  - synced only the VEVO Google Ads keys in Secrets Manager, preserving the rest of the runtime secret
+  - production-equivalent ECS task `5629eb60c42f4c02bc5dc7fe2220cc8d` on private IP `172.31.9.2` then exited `0`
+  - CloudWatch verification for that task shows:
+    - `Successfully connected to Google Ads account: Vevo.sk`
+    - `Currency: EUR`
+    - `Retrieved Google Ads data for 7 days`
+    - `Retrieved Google Ads data for 11 days`
+    - `Retrieved Google Ads data for 32 days`
+    - `Retrieved Google Ads data for 188 days`
+    - `SES message sent`
 - Added automatic daily invoice-generation wiring for both active reporting clients on task branch `codex/daily-invoice-automation`:
   - `daily_report_runner.py` now supports an invoice step after the daily report flow
   - new runner controls:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -66,9 +66,9 @@ Bootstrap entrypoints:
 - CI validates env contract and blocks tracked secret env files
 - Repo-scoped `PROJECT_STATE.md` exists
 - Bootstrap scripts now exist for macOS/Linux and Windows PowerShell
-- VEVO ECS schedule `vevo-daily-report-email` is enabled for `01:00 Europe/Bratislava`
+- VEVO ECS schedule `vevo-daily-report-email` is enabled for `21:00 Europe/Bratislava`
 - VEVO production task definition `vevo-reporting-daily:4` uses full-history runtime range from `2025-05-03` to `yesterday`
-- ROY ECS schedule `roy-daily-report-email` is enabled for `01:00 Europe/Bratislava`
+- ROY ECS schedule `roy-daily-report-email` is enabled for `21:30 Europe/Bratislava`
 - ROY production task definition `roy-reporting-daily:2` now uses full-history runtime range from `2025-09-24` to `yesterday`
 - VEVO and ROY task-branch runtime now supports automatic daily invoice generation inside the existing daily runner:
   - `daily_report_runner.py` can trigger invoice generation after the report run
@@ -85,6 +85,13 @@ Bootstrap entrypoints:
   - HTML report saved as `data/roy/report_20250924-20260411.html`
   - SES delivery confirmed in CloudWatch logs
   - scheduler target updated to `arn:aws:ecs:eu-central-1:919341186960:task-definition/roy-reporting-daily:2`
+- ROY production ads connectivity was re-verified on `2026-04-24`:
+  - Meta account `Roy` reports `EUR`
+  - Google Ads account `Roy.sk` reports `EUR`
+  - Google spend retrieval succeeds in the current production report run
+- VEVO production ads connectivity was re-verified on `2026-04-24`:
+  - Meta account `Wachman` reports `EUR`
+  - Google Ads initialization currently fails with `invalid_grant`, so VEVO Google spend is not reliable until the secret/auth issue is fixed
 - Fixed `html_report_generator.py` period-switcher syntax so `Env Check` / `reporting_qa_smoke.py` pass again on GitHub Actions and on local Python 3.11.
 - VEVO runtime now supports explicit `fixed_daily_cost`, and March 2026 verification confirms `CM3` now diverges from `CM2` once fixed overhead is applied (`fixed_daily_cost = 70 EUR`).
 - VEVO modern dashboard now surfaces practical marketing decision metrics:
@@ -156,6 +163,8 @@ Bootstrap entrypoints:
 - Biznisweb inventory can expose negative or zero available quantities on active products; the report now flags those rows explicitly instead of crashing, but replenishment response policy is still an open product decision
 - VEVO now resolves ambiguous shared-EAN fragrance SKUs by exact item label / compound key before identifier fallback, so Natural vs Premium 500ml/200ml lines no longer collapse onto the same cost.
 - ROY now supports project-configured excluded order statuses for realized revenue filtering, so non-revenue final states can be removed without hardcoded edits in `export_orders.py`.
+- Foreign-market ad spend was previously only correct when the ad platform account itself used `EUR`; project-scoped FX conversion is now implemented on branch `codex/ads-currency-by-project`, but it is not production-active until that branch is merged/deployed.
+- VEVO Google Ads production auth is currently the remaining live blocker for complete ad reporting because the runtime hits `invalid_grant` during client initialization.
 - ROY dashboard now exposes product-demand analytics in the active modern report:
   - growing products
   - declining products
@@ -180,15 +189,43 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- Merge the daily invoice automation branch through PR, wait for the guarded ECR build, then run manual production-equivalent VEVO and ROY tasks with the infra hard-gate:
-  - confirm scheduler/service name + marker path before deploy verification
-  - verify on host with `curl localhost` marker payload that the daily runner reached the invoice step
-  - confirm CloudWatch output shows invoice summary counts and zero-total skips
-- After production verification, let the next scheduled `vevo-daily-report-email` and `roy-daily-report-email` runs execute normally and compare the first automatic invoice day against BiznisWeb admin output
+- Merge/deploy the ad-currency branch so Meta/Google spend is converted into `EUR` per project settings for VEVO and ROY, then run production-equivalent report tasks with the infra hard-gate and verify the source-health payload/logs expose:
+  - detected account currency per source
+  - converted `total_eur`
+  - warning/error if a source currency mismatches project config or lacks a conversion rate
+- In parallel, rotate/fix the VEVO Google Ads refresh-token/auth secret, then rerun the VEVO production-equivalent report until Google Ads connects cleanly and daily spend loads again
 
 ## 9) Change Log
 
 ### 2026-04-24
+- Added project-scoped ad currency guardrails on branch `codex/ads-currency-by-project` so foreign-market Google/Meta spend can be reported in `EUR` without silently breaking profitability math:
+  - `projects/vevo/settings.json` now declares expected ad-account currency for:
+    - `facebook_ads`
+    - `google_ads`
+  - `projects/roy/settings.json` now declares expected ad-account currency for:
+    - `facebook_ads`
+    - `google_ads`
+  - `facebook_ads.py` now stores the detected ad-account currency during connection test
+  - `google_ads.py` now stores the detected customer currency during connection test
+  - `export_orders.py` now converts daily Google/Meta spend to `EUR` through the project FX map before the spend enters report aggregates
+  - source-health entries now record:
+    - detected currency
+    - expected currency
+    - resolved currency used for conversion
+    - `total_original`
+    - `total_eur`
+  - if an ad source currency mismatches the project config, the run is degraded to `warning` instead of silently using the wrong assumption
+  - if a non-zero ad source currency has no FX rate in the project config, spend is ignored and surfaced as `error` instead of being treated as fake `EUR`
+- Verified locally with:
+  - `python -m py_compile export_orders.py facebook_ads.py google_ads.py tests/test_ads_currency_conversion.py`
+  - `python -m unittest tests.test_ads_currency_conversion tests.test_invoice_generation`
+- Verified live runtime state with AWS reads on `2026-04-24`:
+  - `vevo-daily-report-email` is enabled at `21:00 Europe/Bratislava`
+  - `roy-daily-report-email` is enabled at `21:30 Europe/Bratislava`
+  - VEVO Meta account `Wachman` reports `EUR`
+  - VEVO Google Ads client still fails `invalid_grant`
+  - ROY Meta account `Roy` reports `EUR`
+  - ROY Google Ads account `Roy.sk` reports `EUR` and returns daily spend data
 - Added automatic daily invoice-generation wiring for both active reporting clients on task branch `codex/daily-invoice-automation`:
   - `daily_report_runner.py` now supports an invoice step after the daily report flow
   - new runner controls:

--- a/export_orders.py
+++ b/export_orders.py
@@ -65,6 +65,7 @@ except ImportError:
     class FacebookAdsClient:
         def __init__(self):
             self.is_configured = False
+            self.account_currency = None
         def get_daily_spend(self, *args, **kwargs):
             return {}
 
@@ -76,6 +77,7 @@ except ImportError:
     class GoogleAdsClient:
         def __init__(self):
             self.is_configured = False
+            self.customer_currency = None
         def get_daily_spend(self, *args, **kwargs):
             return {}
 
@@ -746,6 +748,133 @@ class BizniWebExporter:
             return float(value)
         except (TypeError, ValueError):
             return None
+
+    @staticmethod
+    def _normalize_currency_code(value: Any) -> str:
+        return str(value or "").strip().upper()
+
+    def _get_ads_currency_settings(self, source_key: str) -> Dict[str, Any]:
+        raw = (((self.project_settings or {}).get("ads_currency") or {}).get(source_key) or {})
+        expected_currency = self._normalize_currency_code(raw.get("expected_currency") or "EUR") or "EUR"
+        return {
+            "expected_currency": expected_currency,
+            "report_currency": "EUR",
+        }
+
+    def _convert_daily_spend_map(self, daily_spend: Dict[str, float], currency: str) -> Dict[str, float]:
+        normalized: Dict[str, float] = {}
+        for date_key, raw_amount in (daily_spend or {}).items():
+            normalized[str(date_key)] = self.convert_to_eur(self._safe_float(raw_amount) or 0.0, currency)
+        return normalized
+
+    def _apply_ads_currency_handling(
+        self,
+        *,
+        source_key: str,
+        label: str,
+        daily_spend: Dict[str, float],
+        detected_currency: Optional[str],
+        source_entry: Dict[str, Any],
+    ) -> Tuple[Dict[str, float], Dict[str, Any]]:
+        entry = dict(source_entry or {})
+        settings = self._get_ads_currency_settings(source_key)
+        expected_currency = settings["expected_currency"]
+        detected_currency_code = self._normalize_currency_code(detected_currency)
+        resolved_currency = detected_currency_code or expected_currency or "EUR"
+        total_original = round(sum(self._safe_float(value) or 0.0 for value in (daily_spend or {}).values()), 2)
+        has_nonzero_spend = any(abs(self._safe_float(value) or 0.0) > 1e-9 for value in (daily_spend or {}).values())
+
+        notes: List[str] = []
+        warnings: List[str] = []
+
+        if detected_currency_code:
+            notes.append(f"Account currency {detected_currency_code}.")
+        elif expected_currency:
+            warnings.append(
+                f"{label} API did not return account currency; using project-configured {expected_currency}."
+            )
+            notes.append(f"API did not return currency, using project-configured {expected_currency}.")
+        else:
+            warnings.append(f"{label} account currency is unknown; assuming EUR.")
+            notes.append("API did not return currency, assuming EUR.")
+            resolved_currency = "EUR"
+
+        if detected_currency_code and expected_currency and detected_currency_code != expected_currency:
+            warnings.append(
+                f"{label} API returned {detected_currency_code}, while project config expects {expected_currency}."
+            )
+            notes.append(
+                f"Project expects {expected_currency}, but EUR conversion uses detected {detected_currency_code}."
+            )
+
+        conversion_rate = CURRENCY_RATES_TO_EUR.get(resolved_currency)
+        if conversion_rate is None:
+            status = "error" if has_nonzero_spend else "warning"
+            warning_message = (
+                f"{label} spend currency {resolved_currency} has no EUR conversion rate in project settings. "
+                "Spend was ignored to avoid reporting wrong values."
+            )
+            warnings.append(warning_message)
+            logger.warning(warning_message)
+            print(f"Warning: {warning_message}")
+            entry.update(
+                {
+                    "status": status,
+                    "healthy": False,
+                    "account_currency": detected_currency_code or None,
+                    "expected_currency": expected_currency or None,
+                    "resolved_currency": resolved_currency or None,
+                    "report_currency": settings["report_currency"],
+                    "currency_conversion_applied": False,
+                    "conversion_rate_to_eur": None,
+                    "total_original": total_original,
+                    "total_eur": 0.0,
+                    "warnings": warnings,
+                }
+            )
+            base_message = str(entry.get("message", "")).strip()
+            entry["message"] = " ".join(part for part in [base_message, warning_message] if part).strip()
+            return {}, entry
+
+        converted_daily_spend = (
+            dict(daily_spend)
+            if resolved_currency == "EUR"
+            else self._convert_daily_spend_map(daily_spend, resolved_currency)
+        )
+        total_eur = round(sum(self._safe_float(value) or 0.0 for value in converted_daily_spend.values()), 2)
+
+        if resolved_currency == "EUR":
+            notes.append("Spend already denominated in EUR.")
+        else:
+            notes.append(f"Converted spend from {resolved_currency} to EUR using rate {conversion_rate:.6f}.")
+
+        if warnings and entry.get("status") == "ok":
+            entry["status"] = "warning"
+            entry["healthy"] = False
+
+        for warning in warnings:
+            logger.warning(warning)
+            print(f"Warning: {warning}")
+
+        entry.update(
+            {
+                "account_currency": detected_currency_code or None,
+                "expected_currency": expected_currency or None,
+                "resolved_currency": resolved_currency or None,
+                "report_currency": settings["report_currency"],
+                "currency_conversion_applied": bool(resolved_currency and resolved_currency != "EUR"),
+                "conversion_rate_to_eur": float(conversion_rate),
+                "total_original": total_original,
+                "total_eur": total_eur,
+            }
+        )
+        if warnings:
+            entry["warnings"] = warnings
+
+        base_message = str(entry.get("message", "")).strip()
+        detail_message = " ".join(notes).strip()
+        entry["message"] = " ".join(part for part in [base_message, detail_message] if part).strip()
+        return converted_daily_spend, entry
 
     @staticmethod
     def _count_missing_values(frame: pd.DataFrame, column: str) -> int:
@@ -3742,6 +3871,13 @@ class BizniWebExporter:
                     campaign_count=len(fb_campaigns),
                     hourly_rows=len(fb_hourly_stats),
                 )
+                fb_daily_spend, source_health["sources"]["facebook_ads"] = self._apply_ads_currency_handling(
+                    source_key="facebook_ads",
+                    label="Facebook Ads",
+                    daily_spend=fb_daily_spend,
+                    detected_currency=getattr(self.fb_client, "account_currency", None),
+                    source_entry=source_health["sources"]["facebook_ads"],
+                )
         elif MANUAL_FB_ADS_TOTAL is not None:
             source_health["sources"]["facebook_ads"] = self._build_source_entry(
                 key="facebook_ads",
@@ -3807,6 +3943,13 @@ class BizniWebExporter:
                     message=f"Google Ads API connected successfully. Daily spend loaded for {len(google_ads_daily_spend)} active days.",
                     healthy=True,
                     active_days=len(google_ads_daily_spend),
+                )
+                google_ads_daily_spend, source_health["sources"]["google_ads"] = self._apply_ads_currency_handling(
+                    source_key="google_ads",
+                    label="Google Ads",
+                    daily_spend=google_ads_daily_spend,
+                    detected_currency=getattr(self.google_ads_client, "customer_currency", None),
+                    source_entry=source_health["sources"]["google_ads"],
                 )
         elif MANUAL_GOOGLE_ADS_TOTAL is not None:
             source_health["sources"]["google_ads"] = self._build_source_entry(

--- a/facebook_ads.py
+++ b/facebook_ads.py
@@ -31,6 +31,8 @@ class FacebookAdsClient:
         self.ad_account_id = os.getenv('FACEBOOK_AD_ACCOUNT_ID')
         self.app_id = os.getenv('FACEBOOK_APP_ID')
         self.app_secret = os.getenv('FACEBOOK_APP_SECRET')
+        self.account_name = None
+        self.account_currency = None
         self.request_timeout = resolve_timeout(os.getenv('FACEBOOK_API_TIMEOUT_SEC'))
         
         # API version - use latest stable version
@@ -747,6 +749,8 @@ class FacebookAdsClient:
             }
             
             data = self._get_json(url, params, "Failed to connect to Facebook Ads API")
+            self.account_name = str(data.get('name', '')).strip() or None
+            self.account_currency = str(data.get('currency', '')).strip().upper() or None
             logger.info(f"Successfully connected to Facebook Ads account: {data.get('name', 'Unknown')}")
             logger.info(f"Account currency: {data.get('currency', 'Unknown')}")
 

--- a/google_ads.py
+++ b/google_ads.py
@@ -26,6 +26,8 @@ class GoogleAdsClient:
         self.refresh_token = os.getenv('GOOGLE_ADS_REFRESH_TOKEN')
         self.customer_id = os.getenv('GOOGLE_ADS_CUSTOMER_ID', '7592903323')
         self.login_customer_id = os.getenv('GOOGLE_ADS_LOGIN_CUSTOMER_ID')  # Optional, for MCC accounts
+        self.customer_name = None
+        self.customer_currency = None
         
         # Cache configuration
         base_data_dir = Path(os.getenv('REPORT_DATA_DIR', 'data'))
@@ -310,6 +312,8 @@ class GoogleAdsClient:
             
             # Process the response
             for row in response:
+                self.customer_name = str(row.customer.descriptive_name).strip() or None
+                self.customer_currency = str(row.customer.currency_code).strip().upper() or None
                 logger.info(f"Successfully connected to Google Ads account: {row.customer.descriptive_name}")
                 logger.info(f"Customer ID: {row.customer.id}")
                 logger.info(f"Currency: {row.customer.currency_code}")

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -465,5 +465,13 @@
     "HUF": 0.0025,
     "PLN": 0.23,
     "USD": 0.92
+  },
+  "ads_currency": {
+    "facebook_ads": {
+      "expected_currency": "EUR"
+    },
+    "google_ads": {
+      "expected_currency": "EUR"
+    }
   }
 }

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -132,5 +132,13 @@
     "HUF": 0.0025,
     "PLN": 0.23,
     "USD": 0.92
+  },
+  "ads_currency": {
+    "facebook_ads": {
+      "expected_currency": "EUR"
+    },
+    "google_ads": {
+      "expected_currency": "EUR"
+    }
   }
 }

--- a/tests/test_ads_currency_conversion.py
+++ b/tests/test_ads_currency_conversion.py
@@ -1,0 +1,125 @@
+import unittest
+from unittest.mock import patch
+
+import export_orders
+from reporting_core.config import load_project_settings
+
+
+class AdsCurrencyConversionTests(unittest.TestCase):
+    def _make_exporter(self, project_settings=None):
+        exporter = export_orders.BizniWebExporter.__new__(export_orders.BizniWebExporter)
+        exporter.project_name = "test_project"
+        exporter.project_settings = project_settings or {}
+        return exporter
+
+    def _make_source_entry(self, key: str, label: str):
+        return export_orders.BizniWebExporter._build_source_entry(
+            key=key,
+            label=label,
+            status="ok",
+            mode="api",
+            message=f"{label} API connected successfully.",
+            healthy=True,
+            active_days=2,
+        )
+
+    def test_project_settings_define_ads_currency_for_vevo_and_roy(self) -> None:
+        vevo_settings = load_project_settings("vevo")
+        roy_settings = load_project_settings("roy")
+
+        self.assertEqual("EUR", vevo_settings["ads_currency"]["facebook_ads"]["expected_currency"])
+        self.assertEqual("EUR", vevo_settings["ads_currency"]["google_ads"]["expected_currency"])
+        self.assertEqual("EUR", roy_settings["ads_currency"]["facebook_ads"]["expected_currency"])
+        self.assertEqual("EUR", roy_settings["ads_currency"]["google_ads"]["expected_currency"])
+
+    def test_detected_foreign_currency_spend_is_converted_to_eur(self) -> None:
+        exporter = self._make_exporter(
+            {
+                "ads_currency": {
+                    "google_ads": {
+                        "expected_currency": "PLN",
+                    }
+                }
+            }
+        )
+        entry = self._make_source_entry("google_ads", "Google Ads")
+
+        with patch.dict(export_orders.CURRENCY_RATES_TO_EUR, {"EUR": 1.0, "PLN": 0.23}, clear=True):
+            converted_spend, updated_entry = exporter._apply_ads_currency_handling(
+                source_key="google_ads",
+                label="Google Ads",
+                daily_spend={"2026-04-01": 100.0, "2026-04-02": 50.0},
+                detected_currency="PLN",
+                source_entry=entry,
+            )
+
+        self.assertAlmostEqual(23.0, converted_spend["2026-04-01"])
+        self.assertAlmostEqual(11.5, converted_spend["2026-04-02"])
+        self.assertEqual("ok", updated_entry["status"])
+        self.assertTrue(updated_entry["currency_conversion_applied"])
+        self.assertEqual("PLN", updated_entry["resolved_currency"])
+        self.assertEqual("EUR", updated_entry["report_currency"])
+        self.assertAlmostEqual(150.0, updated_entry["total_original"])
+        self.assertAlmostEqual(34.5, updated_entry["total_eur"])
+
+    def test_currency_mismatch_warns_but_uses_detected_currency(self) -> None:
+        exporter = self._make_exporter(
+            {
+                "ads_currency": {
+                    "facebook_ads": {
+                        "expected_currency": "EUR",
+                    }
+                }
+            }
+        )
+        entry = self._make_source_entry("facebook_ads", "Facebook Ads")
+
+        with patch.dict(export_orders.CURRENCY_RATES_TO_EUR, {"EUR": 1.0, "PLN": 0.23}, clear=True):
+            converted_spend, updated_entry = exporter._apply_ads_currency_handling(
+                source_key="facebook_ads",
+                label="Facebook Ads",
+                daily_spend={"2026-04-01": 100.0},
+                detected_currency="PLN",
+                source_entry=entry,
+            )
+
+        self.assertAlmostEqual(23.0, converted_spend["2026-04-01"])
+        self.assertEqual("warning", updated_entry["status"])
+        self.assertTrue(
+            any("API returned PLN, while project config expects EUR." in warning for warning in updated_entry["warnings"])
+        )
+        self.assertIn("detected PLN", updated_entry["message"])
+        self.assertEqual("PLN", updated_entry["resolved_currency"])
+        self.assertAlmostEqual(23.0, updated_entry["total_eur"])
+
+    def test_missing_conversion_rate_ignores_spend_to_prevent_wrong_reporting(self) -> None:
+        exporter = self._make_exporter(
+            {
+                "ads_currency": {
+                    "google_ads": {
+                        "expected_currency": "RON",
+                    }
+                }
+            }
+        )
+        entry = self._make_source_entry("google_ads", "Google Ads")
+
+        with patch.dict(export_orders.CURRENCY_RATES_TO_EUR, {"EUR": 1.0}, clear=True):
+            converted_spend, updated_entry = exporter._apply_ads_currency_handling(
+                source_key="google_ads",
+                label="Google Ads",
+                daily_spend={"2026-04-01": 100.0},
+                detected_currency="RON",
+                source_entry=entry,
+            )
+
+        self.assertEqual({}, converted_spend)
+        self.assertEqual("error", updated_entry["status"])
+        self.assertFalse(updated_entry["currency_conversion_applied"])
+        self.assertAlmostEqual(100.0, updated_entry["total_original"])
+        self.assertAlmostEqual(0.0, updated_entry["total_eur"])
+        self.assertIn("no EUR conversion rate", updated_entry["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert Google and Meta daily spend into EUR before it enters reporting aggregates
- keep VEVO and ROY expectations separated in project settings
- surface currency mismatches or missing FX rates in source health instead of silently reporting wrong values

## Verification
- python -m py_compile export_orders.py facebook_ads.py google_ads.py tests/test_ads_currency_conversion.py
- python -m unittest tests.test_ads_currency_conversion tests.test_invoice_generation

## Live findings
- ROY Meta and Google currently report EUR and Google spend retrieval succeeds
- VEVO Meta currently reports EUR
- VEVO Google Ads still fails invalid_grant in production and needs secret/auth remediation separately
