### PR TITLE
Fix daily invoice generation

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-04-28
+Last updated: 2026-05-04
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -79,6 +79,7 @@ Bootstrap entrypoints:
   - zero-total orders are excluded before invoice creation
   - invoice pagination now fetches newest orders first and stops once it passes the configured invoice window
   - invoice debug logging now redacts auth headers instead of printing API tokens
+  - `2026-05-04` production catch-up generated all currently eligible missing invoices for `2026-05-01..2026-05-04`: VEVO `16/16`, ROY `15/15`, with post-run API audit showing `eligible_missing_invoice=0` for both projects
 - Production schedule drift from the evening cadence was corrected on `2026-04-28`:
   - VEVO `21:00 Europe/Bratislava` -> `01:00 Europe/Bratislava`
   - ROY `21:30 Europe/Bratislava` -> `01:30 Europe/Bratislava`
@@ -187,13 +188,41 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- Monitor the first split production cycle:
-  - on `2026-04-28`, confirm `vevo-daily-invoice-generation` starts at `20:00 Europe/Bratislava` and `roy-daily-invoice-generation` starts at `20:30 Europe/Bratislava`
-  - confirm CloudWatch invoice summaries show no unexpected create failures
-  - on `2026-04-29`, confirm `vevo-daily-report-email` starts at `01:00 Europe/Bratislava` and `roy-daily-report-email` starts at `01:30 Europe/Bratislava`
-  - confirm report logs say invoice generation was skipped, and report emails cover the completed previous day
+- After `2026-05-04 20:30 Europe/Bratislava`, verify the next scheduled invoice runs:
+  - confirm `vevo-daily-invoice-generation` and `roy-daily-invoice-generation` run on schedule
+  - confirm CloudWatch summaries show `failed=0`
+  - if a material backlog appears again after a successful scheduled run, move the invoice schedule later or add a second post-fulfillment catch-up run
 
 ## 9) Change Log
+
+### 2026-05-04
+- Investigated why VEVO and ROY invoices were not generated for recent eligible orders.
+- Confirmed hard-gate runtime context:
+  - instance-id/IP: `N/A` as invoice automation runs on scheduled ECS/Fargate tasks, not a fixed EC2 host
+  - service/schedule names: `vevo-daily-invoice-generation`, `roy-daily-invoice-generation`
+  - task definitions: `vevo-invoice-daily:1`, `roy-invoice-daily:1`
+  - image path: `919341186960.dkr.ecr.eu-central-1.amazonaws.com/vevo-reporting:latest`
+  - image digest verified on host tasks: `sha256:050350f9f8b9e76bec170935a8c9dbffbb1a9044b42b35f78435249a3c8bbe90`
+  - log paths: `/ecs/vevo-invoice-daily`, `/ecs/roy-invoice-daily`
+- Confirmed both EventBridge Scheduler jobs are `ENABLED`:
+  - VEVO `cron(0 20 * * ? *)` in `Europe/Bratislava`
+  - ROY `cron(30 20 * * ? *)` in `Europe/Bratislava`
+- Reviewed CloudWatch invoice logs from `2026-05-01..2026-05-03`:
+  - scheduled jobs started, logged in to BizniWeb successfully, fetched orders, and exited cleanly
+  - each scheduled run ended with `matched=0`, so no invoices were created during those runs
+- Ran production dry-run diagnostics with direct host marker verification:
+  - VEVO dry-run task `e3083d578c654911819584773a9ed533`, private IP `172.31.1.75`, marker `LOCALHOST_MARKER_OK:vevo:invoice-dry-run`, matched `16`, failed `0`
+  - ROY dry-run task `fcaea9db308c42578b46e4d0942bfb0f`, private IP `172.31.46.195`, marker `LOCALHOST_MARKER_OK:roy:invoice-dry-run`, matched `15`, failed `0`
+- Ran production Fargate invoice catch-up for `2026-05-01..2026-05-04`:
+  - VEVO catch-up task `3436093656e94dfbac9f8c329f2bdf93`, private IP `172.31.40.111`, marker `LOCALHOST_MARKER_OK:vevo:invoice-catchup`, created `16`, failed `0`
+  - ROY catch-up task `b312e817c0274cc7becd2f602a70bb1d`, private IP `172.31.38.114`, marker `LOCALHOST_MARKER_OK:roy:invoice-catchup`, created `15`, failed `0`
+- Verified live BizniWeb API after catch-up:
+  - VEVO `eligible_missing_invoice=0` for `2026-05-01..2026-05-04`
+  - ROY `eligible_missing_invoice=0` for `2026-05-01..2026-05-04`
+- Operational conclusion:
+  - automation was not down; the previous scheduled runs had no eligible `Odoslana`/no-invoice orders at the time they ran
+  - the missing invoices became eligible before the next scheduled evening run, so the one-off catch-up closed the backlog early
+  - if this repeats after normal fulfillment timing, adjust invoice run timing or add a second daily catch-up pass
 
 ### 2026-04-28
 - Fixed reporting calculation issues found during VEVO/ROY audit:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-05-04
