### PR TITLE
Restrict invoice generation to shipped orders

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -82,7 +82,8 @@ Bootstrap entrypoints:
   - invoice pagination now fetches newest orders first and stops once it passes the configured invoice window
   - invoice debug logging now redacts auth headers instead of printing API tokens
   - `2026-05-04` production catch-up generated all currently eligible missing invoices for `2026-05-01..2026-05-04`: VEVO `16/16`, ROY `15/15`, with post-run API audit showing `eligible_missing_invoice=0` for both projects
-  - `2026-05-07` production fix normalizes Slovak diacritics before status matching, so `Caka na vybavenie` / `Čaká na vybavenie` is eligible as intended; current verified ECR `latest` digest for the scheduled invoice tasks is `sha256:78d9c0b56ec0cf5b0f1300062bf3b408967ff54c4ad5e3f28d0467e71e705e7a`
+  - `2026-05-09` incident fix restricts invoice eligibility to exact configured shipped statuses only: VEVO/ROY `eligible_statuses = ["Odoslaná"]`; `Čaká na vybavenie` is not eligible
+  - production invoice schedules were temporarily disabled on `2026-05-09` while the shipped-only fix is deployed and verified
 - Production schedule drift from the evening cadence was corrected on `2026-04-28`:
   - VEVO `21:00 Europe/Bratislava` -> `01:00 Europe/Bratislava`
   - ROY `21:30 Europe/Bratislava` -> `01:30 Europe/Bratislava`
@@ -191,13 +192,37 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- After `2026-05-07 23:59 Europe/Bratislava`, verify the final same-day sweeps:
-  - confirm `vevo-same-day-invoice-sweep` ran at `23:58 Europe/Bratislava` and `roy-same-day-invoice-sweep` ran at `23:59 Europe/Bratislava`
-  - confirm CloudWatch summaries show `failed=0`
-  - confirm a post-run API audit shows `eligible_missing_invoice=0` for both projects
-  - if any order becomes eligible after the final sweep, add a BizniWeb status-change webhook/event path instead of relying only on polling
+- Merge and deploy the shipped-only invoice eligibility fix:
+  - wait for guarded ECR build on `main`
+  - verify directly on Fargate with `curl localhost` marker and assertions that `Odoslaná` is eligible and `Čaká na vybavenie` is not
+  - run dry-run invoice audits for VEVO/ROY before re-enabling schedules
+  - re-enable the four invoice schedules only after the fixed production image is verified
 
 ## 9) Change Log
+
+### 2026-05-09
+- Investigated accidental invoice creation for orders that were not shipped yet.
+- Confirmed immediate hard-gate runtime context:
+  - instance-id/IP: `N/A` because invoice automation runs on scheduled ECS/Fargate tasks
+  - service/schedule names: `vevo-daily-invoice-generation`, `vevo-same-day-invoice-sweep`, `roy-daily-invoice-generation`, `roy-same-day-invoice-sweep`
+  - task definitions: `vevo-invoice-daily:2`, `roy-invoice-daily:2`
+  - image path: `919341186960.dkr.ecr.eu-central-1.amazonaws.com/vevo-reporting:latest`
+  - log paths: `/ecs/vevo-invoice-daily`, `/ecs/roy-invoice-daily`
+- Temporarily disabled all four production invoice schedules to stop further invoice creation during the fix.
+- Root cause:
+  - `_status_matches_invoice_generation(...)` used substring logic: `odoslan` OR (`cak` AND `vybaven`)
+  - that made `Čaká na vybavenie` invoice-eligible even though it is not a shipped status
+  - tests also incorrectly asserted `Čaká na vybavenie` as eligible
+- Corrected the source-of-truth rule:
+  - invoice generation now uses exact normalized allow-list matching
+  - VEVO and ROY project settings set `invoice_generation.eligible_statuses = ["Odoslaná"]`
+  - `Čaká na vybavenie`, `Čaká na úhradu`, expired online payments, and composite statuses like `madfrog stara odoslana` are not eligible
+- Local verification before deploy:
+  - `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python scripts\security_ci.py`
+  - `git diff --check`
+  - local live API dry-runs for `2026-05-07..2026-05-09` returned `matched=0` for both VEVO and ROY with the shipped-only rule
 
 ### 2026-05-07
 - Re-investigated VEVO/ROY invoice generation after another missing-invoice report.

