### PR TITLE
[codex] Deploy App Runner with image digest

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth
+          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -51,6 +51,7 @@ jobs:
             --region "${AWS_REGION}" \
             --query 'imageDetails[0].imageDigest' \
             --output text)"
+          IMAGE_IDENTIFIER="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}@${IMAGE_DIGEST}"
 
           aws ecs describe-task-definition \
             --task-definition vevo-reporting-daily \
@@ -205,7 +206,7 @@ jobs:
           cat > source-configuration.json <<JSON
           {
             "ImageRepository": {
-              "ImageIdentifier": "${IMAGE_URI}",
+              "ImageIdentifier": "${IMAGE_IDENTIFIER}",
               "ImageRepositoryType": "ECR",
               "ImageConfiguration": {
                 "Port": "8080",
@@ -330,12 +331,15 @@ jobs:
           echo "service-arn=${SERVICE_ARN}"
           echo "image-path=${IMAGE_URI}"
           echo "image-digest=${IMAGE_DIGEST}"
+          echo "image-identifier=${IMAGE_IDENTIFIER}"
           echo "health-path=${SERVICE_URL}/health"
           echo "production-board-path=${SERVICE_URL}/production/vevo"
 
           curl -fsS "${SERVICE_URL}/health" > /tmp/health.json
           curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/production/vevo" -o /tmp/production-board.html
           grep -q "vevo-production-board" /tmp/production-board.html
+          grep -q "productsCards" /tmp/production-board.html
+          grep -q "@media (max-width:680px)" /tmp/production-board.html
           curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/production/vevo/live?refresh=1" -o /tmp/production-board-api.json
           python - <<'PY'
           import json

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2370,3 +2370,14 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - local API returned `active_orders=26`, `manufacturing_products=21`, `units_to_make=48.0`, `orders_scanned=300`
 - Next exact step:
   - merge the mobile layout branch into `main`, rebuild the App Runner image, redeploy `biznisweb-vevo-production-board`, then verify authenticated mobile HTML markers on the public URL
+
+### 2026-05-21 (App Runner digest deploy fix in progress)
+- Branch: `codex/apprunner-digest-deploy`
+- Issue found:
+  - App Runner deploy workflow could succeed while keeping the same `latest` image identifier string, so the public service could continue serving the previous runtime image
+- Change:
+  - deploy workflow now resolves the current ECR `latest` digest and passes the digest-specific ECR image identifier to App Runner
+  - deploy smoke now checks the mobile production-board HTML markers `productsCards` and `@media (max-width:680px)`
+  - ECR build regression test list now includes `tests.test_live_dashboard_mobile`
+- Next exact step:
+  - merge the deploy fix, rebuild the ECR image, redeploy App Runner, and verify the public URL contains the mobile production-board markers


### PR DESCRIPTION
What changed
- App Runner deploy now resolves the current ECR digest and uses a digest-specific image identifier.
- Deploy smoke now verifies the mobile production-board HTML markers, not only the generic page marker.
- ECR build regression tests now include tests.test_live_dashboard_mobile.
- PROJECT_STATE.md records the deployment issue and next step.

Validation
- python -m unittest tests.test_live_dashboard_mobile tests.test_live_dashboard_auth tests.test_production_board
- YAML parse for .github/workflows/*.yml
- git diff --check