+Last updated: 2026-05-07
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -71,8 +71,8 @@ Bootstrap entrypoints:
 - ROY report schedule `roy-daily-report-email` is enabled for `01:30 Europe/Bratislava`
 - ROY production report task definition `roy-reporting-daily:3` uses full-history runtime range from `2025-09-24` to `yesterday` and sets `REPORT_SKIP_INVOICES=true`
 - Invoice generation is separated from reporting in production:
-  - VEVO invoice schedule `vevo-daily-invoice-generation` is enabled for `20:00 Europe/Bratislava` and targets `vevo-invoice-daily:1`
-  - ROY invoice schedule `roy-daily-invoice-generation` is enabled for `20:30 Europe/Bratislava` and targets `roy-invoice-daily:1`
+  - VEVO invoice schedule `vevo-daily-invoice-generation` is enabled for `23:00 Europe/Bratislava` and targets `vevo-invoice-daily:1`
+  - ROY invoice schedule `roy-daily-invoice-generation` is enabled for `23:30 Europe/Bratislava` and targets `roy-invoice-daily:1`
   - invoice task definitions run `python generate_invoices.py --project <project>` on the same production image
   - `daily_report_runner.py` now defaults to report-only behavior; `invoice_runner.py` is the repo-local standalone invoice runner for the next production image
   - `projects/vevo/settings.json` and `projects/roy/settings.json` keep separate project-owned `report_schedule` and `invoice_generation` schedule metadata
@@ -80,6 +80,7 @@ Bootstrap entrypoints:
   - invoice pagination now fetches newest orders first and stops once it passes the configured invoice window
   - invoice debug logging now redacts auth headers instead of printing API tokens
   - `2026-05-04` production catch-up generated all currently eligible missing invoices for `2026-05-01..2026-05-04`: VEVO `16/16`, ROY `15/15`, with post-run API audit showing `eligible_missing_invoice=0` for both projects
+  - `2026-05-07` production fix normalizes Slovak diacritics before status matching, so `Caka na vybavenie` / `Čaká na vybavenie` is eligible as intended; current ECR `latest` digest is `sha256:b44976b106aa1ca5f2e7daf849be3204c51869a1cc6f6fe935425f27fa781831`
 - Production schedule drift from the evening cadence was corrected on `2026-04-28`:
   - VEVO `21:00 Europe/Bratislava` -> `01:00 Europe/Bratislava`
   - ROY `21:30 Europe/Bratislava` -> `01:30 Europe/Bratislava`
@@ -188,12 +189,54 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- After `2026-05-04 20:30 Europe/Bratislava`, verify the next scheduled invoice runs:
-  - confirm `vevo-daily-invoice-generation` and `roy-daily-invoice-generation` run on schedule
+- After `2026-05-07 23:30 Europe/Bratislava`, verify the next scheduled invoice runs:
+  - confirm `vevo-daily-invoice-generation` runs at `23:00 Europe/Bratislava` and `roy-daily-invoice-generation` runs at `23:30 Europe/Bratislava`
   - confirm CloudWatch summaries show `failed=0`