--- a/generate_invoices.py
+++ b/generate_invoices.py
@@ -7,7 +7,7 @@ import os
 import argparse
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Dict, List, Any, Optional, Tuple, Union
+from typing import Dict, List, Any, Iterable, Optional, Tuple, Union
 import json
 import re
 import unicodedata
@@ -35,6 +35,7 @@ WEB_TIMEOUT = resolve_timeout(os.getenv('BIZNISWEB_WEB_TIMEOUT_SEC'))
 logger = get_logger('generate_invoices')
 
 DEFAULT_INVOICE_LOOKBACK_DAYS = 7
+DEFAULT_INVOICE_ELIGIBLE_STATUSES = ("Odoslaná",)
 
 # GraphQL query to fetch orders with specific criteria
 ORDER_QUERY = gql("""
@@ -138,10 +139,22 @@ def resolve_invoice_generation_settings(project_settings: Dict[str, Any]) -> Dic
     except (TypeError, ValueError):
         lookback_days = DEFAULT_INVOICE_LOOKBACK_DAYS
 
+    raw_statuses = raw_settings.get("eligible_statuses", DEFAULT_INVOICE_ELIGIBLE_STATUSES)
+    if isinstance(raw_statuses, str):
+        raw_statuses = [raw_statuses]
+    eligible_statuses = [
+        str(status).strip()
+        for status in raw_statuses
+        if str(status or "").strip()
+    ]
+    if not eligible_statuses:
+        eligible_statuses = list(DEFAULT_INVOICE_ELIGIBLE_STATUSES)
+
     return {
         "enabled": bool(raw_settings.get("enabled", False)),
         "lookback_days": max(1, lookback_days),
         "exclude_zero_total_orders": bool(raw_settings.get("exclude_zero_total_orders", True)),
+        "eligible_statuses": eligible_statuses,
     }
 
 
@@ -190,9 +203,18 @@ def _normalize_status_text(status_name: str) -> str:
     return without_marks.strip().lower()
 
 
-def _status_matches_invoice_generation(status_name: str) -> bool:
+def _normalized_invoice_statuses(status_names: Iterable[str]) -> set[str]:
+    return {
+        _normalize_status_text(status)
+        for status in status_names
+        if _normalize_status_text(status)
+    }
+
+
+def _status_matches_invoice_generation(status_name: str, eligible_statuses: Optional[Iterable[str]] = None) -> bool:
     normalized = _normalize_status_text(status_name)
-    return "odoslan" in normalized or ("cak" in normalized and "vybaven" in normalized)
+    allowed_statuses = _normalized_invoice_statuses(eligible_statuses or DEFAULT_INVOICE_ELIGIBLE_STATUSES)
+    return normalized in allowed_statuses
 
 
 def _order_purchase_date(order: Dict[str, Any]) -> str:
@@ -219,6 +241,7 @@ class InvoiceGenerator:
         username: Optional[str] = None,
         password: Optional[str] = None,
         exclude_zero_total_orders: bool = True,
+        eligible_statuses: Optional[Iterable[str]] = None,
     ):
         """Initialize the invoice generator with API credentials"""
         transport = RequestsHTTPTransport(
@@ -238,6 +261,7 @@ class InvoiceGenerator:
         self.web_session = None
         self.arf_token = None
         self.exclude_zero_total_orders = exclude_zero_total_orders
+        self.eligible_statuses = tuple(eligible_statuses or DEFAULT_INVOICE_ELIGIBLE_STATUSES)
         
         # Initialize web session if credentials provided
         if username and password:
@@ -755,7 +779,7 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
                 )
                 continue
 
-            if _status_matches_invoice_generation(status_name) and not has_invoice:
+            if _status_matches_invoice_generation(status_name, self.eligible_statuses) and not has_invoice:
                 filtered_orders.append(order)
                 logger.info(
                     "Order %s matches criteria for invoice generation - Status: %s - Total: %.2f",
@@ -1088,6 +1112,7 @@ def run_invoice_generation(
         None if no_web_login else web_username,
         None if no_web_login else web_password,
         exclude_zero_total_orders=invoice_settings["exclude_zero_total_orders"],
+        eligible_statuses=invoice_settings["eligible_statuses"],
     )
 
     summary = InvoiceRunSummary(

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -17,6 +17,9 @@
     "enabled": true,
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
+    "eligible_statuses": [
+      "Odoslaná"
+    ],
     "schedule_name": "roy-daily-invoice-generation",
     "schedule_expression": "cron(5/15 6-23 * * ? *)",
     "final_sweep_schedule_name": "roy-same-day-invoice-sweep",

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -21,6 +21,9 @@
     "enabled": true,
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
+    "eligible_statuses": [
+      "Odoslaná"
+    ],
     "schedule_name": "vevo-daily-invoice-generation",
     "schedule_expression": "cron(0/15 6-23 * * ? *)",
     "final_sweep_schedule_name": "vevo-same-day-invoice-sweep",

--- a/templates/reporting-client/settings.template.json
+++ b/templates/reporting-client/settings.template.json
@@ -18,6 +18,9 @@
     "enabled": false,
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
+    "eligible_statuses": [
+      "Odoslaná"
+    ],
     "schedule_name": "__CLIENT_SLUG__-daily-invoice-generation",
     "schedule_expression": "cron(0/15 6-23 * * ? *)",
     "final_sweep_schedule_name": "__CLIENT_SLUG__-same-day-invoice-sweep",

--- a/tests/test_invoice_generation.py
+++ b/tests/test_invoice_generation.py
@@ -23,6 +23,7 @@ class InvoiceGenerationTests(unittest.TestCase):
         self.assertTrue(settings["enabled"])
         self.assertEqual(settings["lookback_days"], 7)
         self.assertTrue(settings["exclude_zero_total_orders"])
+        self.assertEqual(["Odoslan\u00e1"], settings["eligible_statuses"])
 
     def test_resolve_invoice_date_window_uses_rolling_lookback(self) -> None:
         from_date, to_date = resolve_invoice_date_window("2026-04-24", 7)
@@ -30,8 +31,10 @@ class InvoiceGenerationTests(unittest.TestCase):
 
     def test_invoice_status_matching_handles_slovak_diacritics(self) -> None:
         self.assertTrue(_status_matches_invoice_generation("Odoslan\u00e1"))
-        self.assertTrue(_status_matches_invoice_generation("\u010cak\u00e1 na vybavenie"))
+        self.assertTrue(_status_matches_invoice_generation("ODOSLANA"))
+        self.assertFalse(_status_matches_invoice_generation("\u010cak\u00e1 na vybavenie"))
         self.assertFalse(_status_matches_invoice_generation("\u010cak\u00e1 na \u00fahradu"))
+        self.assertFalse(_status_matches_invoice_generation("madfrog stara odoslana"))
         self.assertFalse(_status_matches_invoice_generation("Platba online - platnos\u0165 vypr\u0161ala"))
 
     def test_invoice_runner_uses_current_day_reference_window(self) -> None:
@@ -61,6 +64,8 @@ class InvoiceGenerationTests(unittest.TestCase):
         self.assertEqual("roy-same-day-invoice-sweep", roy["invoice_generation"]["final_sweep_schedule_name"])
         self.assertEqual("cron(58 23 * * ? *)", vevo["invoice_generation"]["final_sweep_schedule_expression"])
         self.assertEqual("cron(59 23 * * ? *)", roy["invoice_generation"]["final_sweep_schedule_expression"])
+        self.assertEqual(["Odoslan\u00e1"], vevo["invoice_generation"]["eligible_statuses"])
+        self.assertEqual(["Odoslan\u00e1"], roy["invoice_generation"]["eligible_statuses"])
 
         self.assertNotEqual(vevo["report_schedule"]["task_family"], vevo["invoice_generation"]["task_family"])
         self.assertNotEqual(roy["report_schedule"]["task_family"], roy["invoice_generation"]["task_family"])
@@ -90,7 +95,7 @@ class InvoiceGenerationTests(unittest.TestCase):
                 {
                     "order_num": "A-3",
                     "status": {"name": "Čaká na vybavenie"},
-                    "invoices": [{"invoice_num": "INV-1"}],
+                    "invoices": [],
                     "sum": {"value": 19},
                 },
             ]


### PR DESCRIPTION
## Summary
- restrict invoice eligibility to exact configured shipped statuses only
- set VEVO/ROY invoice_generation.eligible_statuses to [Odoslaná]
- remove the incorrect `Čaká na vybavenie` eligibility behavior and regression-test it
- document the incident and temporary schedule pause in PROJECT_STATE.md

## Current production safety state
- all four invoice schedules are currently DISABLED until the fixed main image is deployed and verified

## Verification
- python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes
- python scripts\reporting_qa_smoke.py
- python scripts\security_ci.py
- git diff --check
- dry-run live API audit for VEVO/ROY 2026-05-07..2026-05-09 matched=0 with the shipped-only rule