### PR TITLE
[codex] Add VEVO production board

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -14,6 +14,8 @@ on:
       - html_report_generator.py
       - daily_report_runner.py
       - dashboard_modern.py
+      - live_dashboard_server.py
+      - production_board.py
       - project_config.py
       - weather_client.py
       - http_client.py
@@ -56,7 +58,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes
+          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2167,6 +2167,9 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - minimum scan: `10` pages / `300` newest orders
   - max scan: `30` pages
   - stop after repeated pages without active orders
+- Updated the ECR build gate so future production-board/live-server edits rebuild the production image:
+  - added `live_dashboard_server.py` and `production_board.py` to `.github/workflows/build-and-push-ecr.yml` path triggers
+  - added `tests.test_production_board` to the image publication regression test step
 - Data privacy note:
   - production board API/UI does not return customer names; it returns order numbers, dates, statuses, sums, product labels, quantities, and ignored-item reasons
 - Verified locally:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2152,3 +2152,33 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - ROY scheduled report on `2026-05-22 01:30 Europe/Bratislava` should include it
 - Next exact step:
   - after the `2026-05-22` scheduled emails run, check the scheduled run logs once and confirm they used image digest `sha256:57ae5b73c83bcb83c8a58bd7c1395ce69e328e8631d42ca75c009650f7c6a1ce`
+
+### 2026-05-21 (VEVO production board local implementation)
+- Branch: `codex/vevo-production-board`
+- Added a VEVO-only production board for active unshipped orders:
+  - live page: `/production/vevo`
+  - JSON endpoint: `/api/production/vevo/live`
+  - included statuses: `Čaká na vybavenie`, `Platba online - zaplatené`
+  - manufactured items are limited to product labels matching configured VEVO terms
+  - configured exception: `Vevo Ylang Absolute prací gél 1L`
+  - future outsourced VEVO products can be added to `production_board.excluded_product_labels`
+- Added scan controls because BiznisWeb rejects status filtering for this API token with HTTP 412:
+  - client-side status filtering over newest orders by purchase date
+  - minimum scan: `10` pages / `300` newest orders
+  - max scan: `30` pages
+  - stop after repeated pages without active orders
+- Data privacy note:
+  - production board API/UI does not return customer names; it returns order numbers, dates, statuses, sums, product labels, quantities, and ignored-item reasons
+- Verified locally:
+  - `python -m py_compile production_board.py live_dashboard_server.py`
+  - `python -m unittest tests.test_production_board tests.test_invoice_generation tests.test_reporting_calculation_fixes`
+  - `git diff --check`
+  - local server `http://127.0.0.1:8788/production/vevo`
+  - HTML marker: `vevo-production-board`
+  - live API summary: `18` active orders, `18` manufacturing products, `36.0` units to make, `8.0` ignored units
+  - live scan: `300` orders / `10` pages, oldest scanned order `2026-05-06 21:38:00`, oldest active order `2026-05-12 12:34:27`, `limit_reached=false`
+  - verified API response contains `0` customer-name fields
+- Not deployed yet:
+  - production deployment still needs normal branch/PR review and the infra hard-gate verification before exposing it on the hosted runtime
+- Next exact step:
+  - push branch, open PR, then deploy after PR approval/merge with host marker and localhost verification

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 from urllib.parse import parse_qs, quote, urlparse
 
+from production_board import get_cached_production_board_snapshot, resolve_production_board_settings
+from reporting_core import load_project_settings
+
 
 ROOT_DIR = Path(__file__).resolve().parent
 PROJECTS_DIR = ROOT_DIR / "projects"
@@ -165,13 +168,24 @@ def build_index_html(projects: List[str]) -> str:
     for project in projects:
         report_path = resolve_latest_report_path(project)
         payload_path = resolve_latest_payload_path(project)
+        production_enabled = False
+        try:
+            production_enabled = bool(resolve_production_board_settings(load_project_settings(project))["enabled"])
+        except Exception:
+            production_enabled = False
         project_q = quote(project)