-  - if a material backlog appears again after a successful scheduled run, move the invoice schedule later or add a second post-fulfillment catch-up run
+  - confirm a post-run API audit shows `eligible_missing_invoice=0` for both projects
 
 ## 9) Change Log
+
+### 2026-05-07
+- Re-investigated VEVO/ROY invoice generation after another missing-invoice report.
+- Confirmed hard-gate runtime context:
+  - instance-id/IP: `N/A` because invoice automation runs on scheduled ECS/Fargate tasks, not a fixed EC2 host
+  - service/schedule names: `vevo-daily-invoice-generation`, `roy-daily-invoice-generation`
+  - task definitions: `vevo-invoice-daily:1`, `roy-invoice-daily:1`
+  - image path: `919341186960.dkr.ecr.eu-central-1.amazonaws.com/vevo-reporting:latest`
+  - log paths: `/ecs/vevo-invoice-daily`, `/ecs/roy-invoice-daily`
+- Confirmed the root causes:
+  - schedulers were not down; CloudWatch showed successful runs on `2026-05-04`, `2026-05-05`, and `2026-05-06`, with created invoices and `failed=0`
+  - orders continued becoming invoice-eligible after the previous `20:00/20:30` run times
+  - `_status_matches_invoice_generation(...)` did not normalize Slovak diacritics, so `Čaká na vybavenie` did not match the intended `cak` + `vybaven` rule
+- Fixed and verified invoice eligibility:
+  - added diacritic normalization before invoice status matching in `generate_invoices.py`
+  - added regression coverage for `Odoslaná`, `Čaká na vybavenie`, `Čaká na úhradu`, and expired online payments
+  - local dry-run after the fix matched VEVO `8` and ROY `9`, including `Čaká na vybavenie`
+- Moved production invoice schedules later in the day:
+  - VEVO `cron(0 20 * * ? *)` -> `cron(0 23 * * ? *)`
+  - ROY `cron(30 20 * * ? *)` -> `cron(30 23 * * ? *)`
+  - confirmed both EventBridge Scheduler jobs remain `ENABLED`
+- Verified locally before deploy:
+  - `python -m py_compile generate_invoices.py invoice_runner.py daily_report_runner.py`
+  - `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python scripts\security_ci.py`
+- Deployed refreshed production image through guarded GitHub Actions workflow:
+  - workflow: `Build and Push ECR`
+  - run: `25492945637`
+  - branch: `codex/invoice-catchup-state-20260504`
+  - result: `success`
+  - ECR `latest` digest: `sha256:b44976b106aa1ca5f2e7daf849be3204c51869a1cc6f6fe935425f27fa781831`
+- Ran production Fargate dry-run diagnostics on the refreshed image with direct host marker verification:
+  - VEVO dry-run task `bf08ecb50f4443d793ae709818b177bd`, private IP `172.31.1.212`, marker `LOCALHOST_MARKER_OK:vevo:invoice-fix-dry-run`, matched `8`, failed `0`
+  - ROY dry-run task `5457ec4f1c334af488dcec769d4aa958`, private IP `172.31.4.43`, marker `LOCALHOST_MARKER_OK:roy:invoice-fix-dry-run`, matched `9`, failed `0`
+- Ran production Fargate invoice catch-up for `2026-05-04..2026-05-07`:
+  - VEVO catch-up task `1b28857e31434fbe80b06484a8d7c149`, private IP `172.31.46.210`, marker `LOCALHOST_MARKER_OK:vevo:invoice-fix-catchup`, created `8`, failed `0`
+  - ROY catch-up task `dd1c5cd25f814c6a844e822dc724f303`, private IP `172.31.44.51`, marker `LOCALHOST_MARKER_OK:roy:invoice-fix-catchup`, created `9`, failed `0`
+- Verified live BizniWeb API after catch-up:
+  - VEVO `eligible_missing_invoice=0` for `2026-05-04..2026-05-07`
+  - ROY `eligible_missing_invoice=0` for `2026-05-04..2026-05-07`
+  - remaining missing invoices are only noneligible statuses: expired/declined online payments, `Storno`, `Čaká na úhradu`
 
 ### 2026-05-04
 - Investigated why VEVO and ROY invoices were not generated for recent eligible orders.

