### PR TITLE
[codex] Add production board smoke check

### DIFF
--- a/.github/workflows/production-reporting-smoke.yml
+++ b/.github/workflows/production-reporting-smoke.yml
@@ -206,6 +206,55 @@ jobs:
           grep -q "daily_profit_loss" /tmp/live-dashboard-api.json
           curl -fsS "http://127.0.0.1:8787/report/${PROJECT}?period=full" -o /tmp/live-report.html
           grep -q "dailyProfitLossChart" /tmp/live-report.html
+          PRODUCTION_BOARD_ENABLED="$(python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          project = os.environ["REPORT_PROJECT"]
+          settings = json.loads((Path("projects") / project / "settings.json").read_text(encoding="utf-8"))
+          print("true" if settings.get("production_board", {}).get("enabled") else "false")
+          PY
+          )"
+          if [[ "$PRODUCTION_BOARD_ENABLED" == "true" ]]; then
+            curl -fsS "http://127.0.0.1:8787/production/${PROJECT}" -o /tmp/production-board.html
+            grep -q "vevo-production-board" /tmp/production-board.html
+            curl -fsS "http://127.0.0.1:8787/api/production/${PROJECT}/live?refresh=1" -o /tmp/production-board-api.json
+            python - <<'PY'
+          import json
+          from pathlib import Path
+          api = json.loads(Path("/tmp/production-board-api.json").read_text(encoding="utf-8"))
+          assert api["project"] == "vevo", api.get("project")
+          assert "Čaká na vybavenie" in api["active_order_statuses"]
+          assert "Platba online - zaplatené" in api["active_order_statuses"]
+          assert "Vevo Ylang Absolute prací gél 1L" in api["excluded_product_labels"]
+          assert "summary" in api and "products" in api and "orders" in api
+          assert all("customer" not in order for order in api["orders"]), "customer leaked in orders"
+          assert all(
+              "customer" not in order
+              for product in api["products"]
+              for order in product.get("orders", [])
+          ), "customer leaked in product orders"
+          marker_path = Path("/tmp/marker/marker.json")
+          marker = json.loads(marker_path.read_text(encoding="utf-8"))
+          marker["production_board"] = {
+              "marker": "PRODUCTION_BOARD_OK",
+              "active_orders": api["summary"].get("active_orders"),
+              "manufacturing_products": api["summary"].get("manufacturing_products"),
+              "units_to_make": api["summary"].get("units_to_make"),
+              "ignored_units": api["summary"].get("ignored_units"),
+              "orders_scanned": api["scan"].get("orders_scanned"),
+              "pages_scanned": api["scan"].get("pages_scanned"),
+              "limit_reached": api["scan"].get("limit_reached"),
+              "customer_fields_returned": 0,
+          }
+          marker_path.write_text(json.dumps(marker, sort_keys=True), encoding="utf-8")
+          PY
+            echo "PRODUCTION_BOARD_MARKER_BEGIN"
+            curl -fsS http://127.0.0.1:8000/marker.json
+            echo
+            echo "PRODUCTION_BOARD_MARKER_END"
+            echo "UI_SMOKE_OK:${PROJECT}:production-board"
+          fi
           echo "UI_SMOKE_OK:${PROJECT}:daily-profit-loss"
           SH
             )"
@@ -281,6 +330,7 @@ jobs:
             echo "image-path=919341186960.dkr.ecr.eu-central-1.amazonaws.com/vevo-reporting:latest"
             echo "marker-path=http://127.0.0.1:8000/marker.json"
             echo "ui-path=http://127.0.0.1:8787/dashboard/${PROJECT}"
+            echo "production-board-ui-path=http://127.0.0.1:8787/production/${PROJECT}"
 
             TASK_STOPPED=false
             for attempt in $(seq 1 240); do

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2155,6 +2155,7 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
 
 ### 2026-05-21 (VEVO production board local implementation)
 - Branch: `codex/vevo-production-board`
+- PR: `https://github.com/vzeman/biznisweb/pull/70` (merged to `main` as `30c6093ba0666676aa4982edac9f5022b7047df1`)
 - Added a VEVO-only production board for active unshipped orders:
   - live page: `/production/vevo`
   - JSON endpoint: `/api/production/vevo/live`
@@ -2182,6 +2183,23 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - live scan: `300` orders / `10` pages, oldest scanned order `2026-05-06 21:38:00`, oldest active order `2026-05-12 12:34:27`, `limit_reached=false`
   - verified API response contains `0` customer-name fields
 - Not deployed yet:
-  - production deployment still needs normal branch/PR review and the infra hard-gate verification before exposing it on the hosted runtime
+  - ECR `latest` refreshed after merge by `Build and Push ECR` run `26219915597`
+  - refreshed digest: `sha256:db4f16d55b38b317f43ac58760d760d56b1255ad015c42cd3ee65e7177abbd3b`
+  - production smoke still needs the new production-board host route check before closing deployment verification
 - Next exact step:
-  - push branch, open PR, then deploy after PR approval/merge with host marker and localhost verification
+  - merge the production smoke workflow enhancement, then run `Production Reporting Smoke` for `vevo` with a production-board marker and verify localhost marker + `/production/vevo`
+
+### 2026-05-21 (VEVO production board smoke workflow enhancement)
+- Branch: `codex/production-board-smoke`
+- Added host-level production board checks to `.github/workflows/production-reporting-smoke.yml`:
+  - when `production_board.enabled` is true, the ECS/Fargate smoke task curls `http://127.0.0.1:8787/production/<project>`
+  - verifies the `vevo-production-board` HTML marker
+  - curls `http://127.0.0.1:8787/api/production/<project>/live?refresh=1`
+  - verifies active statuses, configured Ylang gel exclusion, structured summary/products/orders, and no customer-name fields
+  - writes `PRODUCTION_BOARD_OK` into the localhost marker payload served from `http://127.0.0.1:8000/marker.json`
+  - prints `UI_SMOKE_OK:<project>:production-board`
+- Verified locally:
+  - YAML parse of `.github/workflows/production-reporting-smoke.yml`
+  - `git diff --check`
+- Next exact step:
+  - push branch, open/merge PR, dispatch production smoke for VEVO against refreshed ECR digest `sha256:db4f16d55b38b317f43ac58760d760d56b1255ad015c42cd3ee65e7177abbd3b`


### PR DESCRIPTION
## Summary

Adds production-board verification to the existing production ECS/Fargate smoke workflow.

- when a project has `production_board.enabled`, the smoke task curls `/production/<project>` on localhost
- verifies the `vevo-production-board` HTML marker
- curls `/api/production/<project>/live?refresh=1`
- checks configured active statuses, Ylang gel exclusion, structured board payload, and absence of customer fields
- writes `PRODUCTION_BOARD_OK` into the localhost marker payload
- prints `UI_SMOKE_OK:<project>:production-board`

## Validation

- YAML parse of `.github/workflows/production-reporting-smoke.yml`
- `git diff --check`

## Context

This is the final smoke-gate addition needed before running production verification for the merged VEVO production board.
