### PR TITLE
[codex] Deploy live dashboard with App Runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 BIZNISWEB_API_TOKEN=your_api_token_here
 BIZNISWEB_API_URL=https://vevo.flox.sk/api/graphql
 
+# Optional Basic Auth for live_dashboard_server.py.
+# Leave unset for local unauthenticated use; set both in hosted deployments.
+LIVE_DASHBOARD_AUTH_USER=
+LIVE_DASHBOARD_AUTH_PASSWORD=
+
 # Web login credentials for invoice generation (optional)
 BIZNISWEB_USERNAME=your_username_here
 BIZNISWEB_PASSWORD=your_password_here

--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board
+          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -1,0 +1,353 @@
+name: Deploy Live Dashboard App Runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      service_name:
+        description: App Runner service name
+        required: true
+        default: biznisweb-vevo-production-board
+      auth_user:
+        description: Basic Auth username
+        required: true
+        default: vevo
+
+env:
+  AWS_REGION: eu-central-1
+  ECR_REPOSITORY: vevo-reporting
+  IMAGE_TAG: latest
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy App Runner service
+        shell: bash
+        env:
+          SERVICE_NAME: ${{ inputs.service_name }}
+          AUTH_USER: ${{ inputs.auth_user }}
+        run: |
+          set -euo pipefail
+
+          ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+          IMAGE_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG}"
+          IMAGE_DIGEST="$(aws ecr describe-images \
+            --repository-name "${ECR_REPOSITORY}" \
+            --image-ids imageTag="${IMAGE_TAG}" \
+            --region "${AWS_REGION}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)"
+
+          aws ecs describe-task-definition \
+            --task-definition vevo-reporting-daily \
+            --region "${AWS_REGION}" > task-definition.json
+
+          BIZNISWEB_TOKEN_REF="$(python - <<'PY'
+          import json
+          task_def = json.load(open("task-definition.json", encoding="utf-8"))["taskDefinition"]
+          container = task_def["containerDefinitions"][0]
+          for secret in container.get("secrets", []):
+              if secret.get("name") == "BIZNISWEB_API_TOKEN":
+                  print(secret["valueFrom"])
+                  raise SystemExit(0)
+          raise SystemExit("BIZNISWEB_API_TOKEN secret not found in vevo-reporting-daily")
+          PY
+          )"
+          if [[ "${BIZNISWEB_TOKEN_REF}" != arn:* ]]; then
+            if aws ssm get-parameter --name "${BIZNISWEB_TOKEN_REF}" --region "${AWS_REGION}" >/tmp/token-parameter.json 2>/dev/null; then
+              BIZNISWEB_TOKEN_REF="$(python - <<'PY'
+          import json
+          print(json.load(open("/tmp/token-parameter.json", encoding="utf-8"))["Parameter"]["ARN"])
+          PY
+              )"
+            else
+              BIZNISWEB_TOKEN_REF="$(aws secretsmanager describe-secret \
+                --secret-id "${BIZNISWEB_TOKEN_REF}" \
+                --region "${AWS_REGION}" \
+                --query ARN \
+                --output text)"
+            fi
+          fi
+          BIZNISWEB_TOKEN_POLICY_REF="$(python - "${BIZNISWEB_TOKEN_REF}" <<'PY'
+          import sys
+          raw = sys.argv[1]
+          parts = raw.split(":")
+          if len(parts) > 7 and len(parts) >= 6 and parts[2] == "secretsmanager" and parts[5] == "secret":
+              print(":".join(parts[:7]))
+          else:
+              print(raw)
+          PY
+          )"
+
+          PASSWORD_PARAM="/biznisweb/live-dashboard/basic-auth-password"
+          if ! aws ssm get-parameter --name "${PASSWORD_PARAM}" --region "${AWS_REGION}" >/dev/null 2>&1; then
+            GENERATED_PASSWORD="$(openssl rand -base64 36)"
+            aws ssm put-parameter \
+              --name "${PASSWORD_PARAM}" \
+              --type SecureString \
+              --value "${GENERATED_PASSWORD}" \
+              --region "${AWS_REGION}" >/dev/null
+          fi
+          AUTH_PASSWORD="$(aws ssm get-parameter \
+            --name "${PASSWORD_PARAM}" \
+            --with-decryption \
+            --region "${AWS_REGION}" \
+            --query 'Parameter.Value' \
+            --output text)"
+          echo "::add-mask::${AUTH_PASSWORD}"
+          PASSWORD_PARAM_ARN="$(aws ssm get-parameter \
+            --name "${PASSWORD_PARAM}" \
+            --region "${AWS_REGION}" \
+            --query 'Parameter.ARN' \
+            --output text)"
+
+          ACCESS_ROLE_NAME="BiznisWebAppRunnerECRAccessRole"
+          INSTANCE_ROLE_NAME="BiznisWebLiveDashboardAppRunnerInstanceRole"
+
+          cat > ecr-access-trust.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {"Service": "build.apprunner.amazonaws.com"},
+                "Action": "sts:AssumeRole"
+              }
+            ]
+          }
+          JSON
+
+          if ! aws iam get-role --role-name "${ACCESS_ROLE_NAME}" >/dev/null 2>&1; then
+            aws iam create-role \
+              --role-name "${ACCESS_ROLE_NAME}" \
+              --assume-role-policy-document file://ecr-access-trust.json >/dev/null
+          else
+            aws iam update-assume-role-policy \
+              --role-name "${ACCESS_ROLE_NAME}" \
+              --policy-document file://ecr-access-trust.json
+          fi
+          aws iam attach-role-policy \
+            --role-name "${ACCESS_ROLE_NAME}" \
+            --policy-arn arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess || true
+          ACCESS_ROLE_ARN="$(aws iam get-role --role-name "${ACCESS_ROLE_NAME}" --query 'Role.Arn' --output text)"
+
+          cat > instance-trust.json <<'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {"Service": "tasks.apprunner.amazonaws.com"},
+                "Action": "sts:AssumeRole"
+              }
+            ]
+          }
+          JSON
+
+          if ! aws iam get-role --role-name "${INSTANCE_ROLE_NAME}" >/dev/null 2>&1; then
+            aws iam create-role \
+              --role-name "${INSTANCE_ROLE_NAME}" \
+              --assume-role-policy-document file://instance-trust.json >/dev/null
+          else
+            aws iam update-assume-role-policy \
+              --role-name "${INSTANCE_ROLE_NAME}" \
+              --policy-document file://instance-trust.json
+          fi
+
+          cat > instance-policy.json <<JSON
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": [
+                  "ssm:GetParameter",
+                  "ssm:GetParameters",
+                  "secretsmanager:GetSecretValue"
+                ],
+                "Resource": [
+                  "${BIZNISWEB_TOKEN_POLICY_REF}",
+                  "${PASSWORD_PARAM_ARN}"
+                ]
+              }
+            ]
+          }
+          JSON
+
+          aws iam put-role-policy \
+            --role-name "${INSTANCE_ROLE_NAME}" \
+            --policy-name LiveDashboardRuntimeSecrets \
+            --policy-document file://instance-policy.json
+          INSTANCE_ROLE_ARN="$(aws iam get-role --role-name "${INSTANCE_ROLE_NAME}" --query 'Role.Arn' --output text)"
+
+          cat > source-configuration.json <<JSON
+          {
+            "ImageRepository": {
+              "ImageIdentifier": "${IMAGE_URI}",
+              "ImageRepositoryType": "ECR",
+              "ImageConfiguration": {
+                "Port": "8080",
+                "StartCommand": "python live_dashboard_server.py --host 0.0.0.0 --port 8080",
+                "RuntimeEnvironmentVariables": {
+                  "REPORT_PROJECT": "vevo",
+                  "REPORT_SKIP_PROJECT_ENV": "true",
+                  "LIVE_DASHBOARD_AUTH_USER": "${AUTH_USER}",
+                  "BIZNISWEB_API_TIMEOUT_SEC": "30"
+                },
+                "RuntimeEnvironmentSecrets": {
+                  "BIZNISWEB_API_TOKEN": "${BIZNISWEB_TOKEN_REF}",
+                  "LIVE_DASHBOARD_AUTH_PASSWORD": "${PASSWORD_PARAM_ARN}"
+                }
+              }
+            },
+            "AutoDeploymentsEnabled": false,
+            "AuthenticationConfiguration": {
+              "AccessRoleArn": "${ACCESS_ROLE_ARN}"
+            }
+          }
+          JSON
+
+          cat > instance-configuration.json <<JSON
+          {
+            "Cpu": "0.25 vCPU",
+            "Memory": "0.5 GB",
+            "InstanceRoleArn": "${INSTANCE_ROLE_ARN}"
+          }
+          JSON
+
+          cat > health-check-configuration.json <<'JSON'
+          {
+            "Protocol": "HTTP",
+            "Path": "/health",
+            "Interval": 10,
+            "Timeout": 5,
+            "HealthyThreshold": 1,
+            "UnhealthyThreshold": 5
+          }
+          JSON
+
+          SERVICE_ARN="$(aws apprunner list-services \
+            --region "${AWS_REGION}" \
+            --query "ServiceSummaryList[?ServiceName=='${SERVICE_NAME}'].ServiceArn | [0]" \
+            --output text)"
+
+          if [[ "${SERVICE_ARN}" == "None" || -z "${SERVICE_ARN}" ]]; then
+            cat > create-service.json <<JSON
+          {
+            "ServiceName": "${SERVICE_NAME}",
+            "SourceConfiguration": $(cat source-configuration.json),
+            "InstanceConfiguration": $(cat instance-configuration.json),
+            "HealthCheckConfiguration": $(cat health-check-configuration.json),
+            "Tags": [
+              {"Key": "Project", "Value": "biznisweb"},
+              {"Key": "Component", "Value": "vevo-production-board"}
+            ]
+          }
+          JSON
+            aws apprunner create-service \
+              --cli-input-json file://create-service.json \
+              --region "${AWS_REGION}" > service-operation.json
+            SERVICE_ARN="$(python - <<'PY'
+          import json
+          payload = json.load(open("service-operation.json", encoding="utf-8"))
+          print(payload["Service"]["ServiceArn"])
+          PY
+            )"
+          else
+            aws apprunner update-service \
+              --service-arn "${SERVICE_ARN}" \
+              --source-configuration file://source-configuration.json \
+              --instance-configuration file://instance-configuration.json \
+              --health-check-configuration file://health-check-configuration.json \
+              --region "${AWS_REGION}" > service-operation.json
+          fi
+
+          for _ in $(seq 1 90); do
+            aws apprunner describe-service \
+              --service-arn "${SERVICE_ARN}" \
+              --region "${AWS_REGION}" > service.json
+            STATUS="$(python - <<'PY'
+          import json
+          print(json.load(open("service.json", encoding="utf-8"))["Service"]["Status"])
+          PY
+            )"
+            if [[ "${STATUS}" == "RUNNING" ]]; then
+              break
+            fi
+            if [[ "${STATUS}" == "CREATE_FAILED" || "${STATUS}" == "UPDATE_FAILED" || "${STATUS}" == "DELETE_FAILED" ]]; then
+              cat service.json
+              exit 1
+            fi
+            echo "App Runner service ${SERVICE_NAME} status=${STATUS}; waiting..."
+            sleep 20
+          done
+
+          aws apprunner describe-service \
+            --service-arn "${SERVICE_ARN}" \
+            --region "${AWS_REGION}" > service.json
+          STATUS="$(python - <<'PY'
+          import json
+          print(json.load(open("service.json", encoding="utf-8"))["Service"]["Status"])
+          PY
+          )"
+          if [[ "${STATUS}" != "RUNNING" ]]; then
+            cat service.json
+            exit 1
+          fi
+          SERVICE_URL="$(python - <<'PY'
+          import json
+          service = json.load(open("service.json", encoding="utf-8"))["Service"]
+          print("https://" + service["ServiceUrl"])
+          PY
+          )"
+
+          echo "HARD_GATE_CONTEXT project=vevo"
+          echo "instance-id=N/A (AWS App Runner managed service)"
+          echo "private-ip=N/A (AWS App Runner managed service)"
+          echo "service-name=${SERVICE_NAME}"
+          echo "service-arn=${SERVICE_ARN}"
+          echo "image-path=${IMAGE_URI}"
+          echo "image-digest=${IMAGE_DIGEST}"
+          echo "health-path=${SERVICE_URL}/health"
+          echo "production-board-path=${SERVICE_URL}/production/vevo"
+
+          curl -fsS "${SERVICE_URL}/health" > /tmp/health.json
+          curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/production/vevo" -o /tmp/production-board.html
+          grep -q "vevo-production-board" /tmp/production-board.html
+          curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/production/vevo/live?refresh=1" -o /tmp/production-board-api.json
+          python - <<'PY'
+          import json
+          api = json.load(open("/tmp/production-board-api.json", encoding="utf-8"))
+          assert api["project"] == "vevo"
+          assert "Čaká na vybavenie" in api["active_order_statuses"]
+          assert "Platba online - zaplatené" in api["active_order_statuses"]
+          assert "Vevo Ylang Absolute prací gél 1L" in api["excluded_product_labels"]
+          assert "summary" in api and "products" in api and "orders" in api
+          assert all("customer" not in order for order in api["orders"])
+          assert all(
+              "customer" not in order
+              for product in api["products"]
+              for order in product.get("orders", [])
+          )
+          print(
+              "APP_RUNNER_PRODUCTION_BOARD_OK:"
+              f"active_orders={api['summary'].get('active_orders')}:"
+              f"manufacturing_products={api['summary'].get('manufacturing_products')}:"
+              f"units_to_make={api['summary'].get('units_to_make')}:"
+              f"orders_scanned={api['scan'].get('orders_scanned')}"
+          )
+          PY
+          echo "APP_RUNNER_DEPLOY_OK:${SERVICE_NAME}:${SERVICE_URL}"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2249,3 +2249,39 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - future production-board/live-server changes now trigger ECR rebuilds and production smoke can verify the production-board route
 - Next exact step:
   - expose/use the hosted live dashboard entrypoint for production users; code/runtime verification is complete