--- a/generate_invoices.py
+++ b/generate_invoices.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional, Tuple, Union
 import json
 import re
+import unicodedata
 
 from dotenv import load_dotenv
 from gql import gql, Client
@@ -183,8 +184,14 @@ def _coerce_order_total_value(order: Dict[str, Any]) -> float:
         return 0.0
 
 
+def _normalize_status_text(status_name: str) -> str:
+    normalized = unicodedata.normalize("NFKD", status_name or "")
+    without_marks = "".join(char for char in normalized if not unicodedata.combining(char))
+    return without_marks.strip().lower()
+
+
 def _status_matches_invoice_generation(status_name: str) -> bool:
-    normalized = (status_name or "").strip().lower()
+    normalized = _normalize_status_text(status_name)
     return "odoslan" in normalized or ("cak" in normalized and "vybaven" in normalized)
 
 

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -18,7 +18,7 @@
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
     "schedule_name": "roy-daily-invoice-generation",
-    "schedule_expression": "cron(30 20 * * ? *)",
+    "schedule_expression": "cron(30 23 * * ? *)",
     "timezone": "Europe/Bratislava",
     "task_family": "roy-invoice-daily"
   },

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -22,7 +22,7 @@
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
     "schedule_name": "vevo-daily-invoice-generation",
-    "schedule_expression": "cron(0 20 * * ? *)",
+    "schedule_expression": "cron(0 23 * * ? *)",
     "timezone": "Europe/Bratislava",
     "task_family": "vevo-invoice-daily"
   },

--- a/templates/reporting-client/settings.template.json
+++ b/templates/reporting-client/settings.template.json
@@ -19,7 +19,7 @@
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
     "schedule_name": "__CLIENT_SLUG__-daily-invoice-generation",
-    "schedule_expression": "cron(0 20 * * ? *)",
+    "schedule_expression": "cron(0 23 * * ? *)",
     "timezone": "Europe/Bratislava",
     "task_family": "__CLIENT_SLUG__-invoice-daily"
   },

--- a/tests/test_invoice_generation.py
+++ b/tests/test_invoice_generation.py
@@ -7,6 +7,7 @@ from daily_report_runner import maybe_run_invoice_automation, parse_args as pars
 from generate_invoices import (
     InvoiceGenerator,
     InvoiceRunSummary,
+    _status_matches_invoice_generation,
     resolve_invoice_date_window,
     resolve_invoice_generation_settings,
 )
@@ -26,6 +27,12 @@ class InvoiceGenerationTests(unittest.TestCase):
     def test_resolve_invoice_date_window_uses_rolling_lookback(self) -> None:
         from_date, to_date = resolve_invoice_date_window("2026-04-24", 7)
         self.assertEqual(("2026-04-18", "2026-04-24"), (from_date, to_date))
+
+    def test_invoice_status_matching_handles_slovak_diacritics(self) -> None:
+        self.assertTrue(_status_matches_invoice_generation("Odoslan\u00e1"))
+        self.assertTrue(_status_matches_invoice_generation("\u010cak\u00e1 na vybavenie"))
+        self.assertFalse(_status_matches_invoice_generation("\u010cak\u00e1 na \u00fahradu"))
+        self.assertFalse(_status_matches_invoice_generation("Platba online - platnos\u0165 vypr\u0161ala"))
 
     def test_invoice_runner_uses_current_day_reference_window(self) -> None:
         settings = {"invoice_generation": {"enabled": True, "lookback_days": 7}}


### PR DESCRIPTION
## Summary
- normalize invoice status matching so Slovak diacritics do not block Čaká na vybavenie
- move VEVO/ROY invoice schedules to 23:00/23:30 Europe/Bratislava
- record production catch-up and deployment verification in PROJECT_STATE

## Verification
- python -m py_compile generate_invoices.py invoice_runner.py daily_report_runner.py
- python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes
- python scripts/reporting_qa_smoke.py
- python scripts/security_ci.py
- GitHub Actions Build and Push ECR run 25492945637 succeeded
- production Fargate dry-run + catch-up verified with localhost markers