+        production_link = (
+            f"<p><a href='/production/{project_q}'>Open production board</a></p>"
+            if production_enabled
+            else ""
+        )
         cards.append(
             "<article class='card'>"
             f"<h2>{escape(project)}</h2>"
             f"<p>Live dashboard: {'ready' if payload_path else 'missing'}</p>"
             f"<p>HTML report: {'ready' if report_path else 'missing'}</p>"
             f"<p>JSON payload: {'ready' if payload_path else 'missing'}</p>"
+            f"{production_link}"
             f"<p><a href='/dashboard/{project_q}'>Open live dashboard</a></p>"
             f"<p><a href='/report/{project_q}'>Open full HTML report</a></p>"
             f"<p><a href='/api/{project_q}/latest'>Open latest JSON</a></p>"
@@ -521,6 +535,241 @@ def build_live_dashboard_html(projects: List[str], initial_project: str, initial
     return html.replace("__BOOTSTRAP_JSON__", bootstrap_json)
 
 
+def build_production_board_html(project: str) -> str:
+    bootstrap_json = _json_script_content({"project": project})
+    html = """<!doctype html>
+<html lang="sk">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>VEVO Production Board</title>
+  <style>
+    :root {
+      --bg:#f4f6f7; --panel:#ffffff; --line:#d8dee4; --text:#17202a; --muted:#64707d;
+      --green:#157347; --green-bg:#e8f5ee; --red:#b42318; --red-bg:#fdebea;
+      --amber:#9a6700; --amber-bg:#fff4d6; --blue:#1f5f99; --blue-bg:#eaf3fb;
+    }
+    * { box-sizing:border-box; }
+    body { margin:0; background:var(--bg); color:var(--text); font-family:Arial,Helvetica,sans-serif; }
+    main { width:min(1440px,calc(100vw - 24px)); margin:0 auto; padding:16px 0 36px; }
+    header { display:flex; justify-content:space-between; gap:16px; align-items:flex-start; padding:16px 0; }
+    h1 { margin:0; font-size:28px; line-height:1.15; letter-spacing:0; }
+    h2 { margin:0; font-size:18px; line-height:1.2; letter-spacing:0; }
+    p { margin:0; color:var(--muted); line-height:1.45; }
+    button,a.button { min-height:38px; border:1px solid var(--line); background:#fff; color:var(--text); border-radius:6px; padding:0 12px; font-weight:700; cursor:pointer; text-decoration:none; display:inline-flex; align-items:center; justify-content:center; }
+    button.primary { background:#17202a; color:#fff; border-color:#17202a; }
+    .actions { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+    .statusline { color:var(--muted); font-size:13px; min-height:18px; }
+    .summary { display:grid; grid-template-columns:repeat(6,minmax(150px,1fr)); gap:10px; margin-bottom:12px; }
+    .metric { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:12px; min-height:86px; }
+    .metric .label { color:var(--muted); font-size:11px; text-transform:uppercase; font-weight:700; letter-spacing:.04em; }
+    .metric .value { margin-top:8px; font-size:26px; font-weight:800; line-height:1; }
+    .metric .note { margin-top:8px; font-size:12px; color:var(--muted); }
+    .layout { display:grid; grid-template-columns:minmax(0,1.35fr) minmax(360px,.65fr); gap:12px; align-items:start; }
+    .panel { background:var(--panel); border:1px solid var(--line); border-radius:8px; overflow:hidden; }
+    .panel-head { display:flex; justify-content:space-between; gap:12px; align-items:center; padding:12px 14px; border-bottom:1px solid var(--line); background:#fafbfc; }
+    .table-wrap { overflow:auto; }
+    table { width:100%; border-collapse:collapse; min-width:900px; }
+    th,td { padding:10px 12px; border-bottom:1px solid var(--line); text-align:left; vertical-align:top; font-size:13px; }
+    th { color:var(--muted); background:#fafbfc; text-transform:uppercase; font-size:11px; letter-spacing:.04em; }
+    tbody tr:hover { background:#f8fafc; }
+    .qty { font-size:20px; font-weight:800; }
+    .badge { display:inline-flex; align-items:center; min-height:24px; padding:0 8px; border-radius:999px; font-size:12px; font-weight:700; white-space:nowrap; }
+    .badge.make { color:var(--green); background:var(--green-bg); }
+    .badge.skip { color:var(--amber); background:var(--amber-bg); }
+    .badge.warn { color:var(--red); background:var(--red-bg); }
+    .badge.info { color:var(--blue); background:var(--blue-bg); }
+    .muted { color:var(--muted); }
+    .orders-list { display:grid; gap:8px; padding:12px; max-height:760px; overflow:auto; }
+    .order { border:1px solid var(--line); border-radius:8px; padding:10px; background:#fff; }
+    .order-top { display:flex; justify-content:space-between; gap:8px; align-items:flex-start; }
+    .order-num { font-size:16px; font-weight:800; }
+    .items { margin-top:8px; display:grid; gap:5px; }
+    .item { display:flex; justify-content:space-between; gap:10px; font-size:13px; border-top:1px solid #eef1f4; padding-top:5px; }
+    .product-orders { margin-top:8px; display:grid; gap:4px; color:var(--muted); font-size:12px; }
+    .hidden { display:none !important; }
+    .error { margin-bottom:12px; padding:10px 12px; border-radius:8px; color:var(--red); background:var(--red-bg); border:1px solid rgba(180,35,24,.25); }
+    @media (max-width:1120px) {
+      .summary { grid-template-columns:repeat(3,minmax(150px,1fr)); }
+      .layout { grid-template-columns:1fr; }
+    }
+    @media (max-width:680px) {
+      main { width:min(100vw - 14px,1440px); }
+      header { flex-direction:column; }
+      .summary { grid-template-columns:repeat(2,minmax(130px,1fr)); }
+      .metric .value { font-size:22px; }
+      table { min-width:760px; }
+    }
+  </style>
+</head>
+<body>
+  <main data-marker="vevo-production-board">
+    <header>
+      <div>
+        <h1>VEVO výrobný board</h1>
+        <p id="subtitle">Načítavam aktívne objednávky.</p>
+      </div>
+      <div class="actions">
+        <button id="refreshBtn" class="primary" type="button">Refresh</button>
+        <a class="button" href="/">Dashboardy</a>
+      </div>
+    </header>
+    <div id="errorBox" class="error hidden"></div>
+    <section class="summary" id="summary"></section>
+    <section class="layout">
+      <article class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Produkty na výrobu</h2>
+            <p id="productMeta">-</p>
+          </div>
+          <span id="cacheBadge" class="badge info">cache</span>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Produkt</th>
+                <th>Vyrobiť</th>
+                <th>Obj.</th>
+                <th>Najstaršia</th>
+                <th>Statusy</th>
+                <th>Objednávky</th>
+              </tr>
+            </thead>
+            <tbody id="productsBody"></tbody>
+          </table>
+        </div>
+      </article>
+      <article class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Aktívne objednávky</h2>
+            <p id="ordersMeta">-</p>
+          </div>
+        </div>
+        <div class="orders-list" id="ordersList"></div>
+      </article>
+    </section>
+  </main>
+  <script id="production-bootstrap" type="application/json">__BOOTSTRAP_JSON__</script>
+  <script>
+    const BOOTSTRAP = JSON.parse(document.getElementById('production-bootstrap').textContent || '{}');
+    const project = BOOTSTRAP.project || 'vevo';
+    const el = (id) => document.getElementById(id);
+    const fmtInt = (value) => new Intl.NumberFormat('sk-SK', { maximumFractionDigits: 0 }).format(Number(value || 0));
+    const fmtQty = (value) => new Intl.NumberFormat('sk-SK', { maximumFractionDigits: 2 }).format(Number(value || 0));
+    const text = (value, fallback = '-') => value === null || value === undefined || value === '' ? fallback : String(value);
+    const safe = (value) => text(value, '').replace(/[&<>"']/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+    let refreshTimer = null;
+
+    function metric(label, value, note) {
+      return `<article class="metric"><div class="label">${safe(label)}</div><div class="value">${safe(value)}</div><div class="note">${safe(note)}</div></article>`;
+    }
+
+    function statusBadges(statuses) {
+      return Object.entries(statuses || {}).map(([name, count]) => `<span class="badge info">${safe(name)}: ${fmtInt(count)}</span>`).join(' ');
+    }
+
+    function renderSummary(data) {
+      const summary = data.summary || {};
+      const scan = data.scan || {};
+      el('summary').innerHTML = [
+        metric('Aktívne objednávky', fmtInt(summary.active_orders), 'Čaká + online zaplatené'),
+        metric('Objednávky s výrobou', fmtInt(summary.manufacturing_orders), 'Obsahujú VEVO výrobok'),
+        metric('Produkty', fmtInt(summary.manufacturing_products), 'Zoskupené podľa EAN/kódu/názvu'),
+        metric('Kusy na výrobu', fmtQty(summary.units_to_make), 'Súčet VEVO položiek'),
+        metric('Ignorované kusy', fmtQty(summary.ignored_units), 'Iné značky + výnimky'),
+        metric('Skenované', fmtInt(scan.orders_scanned), `${fmtInt(scan.pages_scanned)} strán, najstaršia ${text(scan.oldest_order_at_scanned)}`),
+      ].join('');
+      const generated = text(data.generated_at);
+      const cache = data.cache || {};
+      el('subtitle').textContent = `Posledná aktualizácia ${generated}. Auto refresh ${fmtInt(data.auto_refresh_seconds || 90)}s.`;
+      el('cacheBadge').textContent = `${text(cache.status, 'live')} ${cache.age_seconds !== undefined ? `${cache.age_seconds}s` : ''}`;
+      const stopReason = text(scan.stop_reason, '');
+      let scanMessage = 'Scan prebehol bez dosiahnutia limitu.';
+      if (scan.limit_reached) {
+        scanMessage = 'Dosiahnutý scan limit, staršie aktívne objednávky môžu vyžadovať vyšší limit.';
+      } else if (stopReason === 'empty_active_pages') {
+        scanMessage = `Scan skončil po ${fmtInt(scan.empty_active_pages_at_stop)} stranách bez aktívnych objednávok.`;
+      } else if (stopReason === 'api_exhausted') {
+        scanMessage = 'BiznisWeb API vrátilo všetky dostupné strany.';
+      }
+      el('productMeta').textContent = scanMessage;
+      el('cacheBadge').className = `badge ${cache.status === 'stale_after_error' || scan.limit_reached ? 'warn' : 'info'}`;
+    }
+
+    function renderProducts(data) {
+      const products = data.products || [];
+      el('productsBody').innerHTML = products.length ? products.map((product) => {
+        const orderLines = (product.orders || []).slice(0, 8).map((order) => `${safe(order.order_num)} · ${fmtQty(order.quantity)} ks · ${safe(order.status)}`).join('<br>');
+        const more = (product.orders || []).length > 8 ? `<br><span class="muted">+${fmtInt((product.orders || []).length - 8)} ďalších</span>` : '';
+        return `<tr>
+          <td><strong>${safe(product.label)}</strong><div class="muted">${safe(product.identifier || product.key)}</div></td>
+          <td><span class="qty">${fmtQty(product.quantity_required)}</span></td>
+          <td>${fmtInt(product.orders_count)}</td>
+          <td>${safe(product.oldest_order_at)}</td>
+          <td>${statusBadges(product.statuses)}</td>
+          <td><div class="product-orders">${orderLines}${more}</div></td>
+        </tr>`;
+      }).join('') : `<tr><td colspan="6" class="muted">Aktuálne nie sú žiadne VEVO produkty na výrobu.</td></tr>`;
+    }
+
+    function renderOrders(data) {
+      const orders = data.orders || [];
+      el('ordersMeta').textContent = `${fmtInt(orders.length)} aktívnych objednávok`;
+      el('ordersList').innerHTML = orders.length ? orders.map((order) => {
+        const items = (order.items || []).map((item) => `<div class="item"><span>${safe(item.label)} <span class="muted">(${safe(item.reason)})</span></span><strong>${fmtQty(item.quantity)} ks</strong></div>`).join('');
+        const badgeClass = Number(order.manufacturing_units || 0) > 0 ? 'make' : 'skip';
+        return `<article class="order">
+          <div class="order-top">
+            <div><div class="order-num">${safe(order.order_num)}</div><div class="muted">${safe(order.purchase_at)} · ${safe(order.sum)}</div></div>
+            <span class="badge ${badgeClass}">${fmtQty(order.manufacturing_units)} ks</span>
+          </div>
+          <div class="muted">${safe(order.status)}</div>
+          <div class="items">${items}</div>
+        </article>`;
+      }).join('') : '<p class="muted">Žiadne aktívne objednávky.</p>';
+    }
+
+    function showError(message) {
+      el('errorBox').textContent = message;
+      el('errorBox').classList.remove('hidden');
+    }
+
+    function clearError() {
+      el('errorBox').classList.add('hidden');
+      el('errorBox').textContent = '';
+    }
+
+    async function loadBoard(force = false) {
+      el('refreshBtn').disabled = true;
+      try {
+        const url = `/api/production/${encodeURIComponent(project)}/live${force ? '?refresh=1' : ''}`;
+        const response = await fetch(url, { cache: 'no-store' });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        renderSummary(data);
+        renderProducts(data);
+        renderOrders(data);
+        clearError();
+        if (refreshTimer) clearInterval(refreshTimer);
+        refreshTimer = setInterval(() => loadBoard(false), Math.max(30, Number(data.auto_refresh_seconds || 90)) * 1000);
+      } catch (error) {
+        showError(error instanceof Error ? error.message : String(error));
+      } finally {
+        el('refreshBtn').disabled = false;
+      }
+    }
+
+    el('refreshBtn').addEventListener('click', () => loadBoard(true));
+    loadBoard(false);
+  </script>
+</body>
+</html>"""
+    return html.replace("__BOOTSTRAP_JSON__", bootstrap_json)
+
+
 class LiveDashboardHandler(BaseHTTPRequestHandler):
     server_version = "BizniWebLiveDashboard/1.1"
 
@@ -564,6 +813,28 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
 
         parts = [part for part in path.split("/") if part]
 
+        if len(parts) == 4 and parts[0] == "api" and parts[1] == "production" and parts[3] == "live":
+            project = parts[2]
+            if project not in projects:
+                self._send_json({"error": f"Unknown project '{project}'."}, status=404)
+                return
+
+            try:
+                board_settings = resolve_production_board_settings(load_project_settings(project))
+            except Exception as exc:
+                self._send_json({"error": f"Failed to load production board settings: {exc}"}, status=500)
+                return
+            if not board_settings["enabled"]:
+                self._send_json({"error": f"Production board is not enabled for '{project}'."}, status=404)
+                return
+
+            force_refresh = (query.get("refresh", [""])[0] or "").strip().lower() in {"1", "true", "yes"}
+            try:
+                self._send_json(get_cached_production_board_snapshot(project, force_refresh=force_refresh))
+            except Exception as exc:
+                self._send_json({"error": f"Failed to load production board data: {exc}"}, status=500)
+            return
+
         if len(parts) == 3 and parts[0] == "api" and parts[2] == "latest":
             project = parts[1]
             if project not in projects:
@@ -588,6 +859,30 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 build_live_dashboard_html(projects, project, requested_period),
                 content_type="text/html; charset=utf-8",
             )
+            return
+
+        if len(parts) == 2 and parts[0] == "production":
+            project = parts[1]
+            if project not in projects:
+                self._send_text(f"Unknown project '{escape(project)}'.", content_type="text/plain; charset=utf-8", status=404)
+                return
+            try:
+                board_settings = resolve_production_board_settings(load_project_settings(project))
+            except Exception as exc:
+                self._send_text(
+                    f"Failed to load production board settings: {escape(str(exc))}",
+                    content_type="text/plain; charset=utf-8",
+                    status=500,
+                )
+                return
+            if not board_settings["enabled"]:
+                self._send_text(
+                    f"Production board is not enabled for '{escape(project)}'.",
+                    content_type="text/plain; charset=utf-8",
+                    status=404,
+                )
+                return
+            self._send_text(build_production_board_html(project), content_type="text/html; charset=utf-8")
             return
 
         if len(parts) == 2 and parts[0] == "report":

--- a/production_board.py
+++ b/production_board.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Live production demand board for open BizniWeb orders."""
+
+from __future__ import annotations
+
+import copy
+import os
+import time
+import unicodedata
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from gql import Client, gql
+from gql.transport.requests import RequestsHTTPTransport
+
+from reporting_core import (
+    BASE_DEFAULT_PROJECT,
+    load_project_env,
+    load_project_settings,
+    resolve_biznisweb_api_url,
+)
+
+
+DEFAULT_ACTIVE_ORDER_STATUSES = ("Čaká na vybavenie", "Platba online - zaplatené")
+DEFAULT_MANUFACTURED_TERMS = ("vevo",)
+DEFAULT_SCAN_MAX_PAGES = 30
+DEFAULT_SCAN_MIN_PAGES = 10
+DEFAULT_STOP_AFTER_EMPTY_ACTIVE_PAGES = 2
+DEFAULT_CACHE_TTL_SECONDS = 60
+DEFAULT_AUTO_REFRESH_SECONDS = 90
+
+
+ORDER_QUERY = gql(
+    """
+query GetProductionOrders($params: OrderParams) {
+  getOrderList(params: $params) {
+    data {
+      id
+      order_num
+      pur_date
+      last_change
+      status {
+        id
+        name
+        color
+      }
+      items {
+        item_label
+        ean
+        import_code
+        warehouse_number
+        quantity
+      }
+      sum {
+        formatted
+      }
+    }
+    pageInfo {
+      hasNextPage
+      nextCursor
+      pageIndex
+      totalPages
+    }
+  }
+}
+"""
+)
+
+
+_CACHE: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+
+
+def _normalize_text(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    decomposed = unicodedata.normalize("NFKD", raw)
+    without_marks = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return " ".join(without_marks.split())
+
+
+def _as_list(value: Any, default: Iterable[str]) -> List[str]:
+    if value is None:
+        return [str(item) for item in default]
+    if isinstance(value, str):
+        return [value]
+    return [str(item) for item in value if str(item or "").strip()]
+
+
+def _as_int(value: Any, default: int, *, minimum: int = 1) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, parsed)
+
+
+def resolve_production_board_settings(project_settings: Dict[str, Any]) -> Dict[str, Any]:
+    raw = project_settings.get("production_board") or {}
+    active_statuses = _as_list(raw.get("active_order_statuses"), DEFAULT_ACTIVE_ORDER_STATUSES)
+    manufactured_terms = _as_list(raw.get("manufactured_product_terms"), DEFAULT_MANUFACTURED_TERMS)
+    excluded_labels = _as_list(raw.get("excluded_product_labels"), ())
+    excluded_patterns = _as_list(raw.get("excluded_product_label_patterns"), ())
+
+    return {
+        "enabled": bool(raw.get("enabled", False)),
+        "active_order_statuses": active_statuses,
+        "active_order_statuses_normalized": {_normalize_text(status) for status in active_statuses},
+        "manufactured_product_terms": manufactured_terms,
+        "manufactured_product_terms_normalized": {_normalize_text(term) for term in manufactured_terms},
+        "excluded_product_labels": excluded_labels,
+        "excluded_product_labels_normalized": {_normalize_text(label) for label in excluded_labels},
+        "excluded_product_label_patterns": excluded_patterns,
+        "excluded_product_label_patterns_normalized": {_normalize_text(pattern) for pattern in excluded_patterns},
+        "scan_max_pages": _as_int(raw.get("scan_max_pages"), DEFAULT_SCAN_MAX_PAGES),
+        "scan_min_pages": _as_int(raw.get("scan_min_pages"), DEFAULT_SCAN_MIN_PAGES),
+        "stop_after_empty_active_pages": _as_int(
+            raw.get("stop_after_empty_active_pages"),
+            DEFAULT_STOP_AFTER_EMPTY_ACTIVE_PAGES,
+            minimum=0,
+        ),
+        "cache_ttl_seconds": _as_int(raw.get("cache_ttl_seconds"), DEFAULT_CACHE_TTL_SECONDS),
+        "auto_refresh_seconds": _as_int(raw.get("auto_refresh_seconds"), DEFAULT_AUTO_REFRESH_SECONDS),
+    }
+
+
+def _coerce_quantity(value: Any) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _product_identifier(item: Dict[str, Any], label_norm: str) -> Tuple[str, str]:
+    for field in ("ean", "import_code", "warehouse_number"):
+        value = str(item.get(field) or "").strip()
+        if value:
+            return f"{field}:{value}", value
+    return f"label:{label_norm}", ""
+
+
+def _manufacturing_decision(label: str, settings: Dict[str, Any]) -> Tuple[bool, str]:
+    label_norm = _normalize_text(label)
+    if not label_norm:
+        return False, "missing_label"
+
+    if label_norm in settings["excluded_product_labels_normalized"]:
+        return False, "excluded_product"
+
+    for pattern in settings["excluded_product_label_patterns_normalized"]:
+        if pattern and pattern in label_norm:
+            return False, "excluded_product"
+
+    manufactured_terms = settings["manufactured_product_terms_normalized"]
+    if manufactured_terms and not any(term and term in label_norm for term in manufactured_terms):
+        return False, "not_manufactured_brand"
+
+    return True, "manufactured"
+
+
+def _is_active_order(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
+    status = order.get("status") or {}
+    return _normalize_text(status.get("name")) in settings["active_order_statuses_normalized"]
+
+
+def _order_sort_key(order: Dict[str, Any]) -> Tuple[str, str]:
+    return (str(order.get("purchase_at") or ""), str(order.get("order_num") or ""))
+
+
+def build_production_board_snapshot(
+    *,
+    project: str,
+    orders: List[Dict[str, Any]],
+    settings: Dict[str, Any],
+    scan: Optional[Dict[str, Any]] = None,
+    generated_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    if not settings["enabled"]:
+        raise ValueError(f"Production board is not enabled for project '{project}'.")
+
+    active_orders: List[Dict[str, Any]] = []
+    product_map: Dict[str, Dict[str, Any]] = {}
+    ignored_items: Dict[str, Dict[str, Any]] = {}
+
+    for order in orders:
+        if not _is_active_order(order, settings):
+            continue
+
+        status = order.get("status") or {}
+        status_name = str(status.get("name") or "").strip()
+        order_items: List[Dict[str, Any]] = []
+        manufacturing_units = 0.0
+        ignored_units = 0.0
+
+        for item in order.get("items") or []:
+            label = str(item.get("item_label") or "").strip()
+            quantity = _coerce_quantity(item.get("quantity"))
+            if quantity <= 0:
+                continue
+
+            label_norm = _normalize_text(label)
+            item_key, identifier = _product_identifier(item, label_norm)
+            should_make, reason = _manufacturing_decision(label, settings)
+
+            item_row = {
+                "key": item_key,
+                "label": label,
+                "identifier": identifier,
+                "quantity": quantity,
+                "manufactured": should_make,
+                "reason": reason,
+            }
+            order_items.append(item_row)
+
+            if should_make:
+                manufacturing_units += quantity
+                product = product_map.setdefault(
+                    item_key,
+                    {
+                        "key": item_key,
+                        "label": label,
+                        "identifier": identifier,
+                        "quantity_required": 0.0,
+                        "orders_count": 0,
+                        "orders": [],
+                        "statuses": {},
+                        "labels": [],
+                        "oldest_order_at": None,
+                        "latest_order_at": None,
+                    },
+                )
+                product["quantity_required"] += quantity
+                product["statuses"][status_name] = product["statuses"].get(status_name, 0) + 1
+                if label and label not in product["labels"]:
+                    product["labels"].append(label)
+                product_order = {
+                    "order_num": order.get("order_num"),
+                    "purchase_at": order.get("pur_date"),
+                    "last_change": order.get("last_change"),
+                    "status": status_name,
+                    "quantity": quantity,
+                    "sum": (order.get("sum") or {}).get("formatted"),
+                }
+                product["orders"].append(product_order)
+            else:
+                ignored_units += quantity
+                ignored = ignored_items.setdefault(
+                    item_key,
+                    {
+                        "key": item_key,
+                        "label": label,
+                        "identifier": identifier,
+                        "quantity": 0.0,
+                        "reason": reason,
+                        "orders_count": 0,
+                    },
+                )
+                ignored["quantity"] += quantity
+                ignored["orders_count"] += 1
+
+        active_orders.append(
+            {
+                "id": order.get("id"),
+                "order_num": order.get("order_num"),
+                "purchase_at": order.get("pur_date"),
+                "last_change": order.get("last_change"),
+                "status": status_name,
+                "status_id": status.get("id"),
+                "sum": (order.get("sum") or {}).get("formatted"),
+                "manufacturing_units": manufacturing_units,
+                "ignored_units": ignored_units,
+                "items": order_items,
+            }
+        )
+
+    for product in product_map.values():
+        product["orders"].sort(key=_order_sort_key)
+        product["orders_count"] = len({str(order.get("order_num")) for order in product["orders"]})
+        product["oldest_order_at"] = product["orders"][0].get("purchase_at") if product["orders"] else None
+        product["latest_order_at"] = product["orders"][-1].get("purchase_at") if product["orders"] else None
+        product["quantity_required"] = round(float(product["quantity_required"]), 3)
+
+    products = sorted(
+        product_map.values(),
+        key=lambda row: (-float(row["quantity_required"]), str(row.get("oldest_order_at") or ""), str(row.get("label") or "")),
+    )
+    active_orders.sort(key=_order_sort_key)
+
+    generated = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    oldest_active = active_orders[0]["purchase_at"] if active_orders else None
+    latest_active = active_orders[-1]["purchase_at"] if active_orders else None
+
+    return {
+        "project": project,
+        "generated_at": generated,
+        "active_order_statuses": settings["active_order_statuses"],
+        "manufactured_product_terms": settings["manufactured_product_terms"],
+        "excluded_product_labels": settings["excluded_product_labels"],
+        "auto_refresh_seconds": settings["auto_refresh_seconds"],
+        "summary": {
+            "active_orders": len(active_orders),
+            "manufacturing_orders": len([order for order in active_orders if order["manufacturing_units"] > 0]),
+            "manufacturing_products": len(products),
+            "units_to_make": round(sum(float(product["quantity_required"]) for product in products), 3),
+            "ignored_units": round(sum(float(order["ignored_units"]) for order in active_orders), 3),
+            "oldest_active_order_at": oldest_active,
+            "latest_active_order_at": latest_active,
+        },
+        "scan": scan or {},
+        "products": products,
+        "orders": active_orders,
+        "ignored_items": sorted(
+            ignored_items.values(),
+            key=lambda row: (-float(row["quantity"]), str(row.get("label") or "")),
+        ),
+    }
+
+
+def _build_client(project: str, project_settings: Dict[str, Any]) -> Client:
+    api_url = resolve_biznisweb_api_url(project, project_settings)
+    api_token = os.getenv("BIZNISWEB_API_TOKEN")
+    if not api_token:
+        raise RuntimeError(f"BIZNISWEB_API_TOKEN not found for project '{project}'")
+
+    timeout = int(os.getenv("BIZNISWEB_API_TIMEOUT_SEC", os.getenv("REPORT_HTTP_READ_TIMEOUT_SEC", "30")))
+    transport = RequestsHTTPTransport(
+        url=api_url,
+        headers={"BW-API-Key": f"Token {api_token}"},
+        verify=True,
+        retries=3,
+        timeout=timeout,
+    )
+    return Client(transport=transport, fetch_schema_from_transport=False)
+
+
+def fetch_open_orders_for_production(project: str, settings: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    project_settings = load_project_settings(project)
+    client = _build_client(project, project_settings)
+
+    orders: List[Dict[str, Any]] = []
+    cursor: Optional[int] = None
+    page_count = 0
+    has_next_page = True
+    oldest_order_at: Optional[str] = None
+    empty_active_pages = 0
+    active_orders_seen = 0
+    stop_reason = "api_exhausted"
+
+    while has_next_page and page_count < settings["scan_max_pages"]:
+        params: Dict[str, Any] = {
+            "limit": 30,
+            "order_by": "pur_date",
+            "sort": "DESC",
+        }
+        if cursor is not None:
+            params["cursor"] = cursor
+
+        result = client.execute(ORDER_QUERY, variable_values={"params": params})
+        payload = result.get("getOrderList") or {}
+        page_orders = [order for order in (payload.get("data") or []) if order]
+        orders.extend(page_orders)
+        page_count += 1
+
+        page_active_orders = sum(1 for order in page_orders if _is_active_order(order, settings))
+        active_orders_seen += page_active_orders
+        if page_active_orders:
+            empty_active_pages = 0
+        else:
+            empty_active_pages += 1
+
+        for order in page_orders:
+            pur_date = str(order.get("pur_date") or "")
+            if pur_date and (oldest_order_at is None or pur_date < oldest_order_at):
+                oldest_order_at = pur_date
+
+        page_info = payload.get("pageInfo") or {}
+        has_next_page = bool(page_info.get("hasNextPage"))
+        cursor = page_info.get("nextCursor")
+        if cursor in ("", None):
+            has_next_page = False
+        if (
+            has_next_page
+            and page_count >= settings["scan_min_pages"]
+            and settings["stop_after_empty_active_pages"] > 0
+            and empty_active_pages >= settings["stop_after_empty_active_pages"]
+        ):
+            has_next_page = False
+            stop_reason = "empty_active_pages"
+
+    limit_reached = bool(has_next_page and page_count >= settings["scan_max_pages"])
+    if limit_reached:
+        stop_reason = "scan_max_pages"
+
+    scan = {
+        "orders_scanned": len(orders),
+        "pages_scanned": page_count,
+        "scan_max_pages": settings["scan_max_pages"],
+        "scan_min_pages": settings["scan_min_pages"],
+        "stop_after_empty_active_pages": settings["stop_after_empty_active_pages"],
+        "empty_active_pages_at_stop": empty_active_pages,
+        "active_orders_seen_during_scan": active_orders_seen,
+        "oldest_order_at_scanned": oldest_order_at,
+        "limit_reached": limit_reached,
+        "stop_reason": stop_reason,
+        "source": "biznisweb_api_desc_purchase_date_client_status_filter",
+    }
+    return orders, scan
+
+
+def generate_production_board_snapshot(project: str = BASE_DEFAULT_PROJECT) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    load_project_env(project)
+    project_settings = load_project_settings(project)
+    settings = resolve_production_board_settings(project_settings)
+    orders, scan = fetch_open_orders_for_production(project, settings)
+    return build_production_board_snapshot(project=project, orders=orders, settings=settings, scan=scan)
+
+
+def get_cached_production_board_snapshot(project: str, *, force_refresh: bool = False) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    project_settings = load_project_settings(project)
+    settings = resolve_production_board_settings(project_settings)
+    if not settings["enabled"]:
+        raise ValueError(f"Production board is not enabled for project '{project}'.")
+
+    cache_key = project
+    now = time.monotonic()
+    cached = _CACHE.get(cache_key)
+    if cached and not force_refresh:
+        cached_at, payload = cached
+        if now - cached_at <= settings["cache_ttl_seconds"]:
+            result = copy.deepcopy(payload)
+            result["cache"] = {
+                "status": "fresh",
+                "age_seconds": round(now - cached_at, 1),
+                "ttl_seconds": settings["cache_ttl_seconds"],
+            }
+            return result
+
+    try:
+        payload = generate_production_board_snapshot(project)
+    except Exception as exc:
+        if cached:
+            cached_at, payload = cached
+            result = copy.deepcopy(payload)
+            result["cache"] = {
+                "status": "stale_after_error",
+                "age_seconds": round(now - cached_at, 1),
+                "ttl_seconds": settings["cache_ttl_seconds"],
+                "error": str(exc),
+            }
+            return result
+        raise
+
+    _CACHE[cache_key] = (now, copy.deepcopy(payload))
+    payload["cache"] = {
+        "status": "refreshed",
+        "age_seconds": 0,
+        "ttl_seconds": settings["cache_ttl_seconds"],
+    }
+    return payload

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -13,6 +13,25 @@
   },
   "expense_match_mode": "title_first",
   "product_name_aliases_file": "product_name_aliases.json",
+  "production_board": {
+    "enabled": true,
+    "active_order_statuses": [
+      "Čaká na vybavenie",
+      "Platba online - zaplatené"
+    ],
+    "manufactured_product_terms": [
+      "vevo"
+    ],
+    "excluded_product_labels": [
+      "Vevo Ylang Absolute prací gél 1L"
+    ],
+    "excluded_product_label_patterns": [],
+    "scan_max_pages": 30,
+    "scan_min_pages": 10,
+    "stop_after_empty_active_pages": 2,
+    "cache_ttl_seconds": 60,
+    "auto_refresh_seconds": 90
+  },
   "packaging_cost_per_order": 0.3,
   "shipping_net_per_order": 0.2,
   "fixed_monthly_cost": 0,

--- a/tests/test_production_board.py
+++ b/tests/test_production_board.py
@@ -1,0 +1,129 @@
+import json
+import unittest
+from pathlib import Path
+
+from production_board import build_production_board_snapshot, resolve_production_board_settings
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def make_settings() -> dict:
+    return resolve_production_board_settings(
+        {
+            "production_board": {
+                "enabled": True,
+                "active_order_statuses": [
+                    "\u010cak\u00e1 na vybavenie",
+                    "Platba online - zaplaten\u00e9",
+                ],
+                "manufactured_product_terms": ["vevo"],
+                "excluded_product_labels": ["Vevo Ylang Absolute prac\u00ed g\u00e9l 1L"],
+                "excluded_product_label_patterns": [],
+            }
+        }
+    )
+
+
+def make_order(order_num: str, status_name: str, items: list, pur_date: str = "2026-05-21 08:00:00") -> dict:
+    return {
+        "id": order_num,
+        "order_num": order_num,
+        "pur_date": pur_date,
+        "last_change": pur_date,
+        "status": {"id": 1, "name": status_name, "color": "#fff"},
+        "customer": {"name": "Test", "surname": "Customer"},
+        "items": items,
+        "sum": {"formatted": "10,00 \u20ac"},
+    }
+
+
+def make_item(label: str, quantity: float, ean: str = "", import_code: str = "", warehouse_number: str = "") -> dict:
+    return {
+        "item_label": label,
+        "quantity": quantity,
+        "ean": ean,
+        "import_code": import_code,
+        "warehouse_number": warehouse_number,
+    }
+
+
+class ProductionBoardTests(unittest.TestCase):
+    def test_vevo_settings_enable_board_with_current_exclusion(self) -> None:
+        project_settings = json.loads((ROOT_DIR / "projects" / "vevo" / "settings.json").read_text(encoding="utf-8"))
+        settings = resolve_production_board_settings(project_settings)
+
+        self.assertTrue(settings["enabled"])
+        self.assertEqual(
+            ["\u010cak\u00e1 na vybavenie", "Platba online - zaplaten\u00e9"],
+            settings["active_order_statuses"],
+        )
+        self.assertIn("Vevo Ylang Absolute prac\u00ed g\u00e9l 1L", settings["excluded_product_labels"])
+        self.assertIn("vevo", settings["manufactured_product_terms"])
+
+    def test_snapshot_filters_active_statuses_and_manufactured_products(self) -> None:
+        settings = make_settings()
+        orders = [
+            make_order(
+                "A-1",
+                "\u010cak\u00e1 na vybavenie",
+                [
+                    make_item("Vevo Lavender prac\u00ed parfum 500ml", 2, ean="8580001"),
+                    make_item("Other Brand product", 3, ean="9990001"),
+                    make_item("Vevo Ylang Absolute prac\u00ed g\u00e9l 1L", 4, ean="8589999"),
+                ],
+                "2026-05-20 10:00:00",
+            ),
+            make_order(
+                "A-2",
+                "Platba online - zaplaten\u00e9",
+                [make_item("Vevo Lavender prac\u00ed parfum 500ml", 1, ean="8580001")],
+                "2026-05-21 09:00:00",
+            ),
+            make_order(
+                "A-3",
+                "Odoslan\u00e1",
+                [make_item("Vevo Lavender prac\u00ed parfum 500ml", 9, ean="8580001")],
+                "2026-05-21 10:00:00",
+            ),
+        ]
+
+        snapshot = build_production_board_snapshot(project="vevo", orders=orders, settings=settings)
+
+        self.assertEqual(2, snapshot["summary"]["active_orders"])
+        self.assertEqual(2, snapshot["summary"]["manufacturing_orders"])
+        self.assertEqual(1, snapshot["summary"]["manufacturing_products"])
+        self.assertEqual(3.0, snapshot["summary"]["units_to_make"])
+        self.assertEqual(["A-1", "A-2"], [order["order_num"] for order in snapshot["orders"]])
+
+        product = snapshot["products"][0]
+        self.assertEqual("Vevo Lavender prac\u00ed parfum 500ml", product["label"])
+        self.assertEqual("8580001", product["identifier"])
+        self.assertEqual(3.0, product["quantity_required"])
+        self.assertEqual(2, product["orders_count"])
+
+        ignored_reasons = {item["reason"] for item in snapshot["ignored_items"]}
+        self.assertEqual({"excluded_product", "not_manufactured_brand"}, ignored_reasons)
+        self.assertEqual(7.0, snapshot["summary"]["ignored_units"])
+
+    def test_status_matching_handles_missing_diacritics(self) -> None:
+        settings = make_settings()
+        snapshot = build_production_board_snapshot(
+            project="vevo",
+            orders=[
+                make_order(
+                    "A-1",
+                    "Caka na vybavenie",
+                    [make_item("VEVO citrus 200ml", 2, import_code="V-CITRUS")],
+                )
+            ],
+            settings=settings,
+        )
+
+        self.assertEqual(1, snapshot["summary"]["active_orders"])
+        self.assertEqual(2.0, snapshot["summary"]["units_to_make"])
+        self.assertEqual("V-CITRUS", snapshot["products"][0]["identifier"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a VEVO production board for live manufacturing demand from active unshipped BiznisWeb orders.

- adds `/production/vevo` and `/api/production/vevo/live` to the live dashboard server
- includes orders in `?ak? na vybavenie` and `Platba online - zaplaten?`
- aggregates only configured VEVO products into the manufacturing list
- excludes `Vevo Ylang Absolute prac? g?l 1L` through configurable `production_board.excluded_product_labels`
- keeps ignored non-manufactured items visible separately for operator context
- avoids returning customer names from the production board API/UI

## Notes

BiznisWeb currently returns HTTP 412 when this API token uses `OrderFilter.status`, so the board scans newest orders by purchase date and filters statuses client-side. The scan settings are configurable in `projects/vevo/settings.json`.

## Validation

- `python -m py_compile production_board.py live_dashboard_server.py`
- `python -m unittest tests.test_production_board tests.test_invoice_generation tests.test_reporting_calculation_fixes`
- `git diff --check`
- local server smoke: `http://127.0.0.1:8788/production/vevo`
- live API smoke: 18 active orders, 18 manufacturing products, 36.0 units to make, 8.0 ignored units, no customer-name fields returned

## Deployment

Not deployed yet. Production exposure should happen after review/merge with the normal infra hard-gate: confirm runtime target, verify localhost marker on host, then UI test.