+
+### 2026-05-21 (VEVO production board App Runner exposure in progress)
+- Branch: `codex/live-dashboard-apprunner`
+- Goal:
+  - expose the already-deployed VEVO production board as a persistent AWS-hosted HTTPS service for users outside this PC
+- Chosen hosting target:
+  - AWS App Runner from the existing private ECR image `919341186960.dkr.ecr.eu-central-1.amazonaws.com/vevo-reporting:latest`
+  - service name: `biznisweb-vevo-production-board`
+  - health path: `/health`
+  - user path: `/production/vevo`
+- Rationale:
+  - App Runner gives a stable public HTTPS service URL without maintaining a fixed EC2 host or ALB for this small internal tool
+  - the existing ECS/Fargate reporting image is reused, so Git/ECR remain the deployment source of truth
+- Security change:
+  - added optional Basic Auth to `live_dashboard_server.py`
+  - `/health` remains unauthenticated for managed health checks
+  - all other live dashboard routes require auth when `LIVE_DASHBOARD_AUTH_USER` and `LIVE_DASHBOARD_AUTH_PASSWORD` are configured
+  - App Runner deploy stores `LIVE_DASHBOARD_AUTH_PASSWORD` in SSM Parameter Store at `/biznisweb/live-dashboard/basic-auth-password`
+- Deployment automation:
+  - added `.github/workflows/deploy-live-dashboard-apprunner.yml`
+  - workflow creates/updates App Runner ECR access and runtime instance roles
+  - workflow reuses the existing `BIZNISWEB_API_TOKEN` secret reference from `vevo-reporting-daily`
+  - workflow creates or updates the App Runner service and verifies:
+    - public `/health`
+    - authenticated `/production/vevo`
+    - authenticated `/api/production/vevo/live?refresh=1`
+    - `vevo-production-board` marker
+    - configured active statuses and Ylang gel exclusion
+    - no customer fields in the payload
+- Verified locally:
+  - `python -m py_compile live_dashboard_server.py`
+  - `python -m unittest tests.test_live_dashboard_auth tests.test_production_board`
+  - YAML parse for all `.github/workflows/*.yml`
+  - `git diff --check`
+- Next exact step:
+  - merge this branch, wait for the guarded ECR rebuild, dispatch `Deploy Live Dashboard App Runner`, then record the App Runner service URL and smoke result

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import hmac
 import json
