### PR TITLE
[codex] Allow App Runner auth password rotation

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           SERVICE_NAME: ${{ inputs.service_name }}
           AUTH_USER: ${{ inputs.auth_user }}
+          REQUESTED_AUTH_PASSWORD: ${{ secrets.LIVE_DASHBOARD_AUTH_PASSWORD }}
         run: |
           set -euo pipefail
 
@@ -93,7 +94,15 @@ jobs:
           )"
 
           PASSWORD_PARAM="/biznisweb/live-dashboard/basic-auth-password"
-          if ! aws ssm get-parameter --name "${PASSWORD_PARAM}" --region "${AWS_REGION}" >/dev/null 2>&1; then
+          if [[ -n "${REQUESTED_AUTH_PASSWORD:-}" ]]; then
+            echo "::add-mask::${REQUESTED_AUTH_PASSWORD}"
+            aws ssm put-parameter \
+              --name "${PASSWORD_PARAM}" \
+              --type SecureString \
+              --value "${REQUESTED_AUTH_PASSWORD}" \
+              --overwrite \
+              --region "${AWS_REGION}" >/dev/null
+          elif ! aws ssm get-parameter --name "${PASSWORD_PARAM}" --region "${AWS_REGION}" >/dev/null 2>&1; then
             GENERATED_PASSWORD="$(openssl rand -base64 36)"
             aws ssm put-parameter \
               --name "${PASSWORD_PARAM}" \

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2326,3 +2326,16 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - next recommended exposure step is attaching a memorable domain such as `vyroba.vevo.sk` or `production.vevo.sk` to the App Runner service
 - Next exact step:
   - choose the public hostname and DNS owner, then attach it as an App Runner custom domain and distribute the Basic Auth credentials through a secure channel
+
+### 2026-05-21 (VEVO production board App Runner auth rotation in progress)
+- Branch: `codex/set-apprunner-auth-credentials`
+- Requested credential change:
+  - Basic Auth username: `marek`
+  - Basic Auth password: managed via GitHub Actions secret `LIVE_DASHBOARD_AUTH_PASSWORD`
+- Deployment workflow change:
+  - `.github/workflows/deploy-live-dashboard-apprunner.yml` now overwrites SSM SecureString `/biznisweb/live-dashboard/basic-auth-password` from `secrets.LIVE_DASHBOARD_AUTH_PASSWORD` when the secret is configured
+  - if the secret is not configured, the workflow keeps the previous behavior and only generates a random password when the SSM parameter does not exist
+- Local setup:
+  - updated GitHub Actions secret `LIVE_DASHBOARD_AUTH_PASSWORD` for repo `vzeman/biznisweb`
+- Next exact step:
+  - merge workflow update, dispatch App Runner deploy with `auth_user=marek`, then verify old unauthenticated access still returns `401` and authenticated access works


### PR DESCRIPTION
## Summary

Allows the App Runner deploy workflow to rotate the live dashboard Basic Auth password from a GitHub Actions secret.

- reads `secrets.LIVE_DASHBOARD_AUTH_PASSWORD`
- overwrites SSM SecureString `/biznisweb/live-dashboard/basic-auth-password` when the secret is configured
- keeps the previous generated-password fallback for first-time deployments without the secret
- records the requested App Runner auth rotation state in `PROJECT_STATE.md`

## Requested credentials

- username to deploy: `marek`
- password source: GitHub Actions secret `LIVE_DASHBOARD_AUTH_PASSWORD`

## Validation

- YAML parse for `.github/workflows/deploy-live-dashboard-apprunner.yml`
- `git diff --check`