+import os
 from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 from urllib.parse import parse_qs, quote, urlparse
 
 from production_board import get_cached_production_board_snapshot, resolve_production_board_settings
@@ -17,6 +20,35 @@ from reporting_core import load_project_settings
 
 ROOT_DIR = Path(__file__).resolve().parent
 PROJECTS_DIR = ROOT_DIR / "projects"
+
+
+def live_dashboard_auth_credentials() -> Optional[Tuple[str, str]]:
+    """Return Basic Auth credentials when protection is configured."""
+    user = os.getenv("LIVE_DASHBOARD_AUTH_USER", "").strip()
+    password = os.getenv("LIVE_DASHBOARD_AUTH_PASSWORD", "")
+    if not user and not password:
+        return None
+    if not user or not password:
+        return ("", "")
+    return (user, password)
+
+
+def is_authorized_basic_header(header: Optional[str], credentials: Optional[Tuple[str, str]]) -> bool:
+    if credentials is None:
+        return True
+    expected_user, expected_password = credentials
+    if not expected_user or not expected_password:
+        return False
+    if not header or not header.startswith("Basic "):
+        return False
+    try:
+        decoded = base64.b64decode(header[6:].strip(), validate=True).decode("utf-8")
+    except Exception:
+        return False
+    user, separator, password = decoded.partition(":")
+    if not separator:
+        return False
+    return hmac.compare_digest(user, expected_user) and hmac.compare_digest(password, expected_password)
 
 
 def available_projects() -> List[str]:
@@ -791,6 +823,16 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
     def _send_text(self, text: str, *, content_type: str, status: int = 200) -> None:
         self._send_bytes(text.encode("utf-8"), content_type=content_type, status=status)
 
+    def _send_auth_required(self) -> None:
+        body = b"Authentication required."
+        self.send_response(401)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("WWW-Authenticate", 'Basic realm="BiznisWeb reporting", charset="UTF-8"')
+        self.end_headers()
+        self.wfile.write(body)
+
     def log_message(self, format: str, *args: object) -> None:
         return
 
@@ -798,6 +840,13 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         query = parse_qs(parsed.query)
         path = parsed.path.rstrip("/") or "/"
+        if path != "/health" and not is_authorized_basic_header(
+            self.headers.get("Authorization"),
+            live_dashboard_auth_credentials(),
+        ):
+            self._send_auth_required()
+            return
+
         projects = available_projects()
         requested_period = _normalize_period_key(query.get("period", ["full"])[0] if query.get("period") else "full")
 

--- a/tests/test_live_dashboard_auth.py
+++ b/tests/test_live_dashboard_auth.py
@@ -1,0 +1,51 @@
+import base64
+import os
+import unittest
+from unittest.mock import patch
+
+from live_dashboard_server import is_authorized_basic_header, live_dashboard_auth_credentials
+
+
+def basic_header(user: str, password: str) -> str:
+    token = base64.b64encode(f"{user}:{password}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+class LiveDashboardAuthTests(unittest.TestCase):
+    @patch.dict(os.environ, {}, clear=True)
+    def test_auth_is_disabled_when_credentials_are_unset(self) -> None:
+        self.assertIsNone(live_dashboard_auth_credentials())
+        self.assertTrue(is_authorized_basic_header(None, None))
+
+    @patch.dict(
+        os.environ,
+        {"LIVE_DASHBOARD_AUTH_USER": "vevo", "LIVE_DASHBOARD_AUTH_PASSWORD": "secret"},
+        clear=True,
+    )
+    def test_basic_auth_accepts_valid_credentials(self) -> None:
+        credentials = live_dashboard_auth_credentials()
+        self.assertEqual(("vevo", "secret"), credentials)
+        self.assertTrue(is_authorized_basic_header(basic_header("vevo", "secret"), credentials))
+
+    @patch.dict(
+        os.environ,
+        {"LIVE_DASHBOARD_AUTH_USER": "vevo", "LIVE_DASHBOARD_AUTH_PASSWORD": "secret"},
+        clear=True,
+    )
+    def test_basic_auth_rejects_invalid_or_malformed_credentials(self) -> None:
+        credentials = live_dashboard_auth_credentials()
+        self.assertFalse(is_authorized_basic_header(None, credentials))
+        self.assertFalse(is_authorized_basic_header("Bearer token", credentials))
+        self.assertFalse(is_authorized_basic_header("Basic not-base64", credentials))
+        self.assertFalse(is_authorized_basic_header(basic_header("vevo", "wrong"), credentials))
+        self.assertFalse(is_authorized_basic_header(basic_header("other", "secret"), credentials))
+
+    @patch.dict(os.environ, {"LIVE_DASHBOARD_AUTH_USER": "vevo"}, clear=True)
+    def test_partial_auth_configuration_rejects_all_requests(self) -> None:
+        credentials = live_dashboard_auth_credentials()
+        self.assertEqual(("", ""), credentials)
+        self.assertFalse(is_authorized_basic_header(basic_header("vevo", "anything"), credentials))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds hosted deployment support for the VEVO production board via AWS App Runner.

- adds optional Basic Auth to `live_dashboard_server.py`
- keeps `/health` public for managed health checks and protects all other routes when auth env vars are configured
- adds auth unit tests
- adds a GitHub Actions deploy workflow for App Runner
- deploy workflow reuses the existing ECR image and existing `BIZNISWEB_API_TOKEN` runtime secret reference from `vevo-reporting-daily`
- deploy workflow creates/updates App Runner IAM roles, SSM password parameter, service config, and verifies `/production/vevo` plus the live JSON API
- extends the ECR publication test gate with `tests.test_live_dashboard_auth`

## Validation

- `python -m py_compile live_dashboard_server.py`
- `python -m unittest tests.test_live_dashboard_auth tests.test_production_board`
- YAML parse for all `.github/workflows/*.yml`
- `git diff --check`

## Deployment plan after merge

1. Wait for the guarded ECR rebuild from `main`.
2. Dispatch `Deploy Live Dashboard App Runner` for service `biznisweb-vevo-production-board`.
3. Record the App Runner URL and smoke result in `PROJECT_STATE.md`.
