### PR TITLE
[codex] Add ROY live operations dashboard

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -16,6 +16,7 @@ on:
       - dashboard_modern.py
       - live_dashboard_server.py
       - production_board.py
+      - roy_operations_dashboard.py
       - project_config.py
       - weather_client.py
       - http_client.py
@@ -58,7 +59,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile
+          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -3,6 +3,10 @@ name: Deploy Live Dashboard App Runner
 on:
   workflow_dispatch:
     inputs:
+      project:
+        description: Reporting project slug
+        required: true
+        default: vevo
       service_name:
         description: App Runner service name
         required: true
@@ -11,6 +15,14 @@ on:
         description: Basic Auth username
         required: true
         default: vevo
+      s3_bucket:
+        description: Optional S3 bucket for latest report artifacts
+        required: false
+        default: ""
+      s3_prefix:
+        description: Optional S3 prefix for latest report artifacts
+        required: false
+        default: ""
 
 env:
   AWS_REGION: eu-central-1
@@ -37,11 +49,17 @@ jobs:
       - name: Deploy App Runner service
         shell: bash
         env:
+          PROJECT: ${{ inputs.project }}
           SERVICE_NAME: ${{ inputs.service_name }}
           AUTH_USER: ${{ inputs.auth_user }}
-          REQUESTED_AUTH_PASSWORD: ${{ secrets.LIVE_DASHBOARD_AUTH_PASSWORD }}
+          DEFAULT_AUTH_PASSWORD: ${{ secrets.LIVE_DASHBOARD_AUTH_PASSWORD }}
+          ROY_AUTH_PASSWORD: ${{ secrets.ROY_LIVE_DASHBOARD_AUTH_PASSWORD }}
+          INPUT_S3_BUCKET: ${{ inputs.s3_bucket }}
+          INPUT_S3_PREFIX: ${{ inputs.s3_prefix }}
         run: |
           set -euo pipefail
+          PROJECT="$(printf '%s' "${PROJECT}" | tr '[:upper:]' '[:lower:]')"
+          TASK_FAMILY="${PROJECT}-reporting-daily"
 
           ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
           IMAGE_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG}"
@@ -54,7 +72,7 @@ jobs:
           IMAGE_IDENTIFIER="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}@${IMAGE_DIGEST}"
 
           aws ecs describe-task-definition \
-            --task-definition vevo-reporting-daily \
+            --task-definition "${TASK_FAMILY}" \
             --region "${AWS_REGION}" > task-definition.json
 
           BIZNISWEB_TOKEN_REF="$(python - <<'PY'
@@ -65,7 +83,7 @@ jobs:
               if secret.get("name") == "BIZNISWEB_API_TOKEN":
                   print(secret["valueFrom"])
                   raise SystemExit(0)
-          raise SystemExit("BIZNISWEB_API_TOKEN secret not found in vevo-reporting-daily")
+          raise SystemExit("BIZNISWEB_API_TOKEN secret not found in task definition")
           PY
           )"
           if [[ "${BIZNISWEB_TOKEN_REF}" != arn:* ]]; then
@@ -94,7 +112,43 @@ jobs:
           PY
           )"
 
-          PASSWORD_PARAM="/biznisweb/live-dashboard/basic-auth-password"
+          REPORT_S3_BUCKET_VALUE="${INPUT_S3_BUCKET:-}"
+          REPORT_S3_PREFIX_VALUE="${INPUT_S3_PREFIX:-}"
+          if [[ -z "${REPORT_S3_BUCKET_VALUE}" || -z "${REPORT_S3_PREFIX_VALUE}" ]]; then
+            python - <<'PY' > /tmp/task-env.json
+          import json
+          task_def = json.load(open("task-definition.json", encoding="utf-8"))["taskDefinition"]
+          env = {item.get("name"): item.get("value") for item in task_def["containerDefinitions"][0].get("environment", [])}
+          print(json.dumps(env))
+          PY
+            if [[ -z "${REPORT_S3_BUCKET_VALUE}" ]]; then
+              REPORT_S3_BUCKET_VALUE="$(python - <<'PY'
+          import json
+          env = json.load(open("/tmp/task-env.json", encoding="utf-8"))
+          print(env.get("REPORT_S3_BUCKET") or "")
+          PY
+              )"
+            fi
+            if [[ -z "${REPORT_S3_PREFIX_VALUE}" ]]; then
+              REPORT_S3_PREFIX_VALUE="$(python - "${PROJECT}" <<'PY'
+          import json, sys
+          project = sys.argv[1]
+          env = json.load(open("/tmp/task-env.json", encoding="utf-8"))
+          print(env.get("REPORT_S3_PREFIX") or ("daily-reports/roy-sk" if project == "roy" else f"daily-reports/{project}"))
+          PY
+              )"
+            fi
+          fi
+
+          REQUESTED_AUTH_PASSWORD="${DEFAULT_AUTH_PASSWORD:-}"
+          if [[ "${PROJECT}" == "roy" && -n "${ROY_AUTH_PASSWORD:-}" ]]; then
+            REQUESTED_AUTH_PASSWORD="${ROY_AUTH_PASSWORD}"
+          fi
+
+          PASSWORD_PARAM="/biznisweb/live-dashboard/${PROJECT}/basic-auth-password"
+          if [[ "${PROJECT}" == "vevo" ]]; then
+            PASSWORD_PARAM="/biznisweb/live-dashboard/basic-auth-password"
+          fi
           if [[ -n "${REQUESTED_AUTH_PASSWORD:-}" ]]; then
             echo "::add-mask::${REQUESTED_AUTH_PASSWORD}"
             aws ssm put-parameter \
@@ -196,6 +250,19 @@ jobs:
             ]
           }
           JSON
+          if [[ -n "${REPORT_S3_BUCKET_VALUE:-}" ]]; then
+            python - "${REPORT_S3_BUCKET_VALUE}" "${REPORT_S3_PREFIX_VALUE}" <<'PY'
+          import json, sys
+          bucket, prefix = sys.argv[1], sys.argv[2].strip("/")
+          policy = json.load(open("instance-policy.json", encoding="utf-8"))
+          policy["Statement"].append({
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": [f"arn:aws:s3:::{bucket}/{prefix}/latest/*"],
+          })
+          json.dump(policy, open("instance-policy.json", "w", encoding="utf-8"), indent=2)
+          PY
+          fi
 
           aws iam put-role-policy \
             --role-name "${INSTANCE_ROLE_NAME}" \
@@ -212,10 +279,13 @@ jobs:
                 "Port": "8080",
                 "StartCommand": "python live_dashboard_server.py --host 0.0.0.0 --port 8080",
                 "RuntimeEnvironmentVariables": {
-                  "REPORT_PROJECT": "vevo",
+                  "REPORT_PROJECT": "${PROJECT}",
                   "REPORT_SKIP_PROJECT_ENV": "true",
                   "LIVE_DASHBOARD_AUTH_USER": "${AUTH_USER}",
-                  "BIZNISWEB_API_TIMEOUT_SEC": "30"
+                  "BIZNISWEB_API_TIMEOUT_SEC": "30",
+                  "AWS_REGION": "${AWS_REGION}",
+                  "LIVE_DASHBOARD_S3_BUCKET": "${REPORT_S3_BUCKET_VALUE}",
+                  "LIVE_DASHBOARD_S3_PREFIX": "${REPORT_S3_PREFIX_VALUE}"
                 },
                 "RuntimeEnvironmentSecrets": {
                   "BIZNISWEB_API_TOKEN": "${BIZNISWEB_TOKEN_REF}",
@@ -263,7 +333,7 @@ jobs:
             "HealthCheckConfiguration": $(cat health-check-configuration.json),
             "Tags": [
               {"Key": "Project", "Value": "biznisweb"},
-              {"Key": "Component", "Value": "vevo-production-board"}
+              {"Key": "Component", "Value": "${PROJECT}-live-dashboard"}
             ]
           }
           JSON
@@ -324,7 +394,7 @@ jobs:
           PY
           )"
 
-          echo "HARD_GATE_CONTEXT project=vevo"
+          echo "HARD_GATE_CONTEXT project=${PROJECT}"
           echo "instance-id=N/A (AWS App Runner managed service)"
           echo "private-ip=N/A (AWS App Runner managed service)"
           echo "service-name=${SERVICE_NAME}"
@@ -333,15 +403,40 @@ jobs:
           echo "image-digest=${IMAGE_DIGEST}"
           echo "image-identifier=${IMAGE_IDENTIFIER}"
           echo "health-path=${SERVICE_URL}/health"
-          echo "production-board-path=${SERVICE_URL}/production/vevo"
+          echo "production-board-path=${SERVICE_URL}/production/${PROJECT}"
+          echo "latest-artifacts-s3=s3://${REPORT_S3_BUCKET_VALUE}/${REPORT_S3_PREFIX_VALUE}/latest/"
 
           curl -fsS "${SERVICE_URL}/health" > /tmp/health.json
-          curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/production/vevo" -o /tmp/production-board.html
-          grep -q "vevo-production-board" /tmp/production-board.html
-          grep -q "productsCards" /tmp/production-board.html
-          grep -q "@media (max-width:680px)" /tmp/production-board.html
-          curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/production/vevo/live?refresh=1" -o /tmp/production-board-api.json
-          python - <<'PY'
+          curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/production/${PROJECT}" -o /tmp/production-board.html
+          if [[ "${PROJECT}" == "roy" ]]; then
+            grep -q "roy-operations-dashboard" /tmp/production-board.html
+            grep -q "Executive KPI deck" /tmp/production-board.html
+            curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/operations/roy/live?refresh=1" -o /tmp/production-board-api.json
+            python - <<'PY'
+          import json
+          api = json.load(open("/tmp/production-board-api.json", encoding="utf-8"))
+          assert api["project"] == "roy"
+          assert api["marker"] == "roy-operations-dashboard"
+          assert "executive_kpis" in api and "orders" in api and "inventory" in api
+          assert api["orders"]["auto_refresh_seconds"] == 90
+          assert "personal_pickups" in api["orders"]
+          assert api["executive_kpis"].get("windows"), "Executive KPI windows missing"
+          assert len(api["executive_kpis"].get("months") or []) > 0, "Calendar KPI months missing"
+          assert api["inventory"].get("summary"), "Inventory summary missing"
+          print(
+              "APP_RUNNER_ROY_OPERATIONS_OK:"
+              f"fulfillable_orders={api['orders']['summary'].get('fulfillable_orders')}:"
+              f"personal_pickups={api['orders']['summary'].get('personal_pickups')}:"
+              f"inventory_alerts={api['inventory']['summary'].get('alert_delivery_count')}:"
+              f"kpi_months={len(api['executive_kpis'].get('months') or [])}"
+          )
+          PY
+          else
+            grep -q "vevo-production-board" /tmp/production-board.html
+            grep -q "productsCards" /tmp/production-board.html
+            grep -q "@media (max-width:680px)" /tmp/production-board.html
+            curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/production/vevo/live?refresh=1" -o /tmp/production-board-api.json
+            python - <<'PY'
           import json
           api = json.load(open("/tmp/production-board-api.json", encoding="utf-8"))
           assert api["project"] == "vevo"
@@ -363,4 +458,5 @@ jobs:
               f"orders_scanned={api['scan'].get('orders_scanned')}"
           )
           PY
+          fi
           echo "APP_RUNNER_DEPLOY_OK:${SERVICE_NAME}:${SERVICE_URL}"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -253,6 +253,7 @@ Bootstrap entrypoints:
 - Known issues / notes:
   - in-app browser screenshot capture timed out through CDP, but DOM/UI verification passed.
   - PR checks are green: `env-check`, `secret-scan`, `security-baseline`, `observability-baseline`.
+  - GitHub Actions secret `ROY_LIVE_DASHBOARD_AUTH_PASSWORD` was set on `2026-05-26`; the requested runtime username/password is `roy21` / secret-backed password value.
   - production deploy is not done yet in this branch.
   - ROY App Runner deployment needs `ROY_LIVE_DASHBOARD_AUTH_PASSWORD` set to the intended password and an S3 bucket/prefix that exposes `dashboard_payload_latest.json` under `latest/`.
 - Next exact step:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -204,12 +204,13 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- Deploy the ROY operations dashboard after branch review/merge: build the refreshed ECR image, run App Runner deploy for service `biznisweb-roy-operations-dashboard`, verify `/production/roy` and `/api/operations/roy/live?refresh=1` with the hard-gate host/service/path context.
+- Review and merge draft PR `#80`, then build the refreshed ECR image and deploy App Runner service `biznisweb-roy-operations-dashboard`; verify `/production/roy` and `/api/operations/roy/live?refresh=1` with the hard-gate host/service/path context.
 
 ## 9) Change Log
 
 ### 2026-05-26 (ROY operations dashboard implementation)
 - Branch: `codex/roy-live-dashboard`
+- Draft PR: `https://github.com/vzeman/biznisweb/pull/80`
 - Added a dedicated ROY operations dashboard behind `/production/roy`:
   - Executive KPI deck is rendered from the existing ROY reporting payload.
   - Daily / Weekly / Monthly / All-time KPI windows remain available.
@@ -254,7 +255,7 @@ Bootstrap entrypoints:
   - production deploy is not done yet in this branch.
   - ROY App Runner deployment needs `ROY_LIVE_DASHBOARD_AUTH_PASSWORD` set to the intended password and an S3 bucket/prefix that exposes `dashboard_payload_latest.json` under `latest/`.
 - Next exact step:
-  - push the branch, create/merge PR, build the ECR image, then deploy App Runner service `biznisweb-roy-operations-dashboard` with path `/production/roy` and Basic Auth user `roy21`.
+  - review/merge PR `#80`, build the ECR image, then deploy App Runner service `biznisweb-roy-operations-dashboard` with path `/production/roy` and Basic Auth user `roy21`.
 
 ### 2026-05-11
 - Implemented smart reporting cache revalidation so delayed payment/status changes are not stuck in older daily cache buckets:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -204,9 +204,57 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- Monitor the next scheduled VEVO and ROY daily reports and confirm they finish with normal QA/source-health status after the cache revalidation deployment.
+- Deploy the ROY operations dashboard after branch review/merge: build the refreshed ECR image, run App Runner deploy for service `biznisweb-roy-operations-dashboard`, verify `/production/roy` and `/api/operations/roy/live?refresh=1` with the hard-gate host/service/path context.
 
 ## 9) Change Log
+
+### 2026-05-26 (ROY operations dashboard implementation)
+- Branch: `codex/roy-live-dashboard`
+- Added a dedicated ROY operations dashboard behind `/production/roy`:
+  - Executive KPI deck is rendered from the existing ROY reporting payload.
+  - Daily / Weekly / Monthly / All-time KPI windows remain available.
+  - calendar month switching is generated from the reporting time series.
+  - the page auto-refreshes from live data every `90` seconds.
+- Added live ROY fulfillment data:
+  - `/api/operations/roy/live` fetches open BiznisWeb orders directly.
+  - fulfillable orders include `Platba online - zaplatené` and `Čaká na vybavenie` only when the payment price element is dobierka/dobírka.
+  - the public payload excludes customer PII.
+- Added personal pickup handling:
+  - personal pickup is detected from shipping `Osobný odber na sklade` / shipping id `11`.
+  - pickup rows render a checkbox action.
+  - `POST /api/operations/roy/pickup/<order_num>/ship` validates that the order is a ROY personal pickup in an allowed status, then changes BiznisWeb status to `Odoslaná` (`status_id=4`).
+- Added ROY inventory dashboard surfaces:
+  - home alerts use existing reporting inventory alert rows.
+  - stock tab exposes inventory cost value without VAT, retail value without VAT, risk rows, projected stockout date, reorder date, suggested reorder units, and lead-time context.
+- Updated ROY inventory lead times:
+  - Wachman: `30` working days.
+  - ROY: `30` working days.
+  - MACO STOP: `12` working days.
+  - SD / memory storage family: `3` working days.
+  - added family-level lead-time fallback for memory storage products.
+- App Runner workflows:
+  - deploy workflow is now project-aware instead of VEVO-only.
+  - ROY can use project-specific Basic Auth secret `ROY_LIVE_DASHBOARD_AUTH_PASSWORD`.
+  - App Runner can read latest reporting artifacts from S3 for the KPI/inventory payload.
+  - ROY deploy smoke asserts `/production/roy`, `roy-operations-dashboard`, KPI windows/months, inventory summary, and live order payload.
+  - ECR build workflow now tracks `roy_operations_dashboard.py` and runs `tests.test_roy_operations_dashboard`.
+- Local verification:
+  - `python -m py_compile live_dashboard_server.py roy_operations_dashboard.py export_orders.py`
+  - `python -m unittest`
+  - `python scripts\security_ci.py`
+  - `python scripts\reporting_qa_smoke.py`
+  - `git diff --check`
+  - YAML parse for updated workflows
+  - extracted App Runner deploy Bash script passes `bash -n`
+  - local `/production/roy` returned the `roy-operations-dashboard` marker, `Executive KPI deck`, and `Osobné odbery`
+  - local `/api/operations/roy/live?refresh=1` returned live ROY data with `fulfillable_orders=55`, `personal_pickups=1`, `kpi_months=8`, and inventory alert data
+  - in-app browser smoke verified KPI month switching, inventory tab rendering, and no console errors
+- Known issues / notes:
+  - in-app browser screenshot capture timed out through CDP, but DOM/UI verification passed.
+  - production deploy is not done yet in this branch.
+  - ROY App Runner deployment needs `ROY_LIVE_DASHBOARD_AUTH_PASSWORD` set to the intended password and an S3 bucket/prefix that exposes `dashboard_payload_latest.json` under `latest/`.
+- Next exact step:
+  - push the branch, create/merge PR, build the ECR image, then deploy App Runner service `biznisweb-roy-operations-dashboard` with path `/production/roy` and Basic Auth user `roy21`.
 
 ### 2026-05-11
 - Implemented smart reporting cache revalidation so delayed payment/status changes are not stuck in older daily cache buckets:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -252,6 +252,7 @@ Bootstrap entrypoints:
   - in-app browser smoke verified KPI month switching, inventory tab rendering, and no console errors
 - Known issues / notes:
   - in-app browser screenshot capture timed out through CDP, but DOM/UI verification passed.
+  - PR checks are green: `env-check`, `secret-scan`, `security-baseline`, `observability-baseline`.
   - production deploy is not done yet in this branch.
   - ROY App Runner deployment needs `ROY_LIVE_DASHBOARD_AUTH_PASSWORD` set to the intended password and an S3 bucket/prefix that exposes `dashboard_payload_latest.json` under `latest/`.
 - Next exact step:

--- a/export_orders.py
+++ b/export_orders.py
@@ -8678,6 +8678,11 @@ class BizniWebExporter:
             for key, value in (inventory_config.get("lead_time_working_days_by_brand") or {}).items()
             if str(key).strip()
         }
+        lead_time_working_days_by_family = {
+            str(key).strip().lower(): max(0, int(value or 0))
+            for key, value in (inventory_config.get("lead_time_working_days_by_family") or {}).items()
+            if str(key).strip()
+        }
         alert_exclusion_patterns = [
             str(pattern).strip()
             for pattern in (inventory_config.get("alert_exclusion_label_patterns") or [])
@@ -9183,7 +9188,7 @@ class BizniWebExporter:
                 lambda value: pd.Series(self._extract_product_family(value))
             )
             inventory_products_df["strategic_stock_flag"] = inventory_products_df["brand_key"].isin(hero_brand_keys)
-            inventory_products_df["lead_time_working_days"] = (
+            brand_lead_time = (
                 inventory_products_df["brand_key"]
                 .astype(str)
                 .str.strip()
@@ -9191,6 +9196,19 @@ class BizniWebExporter:
                 .map(lead_time_working_days_by_brand)
                 .fillna(0)
                 .astype(int)
+            )
+            family_lead_time = (
+                inventory_products_df["family_key"]
+                .astype(str)
+                .str.strip()
+                .str.lower()
+                .map(lead_time_working_days_by_family)
+                .fillna(0)
+                .astype(int)
+            )
+            inventory_products_df["lead_time_working_days"] = brand_lead_time.where(
+                brand_lead_time > 0,
+                family_lead_time,
             )
             inventory_products_df["lead_time_calendar_days"] = np.ceil(
                 inventory_products_df["lead_time_working_days"] * (7.0 / 5.0)

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -12,9 +12,14 @@ from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
-from urllib.parse import parse_qs, quote, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
 from production_board import get_cached_production_board_snapshot, resolve_production_board_settings
+from roy_operations_dashboard import (
+    get_cached_roy_operations_snapshot,
+    mark_personal_pickup_shipped,
+    resolve_roy_operations_settings,
+)
 from reporting_core import load_project_settings
 
 
@@ -105,6 +110,64 @@ def _read_json_file(path: Path) -> Dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError(f"JSON payload at '{path}' must decode to an object.")
+    return payload
+
+
+def _project_env_name(project: str) -> str:
+    return "".join(ch if ch.isalnum() else "_" for ch in str(project or "").upper())
+
+
+def _latest_s3_artifact_bytes(project: str, filename: str) -> Optional[bytes]:
+    settings = load_project_settings(project)
+    s3_settings = settings.get("live_dashboard_artifacts") or {}
+    env_project = _project_env_name(project)
+    bucket = (
+        os.getenv(f"LIVE_DASHBOARD_S3_BUCKET_{env_project}", "").strip()
+        or os.getenv("LIVE_DASHBOARD_S3_BUCKET", "").strip()
+        or os.getenv(f"REPORT_S3_BUCKET_{env_project}", "").strip()
+        or os.getenv("REPORT_S3_BUCKET", "").strip()
+        or str(s3_settings.get("s3_bucket") or "").strip()
+    )
+    prefix = (
+        os.getenv(f"LIVE_DASHBOARD_S3_PREFIX_{env_project}", "").strip()
+        or os.getenv("LIVE_DASHBOARD_S3_PREFIX", "").strip()
+        or os.getenv(f"REPORT_S3_PREFIX_{env_project}", "").strip()
+        or os.getenv("REPORT_S3_PREFIX", "").strip()
+        or str(s3_settings.get("s3_prefix") or "").strip()
+        or f"daily-reports/{project}"
+    ).strip("/")
+    if not bucket:
+        return None
+
+    try:
+        import boto3  # type: ignore
+    except ImportError:
+        return None
+
+    region = (
+        os.getenv(f"AWS_REGION_{env_project}", "").strip()
+        or os.getenv("AWS_REGION", "eu-central-1").strip()
+        or "eu-central-1"
+    )
+    key = f"{prefix}/latest/{filename}"
+    try:
+        response = boto3.client("s3", region_name=region).get_object(Bucket=bucket, Key=key)
+        return response["Body"].read()
+    except Exception:
+        return None
+
+
+def read_latest_dashboard_payload(project: str) -> Dict[str, Any]:
+    payload_path = resolve_latest_payload_path(project)
+    if payload_path is not None and payload_path.exists():
+        return _read_json_file(payload_path)
+
+    raw = _latest_s3_artifact_bytes(project, "dashboard_payload_latest.json")
+    if raw is None:
+        return {}
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"S3 dashboard payload for '{project}' must decode to an object.")
     return payload
 
 
@@ -202,7 +265,10 @@ def build_index_html(projects: List[str]) -> str:
         payload_path = resolve_latest_payload_path(project)
         production_enabled = False
         try:
-            production_enabled = bool(resolve_production_board_settings(load_project_settings(project))["enabled"])
+            project_settings = load_project_settings(project)
+            production_enabled = bool(resolve_production_board_settings(project_settings)["enabled"])
+            if project == "roy":
+                production_enabled = production_enabled or bool(resolve_roy_operations_settings(project_settings)["enabled"])
         except Exception:
             production_enabled = False
         project_q = quote(project)
@@ -859,6 +925,459 @@ def build_production_board_html(project: str) -> str:
     return html.replace("__BOOTSTRAP_JSON__", bootstrap_json)
 
 
+def build_roy_operations_dashboard_html(project: str = "roy") -> str:
+    bootstrap_json = _json_script_content({"project": project})
+    html = """<!doctype html>
+<html lang="sk">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ROY Operations Dashboard</title>
+  <style>
+    :root {
+      --bg:#f6f7f4; --panel:#ffffff; --line:#d9ded5; --text:#18211b; --muted:#657163;
+      --green:#11734b; --green-bg:#e6f3ec; --red:#aa2f2f; --red-bg:#fdeaea;
+      --amber:#8a5b00; --amber-bg:#fff2cc; --blue:#245f8f; --blue-bg:#e8f1f8;
+      --ink:#14211b;
+    }
+    * { box-sizing:border-box; }
+    body { margin:0; background:var(--bg); color:var(--text); font-family:Arial,Helvetica,sans-serif; }
+    main { width:min(1500px,calc(100vw - 24px)); margin:0 auto; padding:14px 0 34px; }
+    header { display:flex; justify-content:space-between; gap:16px; align-items:flex-start; padding:12px 0 14px; }
+    h1 { margin:0; font-size:29px; line-height:1.12; letter-spacing:0; }
+    h2 { margin:0; font-size:18px; line-height:1.2; letter-spacing:0; }
+    h3 { margin:0; font-size:15px; line-height:1.2; letter-spacing:0; }
+    p { margin:0; color:var(--muted); line-height:1.42; }
+    button,a.button,select { min-height:38px; border:1px solid var(--line); background:#fff; color:var(--text); border-radius:6px; padding:0 11px; font-weight:700; cursor:pointer; text-decoration:none; display:inline-flex; align-items:center; justify-content:center; }
+    select { cursor:pointer; min-width:150px; }
+    button.primary { background:var(--ink); color:#fff; border-color:var(--ink); }
+    button.tab.active,button.chip.active { background:var(--ink); color:#fff; border-color:var(--ink); }
+    button:disabled { opacity:.55; cursor:not-allowed; }
+    .actions,.tabs,.chips { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+    .statusline { color:var(--muted); font-size:13px; min-height:18px; }
+    .alert-grid { display:grid; grid-template-columns:repeat(5,minmax(150px,1fr)); gap:10px; margin-bottom:12px; }
+    .metric,.kpi-card { background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:12px; min-height:86px; }
+    .metric .label,.kpi-card .label { color:var(--muted); font-size:11px; text-transform:uppercase; font-weight:800; letter-spacing:.04em; }
+    .metric .value,.kpi-card .value { margin-top:7px; font-size:25px; font-weight:850; line-height:1.05; }
+    .metric .note,.kpi-card .note { margin-top:7px; font-size:12px; color:var(--muted); }
+    .panel { background:var(--panel); border:1px solid var(--line); border-radius:8px; overflow:hidden; margin-bottom:12px; }
+    .panel-head { display:flex; justify-content:space-between; gap:12px; align-items:center; padding:12px 14px; border-bottom:1px solid var(--line); background:#fafbf8; }
+    .panel-body { padding:12px; }
+    .kpi-controls { display:flex; justify-content:space-between; gap:12px; align-items:center; flex-wrap:wrap; margin-bottom:12px; }
+    .kpi-grid { display:grid; grid-template-columns:repeat(3,minmax(220px,1fr)); gap:10px; }
+    .kpi-card svg { width:100%; height:42px; margin-top:10px; display:block; }
+    .positive { color:var(--green); }
+    .negative { color:var(--red); }
+    .neutral { color:var(--muted); }
+    .badge { display:inline-flex; align-items:center; min-height:24px; padding:0 8px; border-radius:999px; font-size:12px; font-weight:800; white-space:nowrap; }
+    .badge.good { color:var(--green); background:var(--green-bg); }
+    .badge.warn { color:var(--amber); background:var(--amber-bg); }
+    .badge.bad { color:var(--red); background:var(--red-bg); }
+    .badge.info { color:var(--blue); background:var(--blue-bg); }
+    .table-wrap { overflow:auto; }
+    table { width:100%; min-width:980px; border-collapse:collapse; }
+    th,td { padding:10px 12px; border-bottom:1px solid var(--line); text-align:left; vertical-align:top; font-size:13px; }
+    th { color:var(--muted); background:#fafbf8; text-transform:uppercase; font-size:11px; letter-spacing:.04em; }
+    tbody tr:hover { background:#f8faf7; }
+    .muted { color:var(--muted); }
+    .mono { font-family:Consolas,Monaco,monospace; }
+    .items { display:grid; gap:3px; max-width:560px; }
+    .item-line { display:flex; justify-content:space-between; gap:10px; border-top:1px solid #edf0eb; padding-top:3px; }
+    .layout-2 { display:grid; grid-template-columns:minmax(0,1fr) minmax(420px,.42fr); gap:12px; align-items:start; }
+    .pickup-list { display:grid; gap:8px; max-height:620px; overflow:auto; }
+    .pickup { border:1px solid var(--line); border-radius:8px; padding:10px; background:#fff; }
+    .pickup-top { display:flex; justify-content:space-between; gap:10px; align-items:flex-start; }
+    .pickup-title { font-weight:850; font-size:16px; }
+    .checkline { display:flex; gap:8px; align-items:center; margin-top:9px; font-weight:800; }
+    .checkline input { width:19px; height:19px; }
+    .hidden { display:none !important; }
+    .error,.ok { margin-bottom:12px; padding:10px 12px; border-radius:8px; border:1px solid rgba(170,47,47,.25); color:var(--red); background:var(--red-bg); }
+    .ok { color:var(--green); background:var(--green-bg); border-color:rgba(17,115,75,.25); }
+    @media (max-width:1180px) {
+      .alert-grid { grid-template-columns:repeat(3,minmax(150px,1fr)); }
+      .kpi-grid { grid-template-columns:repeat(2,minmax(220px,1fr)); }
+      .layout-2 { grid-template-columns:1fr; }
+    }
+    @media (max-width:720px) {
+      main { width:100%; padding:10px 8px 26px; }
+      header { flex-direction:column; gap:10px; padding-top:8px; }
+      h1 { font-size:23px; }
+      .actions { width:100%; }
+      .actions button,.actions a.button { flex:1 1 auto; min-height:44px; }
+      .alert-grid,.kpi-grid { grid-template-columns:1fr; }
+      .panel-head,.kpi-controls { align-items:flex-start; flex-direction:column; }
+      button,a.button,select { min-height:42px; }
+      table { min-width:860px; }
+    }
+  </style>
+</head>
+<body>
+  <main data-marker="roy-operations-dashboard">
+    <header>
+      <div>
+        <h1>ROY operations dashboard</h1>
+        <p id="subtitle">Načítavam live stav.</p>
+      </div>
+      <div class="actions">
+        <button id="refreshBtn" class="primary" type="button">Refresh</button>
+        <a class="button" href="/">Dashboardy</a>
+      </div>
+    </header>
+    <div id="messageBox" class="hidden"></div>
+    <section class="alert-grid" id="alertGrid"></section>
+    <section class="panel">
+      <div class="panel-head">
+        <div>
+          <h2>Executive KPI deck</h2>
+          <p id="kpiMeta">-</p>
+        </div>
+        <span id="cacheBadge" class="badge info">cache</span>
+      </div>
+      <div class="panel-body">
+        <div class="kpi-controls">
+          <div class="chips" id="kpiWindowNav"></div>
+          <select id="monthSelect" aria-label="Kalendárny mesiac"></select>
+        </div>
+        <div class="kpi-grid" id="kpiGrid"></div>
+      </div>
+    </section>
+    <nav class="tabs" style="margin-bottom:12px;">
+      <button class="tab active" type="button" data-view="overview">Prehľad</button>
+      <button class="tab" type="button" data-view="orders">Objednávky</button>
+      <button class="tab" type="button" data-view="inventory">Sklad</button>
+    </nav>
+    <section id="view-overview">
+      <div class="layout-2">
+        <article class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Objednávky na vybavenie</h2>
+              <p id="ordersMeta">-</p>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Objednávka</th><th>Status</th><th>Platba</th><th>Doprava</th><th>Suma</th><th>Položky</th></tr></thead>
+              <tbody id="ordersBody"></tbody>
+            </table>
+          </div>
+        </article>
+        <article class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Osobné odbery</h2>
+              <p id="pickupMeta">-</p>
+            </div>
+          </div>
+          <div class="panel-body pickup-list" id="pickupList"></div>
+        </article>
+      </div>
+      <article class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Skladové upozornenia</h2>
+            <p id="inventoryAlertMeta">-</p>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Produkt</th><th>Riziko</th><th>Sklad</th><th>30d dopyt</th><th>Cover</th><th>Vypredanie</th><th>Objednať do</th><th>Návrh</th></tr></thead>
+            <tbody id="alertRowsBody"></tbody>
+          </table>
+        </div>
+      </article>
+    </section>
+    <section id="view-orders" class="hidden">
+      <article class="panel">
+        <div class="panel-head"><h2>Všetky vybaviteľné objednávky</h2><p id="ordersScanMeta">-</p></div>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Objednávka</th><th>Dátum</th><th>Status</th><th>Platba</th><th>Doprava</th><th>Suma</th><th>Položky</th></tr></thead>
+            <tbody id="ordersFullBody"></tbody>
+          </table>
+        </div>
+      </article>
+    </section>
+    <section id="view-inventory" class="hidden">
+      <article class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Skladové zásoby</h2>
+            <p id="inventoryMeta">-</p>
+          </div>
+        </div>
+        <div class="panel-body">
+          <div class="alert-grid" id="inventorySummaryGrid"></div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Produkt</th><th>Sklad</th><th>Nákupná hodnota</th><th>Predajná hodnota</th><th>Cover</th><th>Vypredanie</th><th>Lead time</th><th>Reorder</th></tr></thead>
+            <tbody id="inventoryRowsBody"></tbody>
+          </table>
+        </div>
+      </article>
+    </section>
+  </main>
+  <script id="roy-operations-bootstrap" type="application/json">__BOOTSTRAP_JSON__</script>
+  <script>
+    const BOOTSTRAP = JSON.parse(document.getElementById('roy-operations-bootstrap').textContent || '{}');
+    const project = BOOTSTRAP.project || 'roy';
+    const el = (id) => document.getElementById(id);
+    const fmtInt = (value) => new Intl.NumberFormat('sk-SK', { maximumFractionDigits:0 }).format(Math.round(Number(value || 0)));
+    const fmtQty = (value) => new Intl.NumberFormat('sk-SK', { maximumFractionDigits:1 }).format(Number(value || 0));
+    const fmtMoney = (value) => new Intl.NumberFormat('sk-SK', { style:'currency', currency:'EUR', maximumFractionDigits:2 }).format(Number(value || 0));
+    const fmtPct = (value) => value === null || value === undefined ? 'N/A' : `${new Intl.NumberFormat('sk-SK', { maximumFractionDigits:1 }).format(Number(value || 0))}%`;
+    const fmtRatio = (value) => value === null || value === undefined ? 'N/A' : `${new Intl.NumberFormat('sk-SK', { maximumFractionDigits:2 }).format(Number(value || 0))}x`;
+    const text = (value, fallback='-') => value === null || value === undefined || value === '' ? fallback : String(value);
+    const safe = (value) => text(value, '').replace(/[&<>"']/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+    let latestData = null;
+    let refreshTimer = null;
+    let kpiScope = 'monthly';
+
+    const metricDefsFallback = [
+      { key:'revenue', label_en:'Revenue (net)' },
+      { key:'profit', label_en:'Post-ad profit (€)' },
+      { key:'orders', label_en:'Orders' },
+      { key:'aov', label_en:'AOV (net)' },
+      { key:'cac', label_en:'CAC' },
+      { key:'roas', label_en:'ROAS' },
+      { key:'pre_ad_contribution_margin', label_en:'Pre-ad contribution' },
+      { key:'post_ad_margin', label_en:'Post-ad margin' },
+      { key:'company_margin_with_fixed', label_en:'Company margin (incl. fixed)' },
+    ];
+
+    function metric(label, value, note, tone='info') {
+      return `<article class="metric"><div class="label">${safe(label)}</div><div class="value">${safe(value)}</div><div class="note">${safe(note)}</div></article>`;
+    }
+    function badgeClass(value) {
+      const v = String(value || '').toLowerCase();
+      if (v.includes('negative') || v.includes('out of stock') || v.includes('critical') || v.includes('urgent') || v.includes('order now')) return 'bad';
+      if (v.includes('low') || v.includes('watch') || v.includes('prepare') || v.includes('plan')) return 'warn';
+      if (v.includes('healthy') || v.includes('ok')) return 'good';
+      return 'info';
+    }
+    function formatKpiValue(key, value) {
+      if (['revenue','profit','aov','cac'].includes(key)) return value === null || value === undefined ? 'N/A' : fmtMoney(value);
+      if (key === 'orders') return fmtInt(value);
+      if (key === 'roas') return fmtRatio(value);
+      if (key.includes('margin') || key.includes('contribution')) return fmtPct(value);
+      return text(value, 'N/A');
+    }
+    function comparisonText(scope, metricKey, windowPayload) {
+      const kpis = latestData.executive_kpis || {};
+      if (scope.startsWith('month:')) {
+        const comparison = ((windowPayload.comparisons || {})[metricKey] || {}).vs_previous_month;
+        return comparison === null || comparison === undefined ? 'N/A vs previous month' : `${comparison >= 0 ? '+' : ''}${fmtPct(comparison)} vs previous month`;
+      }
+      const comparison = (((kpis.comparisons || {})[scope] || {})[metricKey]) || {};
+      const key = Object.keys(comparison).find((name) => name.startsWith('vs_') && comparison[name] !== null && comparison[name] !== undefined);
+      if (!key) return 'N/A vs comparable period';
+      return `${comparison[key] >= 0 ? '+' : ''}${fmtPct(comparison[key])} ${key.replaceAll('_', ' ')}`;
+    }
+    function sparkline(values, key) {
+      if (!Array.isArray(values) || values.length < 2) return '';
+      const nums = values.map((v) => Number(v || 0));
+      const min = Math.min(...nums);
+      const max = Math.max(...nums);
+      const spread = max - min || 1;
+      const points = nums.map((v, i) => {
+        const x = (i / Math.max(nums.length - 1, 1)) * 100;
+        const y = 38 - ((v - min) / spread) * 32;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      }).join(' ');
+      const cls = ['cac'].includes(key) ? '#aa2f2f' : '#11734b';
+      return `<svg viewBox="0 0 100 42" preserveAspectRatio="none" aria-hidden="true"><polyline points="${points}" fill="none" stroke="${cls}" stroke-width="2.4" vector-effect="non-scaling-stroke"/><polygon points="0,40 ${points} 100,40" fill="${cls}" opacity=".10"/></svg>`;
+    }
+    function selectedKpiWindow() {
+      const kpis = latestData.executive_kpis || {};
+      if (kpiScope.startsWith('month:')) {
+        const monthKey = kpiScope.slice(6);
+        return (kpis.months || []).find((row) => row.key === monthKey) || null;
+      }
+      return (kpis.windows || {})[kpiScope] || null;
+    }
+    function renderKpiControls() {
+      const labels = { daily:'Daily', weekly:'Weekly', monthly:'Monthly', all_time:'All-time' };
+      el('kpiWindowNav').innerHTML = Object.keys(labels).map((key) => `<button class="chip ${kpiScope === key ? 'active' : ''}" type="button" data-kpi-window="${key}">${labels[key]}</button>`).join('');
+      el('kpiWindowNav').querySelectorAll('[data-kpi-window]').forEach((btn) => btn.addEventListener('click', () => { kpiScope = btn.dataset.kpiWindow; renderKpis(); }));
+      const months = ((latestData.executive_kpis || {}).months || []).slice().reverse();
+      el('monthSelect').innerHTML = '<option value="">Kalendárny mesiac</option>' + months.map((m) => `<option value="${safe(m.key)}">${safe(m.label_sk || m.key)}</option>`).join('');
+      el('monthSelect').value = kpiScope.startsWith('month:') ? kpiScope.slice(6) : '';
+      el('monthSelect').onchange = () => { if (el('monthSelect').value) { kpiScope = `month:${el('monthSelect').value}`; renderKpis(); } };
+    }
+    function renderKpis() {
+      if (!latestData) return;
+      renderKpiControls();
+      const kpis = latestData.executive_kpis || {};
+      const defs = (kpis.metric_defs || []).length ? kpis.metric_defs : metricDefsFallback;
+      const windowPayload = selectedKpiWindow() || {};
+      const metrics = windowPayload.metrics || {};
+      const trend = windowPayload.trend || {};
+      const trendMetrics = trend.metrics || {};
+      el('kpiMeta').textContent = `${text(windowPayload.label_sk || windowPayload.label_en || kpiScope)} · zdroj ${text(kpis.source_generated_at)}`;
+      el('kpiGrid').innerHTML = defs.map((def) => {
+        const key = def.key;
+        const value = metrics[key];
+        const compare = comparisonText(kpiScope, key, windowPayload);
+        const tone = compare.startsWith('-') && key !== 'cac' ? 'negative' : compare.startsWith('+') ? 'positive' : 'neutral';
+        const secondary = key === 'company_margin_with_fixed' && (windowPayload.secondary_metrics || {}).company_margin_with_fixed !== undefined
+          ? ` · ${fmtMoney((windowPayload.secondary_metrics || {}).company_margin_with_fixed)}` : '';
+        return `<article class="kpi-card"><div class="label">${safe(def.label_en || key)}</div><div class="value">${safe(formatKpiValue(key, value))}</div><div class="note ${tone}">${safe(compare)}${safe(secondary)}</div>${sparkline(trendMetrics[key], key)}</article>`;
+      }).join('');
+    }
+    function renderAlerts(data) {
+      const orders = (data.orders || {}).summary || {};
+      const inv = (data.inventory || {}).summary || {};
+      el('alertGrid').innerHTML = [
+        metric('Na vybavenie', fmtInt(orders.fulfillable_orders), `${fmtInt(orders.paid_online_orders)} online + ${fmtInt(orders.cod_waiting_orders)} dobierka`),
+        metric('Osobné odbery', fmtInt(orders.personal_pickups), `${fmtInt(orders.pickup_actions_available)} akcií dostupných`),
+        metric('Kritický sklad', fmtInt(inv.stock_risk_critical_count), `${fmtInt(inv.stock_risk_30d_count)} položiek v 30d riziku`),
+        metric('Objednať teraz', fmtInt(inv.alert_reorder_now_count), `${fmtInt(inv.alert_prepare_po_count)} pripraviť PO`),
+        metric('Hodnota skladu', fmtMoney(inv.inventory_cost_value), `predajná ${fmtMoney(inv.inventory_retail_value)}`),
+      ].join('');
+    }
+    function orderItemsHtml(order) {
+      const items = order.items || [];
+      if (!items.length) return '<span class="muted">bez položiek</span>';
+      return `<div class="items">${items.slice(0, 6).map((item) => `<div class="item-line"><span>${safe(item.label)}</span><strong>${fmtQty(item.quantity)} ks</strong></div>`).join('')}${items.length > 6 ? `<div class="muted">+${fmtInt(items.length - 6)} ďalších</div>` : ''}</div>`;
+    }
+    function orderRow(order, includeDate=false) {
+      return `<tr>
+        <td><strong class="mono">${safe(order.order_num)}</strong>${includeDate ? `<div class="muted">${safe(order.purchase_at)}</div>` : ''}</td>
+        <td><span class="badge ${order.fulfillment_reason === 'paid_online' ? 'good' : 'warn'}">${safe(order.status)}</span></td>
+        <td>${safe((order.payment || {}).title)}</td>
+        <td>${safe((order.shipping || {}).title)}</td>
+        <td>${safe(order.sum)}</td>
+        <td>${orderItemsHtml(order)}</td>
+      </tr>`;
+    }
+    function renderOrders(data) {
+      const ordersPayload = data.orders || {};
+      const orders = ordersPayload.orders || [];
+      const scan = ordersPayload.scan || {};
+      el('ordersMeta').textContent = `${fmtInt(orders.length)} objednávok · hodnota ${fmtMoney((ordersPayload.summary || {}).fulfillable_value)}`;
+      el('ordersScanMeta').textContent = `${fmtInt(scan.orders_scanned)} skenovaných objednávok, ${fmtInt(scan.pages_scanned)} strán, stop=${text(scan.stop_reason)}`;
+      const limited = orders.slice(0, 24);
+      el('ordersBody').innerHTML = limited.length ? limited.map((order) => orderRow(order)).join('') : '<tr><td colspan="6" class="muted">Žiadne vybaviteľné objednávky.</td></tr>';
+      el('ordersFullBody').innerHTML = orders.length ? orders.map((order) => orderRow(order, true)).join('') : '<tr><td colspan="7" class="muted">Žiadne vybaviteľné objednávky.</td></tr>';
+    }
+    function renderPickups(data) {
+      const pickups = ((data.orders || {}).personal_pickups) || [];
+      el('pickupMeta').textContent = `${fmtInt(pickups.length)} osobných odberov`;
+      el('pickupList').innerHTML = pickups.length ? pickups.map((order) => `
+        <article class="pickup">
+          <div class="pickup-top">
+            <div><div class="pickup-title mono">${safe(order.order_num)}</div><div class="muted">${safe(order.purchase_at)} · ${safe(order.sum)}</div></div>
+            <span class="badge ${badgeClass(order.status)}">${safe(order.status)}</span>
+          </div>
+          <div class="muted" style="margin-top:6px;">${safe((order.payment || {}).title)}</div>
+          <div style="margin-top:8px;">${orderItemsHtml(order)}</div>
+          <label class="checkline"><input type="checkbox" data-ship-pickup="${safe(order.order_num)}" ${order.pickup_action_allowed ? '' : 'disabled'}> Označiť ako odoslaná</label>
+        </article>`).join('') : '<p class="muted">Žiadne osobné odbery.</p>';
+      el('pickupList').querySelectorAll('[data-ship-pickup]').forEach((input) => input.addEventListener('change', () => markPickupShipped(input)));
+    }
+    function inventoryAlertRow(row) {
+      return `<tr>
+        <td><strong>${safe(row.product)}</strong><div class="muted mono">${safe(row.sku)}</div></td>
+        <td><span class="badge ${badgeClass(row.stock_risk_level || row.reorder_action_label)}">${safe(row.stock_risk_level || row.reorder_action_label)}</span></td>
+        <td>${fmtQty(row.available_quantity)} ks</td>
+        <td>${fmtQty(row.alert_30d_units)} ks</td>
+        <td>${row.days_of_cover === null || row.days_of_cover === undefined ? 'N/A' : `${fmtQty(row.days_of_cover)} dní`}</td>
+        <td>${safe(row.projected_stockout_date)}</td>
+        <td>${safe(row.reorder_by_date)}</td>
+        <td><strong>${safe(row.reorder_action_label)}</strong><div class="muted">${fmtQty(row.suggested_reorder_units)} ks · LT ${fmtInt(row.lead_time_working_days)}d</div></td>
+      </tr>`;
+    }
+    function renderInventory(data) {
+      const inv = data.inventory || {};
+      const summary = inv.summary || {};
+      const alerts = inv.alert_rows || [];
+      const inventoryRows = inv.inventory_rows || [];
+      el('inventoryAlertMeta').textContent = `${fmtInt(summary.alert_delivery_count)} alertov · snapshot ${text(summary.inventory_snapshot_date)}`;
+      el('alertRowsBody').innerHTML = alerts.length ? alerts.slice(0, 30).map(inventoryAlertRow).join('') : '<tr><td colspan="8" class="muted">Bez kritických skladových alertov.</td></tr>';
+      el('inventoryMeta').textContent = `${fmtInt(summary.inventory_products_with_stock)} produktov so skladom · coverage ${fmtPct(summary.inventory_cost_coverage_units_pct)}`;
+      el('inventorySummaryGrid').innerHTML = [
+        metric('Nákupná hodnota bez DPH', fmtMoney(summary.inventory_cost_value), `${fmtQty(summary.inventory_available_units)} ks skladom`),
+        metric('Predajná hodnota bez DPH', fmtMoney(summary.inventory_retail_value), `coverage ${fmtPct(summary.inventory_cost_coverage_retail_pct)}`),
+        metric('45d watchlist', fmtInt(summary.stock_risk_45d_count), `${fmtInt(summary.out_of_stock_recent_demand_count)} vypredané s dopytom`),
+        metric('Dead stock', fmtMoney(summary.dead_stock_cost_value), `${fmtInt(summary.dead_stock_count)} položiek`),
+        metric('Tržby v riziku', fmtMoney(summary.revenue_at_risk_30d), `zisk ${fmtMoney(summary.profit_at_risk_30d)}`),
+      ].join('');
+      el('inventoryRowsBody').innerHTML = inventoryRows.length ? inventoryRows.slice(0, 80).map((row) => `<tr>
+        <td><strong>${safe(row.product)}</strong><div class="muted mono">${safe(row.sku)}</div></td>
+        <td>${fmtQty(row.available_quantity)} ks</td>
+        <td>${fmtMoney(row.inventory_cost_value)}</td>
+        <td>${fmtMoney(row.inventory_retail_value)}</td>
+        <td>${row.days_of_cover === null || row.days_of_cover === undefined ? 'N/A' : `${fmtQty(row.days_of_cover)} dní`}</td>
+        <td>${safe(row.projected_stockout_date)}</td>
+        <td>${fmtInt(row.lead_time_working_days)} pracovných dní</td>
+        <td>${safe(row.reorder_action_label)}<div class="muted">${safe(row.reorder_by_date)} · ${fmtQty(row.suggested_reorder_units)} ks</div></td>
+      </tr>`).join('') : '<tr><td colspan="8" class="muted">Skladový payload zatiaľ nie je dostupný.</td></tr>';
+    }
+    function showMessage(message, ok=false) {
+      el('messageBox').className = ok ? 'ok' : 'error';
+      el('messageBox').textContent = message;
+    }
+    function clearMessage() { el('messageBox').className = 'hidden'; el('messageBox').textContent = ''; }
+    function render(data) {
+      latestData = data;
+      const cache = data.cache || {};
+      el('subtitle').textContent = `Posledná aktualizácia ${text(data.generated_at)}. Auto refresh ${fmtInt(data.auto_refresh_seconds || 90)}s.`;
+      el('cacheBadge').textContent = `${text(cache.status, 'live')} ${cache.age_seconds !== undefined ? `${cache.age_seconds}s` : ''}`;
+      el('cacheBadge').className = `badge ${cache.status === 'stale_after_error' ? 'bad' : 'info'}`;
+      renderAlerts(data);
+      renderKpis();
+      renderOrders(data);
+      renderPickups(data);
+      renderInventory(data);
+    }
+    async function loadDashboard(force=false) {
+      el('refreshBtn').disabled = true;
+      try {
+        const response = await fetch(`/api/operations/${encodeURIComponent(project)}/live${force ? '?refresh=1' : ''}`, { cache:'no-store' });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        render(data);
+        clearMessage();
+        if (refreshTimer) clearInterval(refreshTimer);
+        refreshTimer = setInterval(() => loadDashboard(false), Math.max(30, Number(data.auto_refresh_seconds || 90)) * 1000);
+      } catch (error) {
+        showMessage(error instanceof Error ? error.message : String(error));
+      } finally {
+        el('refreshBtn').disabled = false;
+      }
+    }
+    async function markPickupShipped(input) {
+      const orderNum = input.dataset.shipPickup;
+      if (!window.confirm(`Zmeniť objednávku ${orderNum} v eshope na Odoslaná?`)) {
+        input.checked = false;
+        return;
+      }
+      input.disabled = true;
+      try {
+        const response = await fetch(`/api/operations/${encodeURIComponent(project)}/pickup/${encodeURIComponent(orderNum)}/ship`, { method:'POST', cache:'no-store' });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        showMessage(`Objednávka ${orderNum} je zmenená na Odoslaná.`, true);
+        await loadDashboard(true);
+      } catch (error) {
+        input.checked = false;
+        input.disabled = false;
+        showMessage(error instanceof Error ? error.message : String(error));
+      }
+    }
+    el('refreshBtn').addEventListener('click', () => loadDashboard(true));
+    document.querySelectorAll('[data-view]').forEach((button) => button.addEventListener('click', () => {
+      document.querySelectorAll('[data-view]').forEach((btn) => btn.classList.toggle('active', btn === button));
+      ['overview','orders','inventory'].forEach((view) => el(`view-${view}`).classList.toggle('hidden', button.dataset.view !== view));
+    }));
+    loadDashboard(false);
+  </script>
+</body>
+</html>"""
+    return html.replace("__BOOTSTRAP_JSON__", bootstrap_json)
+
+
 class LiveDashboardHandler(BaseHTTPRequestHandler):
     server_version = "BizniWebLiveDashboard/1.1"
 
@@ -918,6 +1437,36 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
             return
 
         parts = [part for part in path.split("/") if part]
+
+        if len(parts) == 4 and parts[0] == "api" and parts[1] == "operations" and parts[3] == "live":
+            project = parts[2]
+            if project not in projects:
+                self._send_json({"error": f"Unknown project '{project}'."}, status=404)
+                return
+            if project != "roy":
+                self._send_json({"error": f"Operations dashboard is not enabled for '{project}'."}, status=404)
+                return
+            try:
+                operations_settings = resolve_roy_operations_settings(load_project_settings(project))
+            except Exception as exc:
+                self._send_json({"error": f"Failed to load ROY operations settings: {exc}"}, status=500)
+                return
+            if not operations_settings["enabled"]:
+                self._send_json({"error": f"Operations dashboard is not enabled for '{project}'."}, status=404)
+                return
+
+            force_refresh = (query.get("refresh", [""])[0] or "").strip().lower() in {"1", "true", "yes"}
+            try:
+                self._send_json(
+                    get_cached_roy_operations_snapshot(
+                        project,
+                        report_payload=read_latest_dashboard_payload(project),
+                        force_refresh=force_refresh,
+                    )
+                )
+            except Exception as exc:
+                self._send_json({"error": f"Failed to load ROY operations data: {exc}"}, status=500)
+            return
 
         if len(parts) == 4 and parts[0] == "api" and parts[1] == "production" and parts[3] == "live":
             project = parts[2]
@@ -982,6 +1531,19 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 )
                 return
             if not board_settings["enabled"]:
+                if project == "roy":
+                    try:
+                        operations_settings = resolve_roy_operations_settings(load_project_settings(project))
+                    except Exception as exc:
+                        self._send_text(
+                            f"Failed to load ROY operations settings: {escape(str(exc))}",
+                            content_type="text/plain; charset=utf-8",
+                            status=500,
+                        )
+                        return
+                    if operations_settings["enabled"]:
+                        self._send_text(build_roy_operations_dashboard_html(project), content_type="text/html; charset=utf-8")
+                        return
                 self._send_text(
                     f"Production board is not enabled for '{escape(project)}'.",
                     content_type="text/plain; charset=utf-8",
@@ -1008,6 +1570,38 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
             return
 
         self._send_text("Not found.", content_type="text/plain; charset=utf-8", status=404)
+
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        if not is_authorized_basic_header(
+            self.headers.get("Authorization"),
+            live_dashboard_auth_credentials(),
+        ):
+            self._send_auth_required()
+            return
+
+        projects = available_projects()
+        parts = [part for part in path.split("/") if part]
+        if (
+            len(parts) == 6
+            and parts[0] == "api"
+            and parts[1] == "operations"
+            and parts[3] == "pickup"
+            and parts[5] == "ship"
+        ):
+            project = parts[2]
+            order_num = unquote(parts[4])
+            if project not in projects:
+                self._send_json({"error": f"Unknown project '{project}'."}, status=404)
+                return
+            try:
+                self._send_json(mark_personal_pickup_shipped(project, order_num))
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=400)
+            return
+
+        self._send_json({"error": "Not found."}, status=404)
 
 
 def parse_args() -> argparse.Namespace:

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -10,6 +10,9 @@
     "timezone": "Europe/Bratislava",
     "task_family": "roy-reporting-daily"
   },
+  "live_dashboard_artifacts": {
+    "s3_prefix": "daily-reports/roy-sk"
+  },
   "packaging_cost_per_order": 0.05,
   "shipping_net_per_order": -0.2,
   "fixed_monthly_cost": 5500,
@@ -26,6 +29,43 @@
     "final_sweep_schedule_expression": "cron(59 23 * * ? *)",
     "timezone": "Europe/Bratislava",
     "task_family": "roy-invoice-daily"
+  },
+  "operations_dashboard": {
+    "enabled": true,
+    "paid_statuses": [
+      "Platba online - zaplatené"
+    ],
+    "cod_statuses": [
+      "Čaká na vybavenie"
+    ],
+    "cod_payment_patterns": [
+      "dobierka",
+      "dobierkou",
+      "dobírka",
+      "dobírkou"
+    ],
+    "cod_payment_ids": [
+      "7",
+      "10"
+    ],
+    "personal_pickup_shipping_names": [
+      "Osobný odber na sklade"
+    ],
+    "personal_pickup_shipping_ids": [
+      "11"
+    ],
+    "pickup_action_statuses": [
+      "Čaká na vybavenie",
+      "Platba online - zaplatené",
+      "Pripravené k odberu"
+    ],
+    "shipped_status_name": "Odoslaná",
+    "shipped_status_id": 4,
+    "scan_max_pages": 30,
+    "scan_min_pages": 8,
+    "stop_after_empty_fulfillable_pages": 3,
+    "cache_ttl_seconds": 60,
+    "auto_refresh_seconds": 90
   },
   "inventory_model": {
     "enabled": true,
@@ -46,12 +86,17 @@
     "hero_reorder_cover_days": 45,
     "hero_brand_keys": [
       "wachman",
-      "maco_stop"
+      "maco_stop",
+      "roy"
     ],
     "lead_time_working_days_by_brand": {
-      "maco_stop": 10,
-      "wachman": 20,
-      "roy": 50
+      "maco_stop": 12,
+      "wachman": 30,
+      "roy": 30,
+      "verbatim": 3
+    },
+    "lead_time_working_days_by_family": {
+      "memory_storage": 3
     },
     "alert_exclusion_label_patterns": [
       "reklamacia",

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""Live ROY operations dashboard data and actions."""
+
+from __future__ import annotations
+
+import copy
+import os
+import time
+import unicodedata
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from gql import Client, gql
+from gql.transport.requests import RequestsHTTPTransport
+
+from reporting_core import BASE_DEFAULT_PROJECT, load_project_env, load_project_settings, resolve_biznisweb_api_url
+
+
+DEFAULT_PAID_STATUSES = ("Platba online - zaplatené",)
+DEFAULT_COD_STATUSES = ("Čaká na vybavenie",)
+DEFAULT_COD_PAYMENT_PATTERNS = ("dobierk", "dobirk")
+DEFAULT_PICKUP_SHIPPING_NAMES = ("Osobný odber na sklade",)
+DEFAULT_PICKUP_SHIPPING_IDS = ("11",)
+DEFAULT_PICKUP_ACTION_STATUSES = ("Čaká na vybavenie", "Platba online - zaplatené", "Pripravené k odberu")
+DEFAULT_SHIPPED_STATUS_NAME = "Odoslaná"
+DEFAULT_SHIPPED_STATUS_ID = 4
+DEFAULT_SCAN_MAX_PAGES = 30
+DEFAULT_SCAN_MIN_PAGES = 8
+DEFAULT_STOP_AFTER_EMPTY_FULFILLABLE_PAGES = 3
+DEFAULT_CACHE_TTL_SECONDS = 60
+DEFAULT_AUTO_REFRESH_SECONDS = 90
+
+
+ROY_OPERATIONS_ORDER_QUERY = gql(
+    """
+query GetRoyOperationsOrders($params: OrderParams) {
+  getOrderList(params: $params) {
+    data {
+      id
+      order_num
+      pur_date
+      last_change
+      status {
+        id
+        name
+        color
+      }
+      price_elements {
+        type
+        title
+        value
+        reference_id
+        price {
+          value
+          formatted
+        }
+      }
+      items {
+        item_label
+        ean
+        import_code
+        warehouse_number
+        quantity
+      }
+      sum {
+        value
+        formatted
+      }
+    }
+    pageInfo {
+      hasNextPage
+      nextCursor
+      pageIndex
+      totalPages
+    }
+  }
+}
+"""
+)
+
+
+CHANGE_ORDER_STATUS_MUTATION = gql(
+    """
+mutation ChangeOrderStatus($order_num: String!, $status_id: Int!) {
+  changeOrderStatus(order_num: $order_num, status_id: $status_id) {
+    order_num
+    last_change
+    status {
+      id
+      name
+    }
+  }
+}
+"""
+)
+
+
+LIST_ORDER_STATUSES_QUERY = gql(
+    """
+query ListOrderStatuses($lang_code: CountryCodeAlpha2!) {
+  listOrderStatuses(lang_code: $lang_code, only_active: true) {
+    id
+    name
+  }
+}
+"""
+)
+
+
+_CACHE: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+
+
+def _normalize_text(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    decomposed = unicodedata.normalize("NFKD", raw)
+    without_marks = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return " ".join(without_marks.split())
+
+
+def _as_list(value: Any, default: Iterable[str]) -> List[str]:
+    if value is None:
+        return [str(item) for item in default]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(item) for item in value if str(item or "").strip()]
+
+
+def _as_int(value: Any, default: int, *, minimum: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, parsed)
+
+
+def _to_float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _pct_change(current: Optional[float], previous: Optional[float]) -> Optional[float]:
+    if current is None or previous in (None, 0):
+        return None
+    return (float(current) - float(previous)) / abs(float(previous)) * 100.0
+
+
+def resolve_roy_operations_settings(project_settings: Dict[str, Any]) -> Dict[str, Any]:
+    raw = project_settings.get("operations_dashboard") or {}
+    paid_statuses = _as_list(raw.get("paid_statuses"), DEFAULT_PAID_STATUSES)
+    cod_statuses = _as_list(raw.get("cod_statuses"), DEFAULT_COD_STATUSES)
+    cod_payment_patterns = _as_list(raw.get("cod_payment_patterns"), DEFAULT_COD_PAYMENT_PATTERNS)
+    cod_payment_ids = _as_list(raw.get("cod_payment_ids"), ())
+    pickup_shipping_names = _as_list(raw.get("personal_pickup_shipping_names"), DEFAULT_PICKUP_SHIPPING_NAMES)
+    pickup_shipping_ids = _as_list(raw.get("personal_pickup_shipping_ids"), DEFAULT_PICKUP_SHIPPING_IDS)
+    pickup_action_statuses = _as_list(raw.get("pickup_action_statuses"), DEFAULT_PICKUP_ACTION_STATUSES)
+    shipped_status_name = str(raw.get("shipped_status_name") or DEFAULT_SHIPPED_STATUS_NAME).strip()
+
+    return {
+        "enabled": bool(raw.get("enabled", False)),
+        "paid_statuses": paid_statuses,
+        "paid_statuses_normalized": {_normalize_text(status) for status in paid_statuses},
+        "cod_statuses": cod_statuses,
+        "cod_statuses_normalized": {_normalize_text(status) for status in cod_statuses},
+        "cod_payment_patterns": cod_payment_patterns,
+        "cod_payment_patterns_normalized": {_normalize_text(pattern) for pattern in cod_payment_patterns},
+        "cod_payment_ids": {str(value).strip() for value in cod_payment_ids if str(value).strip()},
+        "personal_pickup_shipping_names": pickup_shipping_names,
+        "personal_pickup_shipping_names_normalized": {_normalize_text(name) for name in pickup_shipping_names},
+        "personal_pickup_shipping_ids": {str(value).strip() for value in pickup_shipping_ids if str(value).strip()},
+        "pickup_action_statuses": pickup_action_statuses,
+        "pickup_action_statuses_normalized": {_normalize_text(status) for status in pickup_action_statuses},
+        "shipped_status_name": shipped_status_name,
+        "shipped_status_name_normalized": _normalize_text(shipped_status_name),
+        "shipped_status_id": _as_int(raw.get("shipped_status_id"), DEFAULT_SHIPPED_STATUS_ID, minimum=1),
+        "scan_max_pages": _as_int(raw.get("scan_max_pages"), DEFAULT_SCAN_MAX_PAGES, minimum=1),
+        "scan_min_pages": _as_int(raw.get("scan_min_pages"), DEFAULT_SCAN_MIN_PAGES, minimum=1),
+        "stop_after_empty_fulfillable_pages": _as_int(
+            raw.get("stop_after_empty_fulfillable_pages"),
+            DEFAULT_STOP_AFTER_EMPTY_FULFILLABLE_PAGES,
+            minimum=0,
+        ),
+        "cache_ttl_seconds": _as_int(raw.get("cache_ttl_seconds"), DEFAULT_CACHE_TTL_SECONDS, minimum=1),
+        "auto_refresh_seconds": _as_int(raw.get("auto_refresh_seconds"), DEFAULT_AUTO_REFRESH_SECONDS, minimum=30),
+    }
+
+
+def _price_elements(order: Dict[str, Any], element_type: str) -> List[Dict[str, Any]]:
+    wanted = _normalize_text(element_type)
+    return [
+        element
+        for element in order.get("price_elements") or []
+        if _normalize_text(element.get("type")) == wanted
+    ]
+
+
+def _price_element_info(order: Dict[str, Any], element_type: str) -> Dict[str, Any]:
+    elements = _price_elements(order, element_type)
+    if not elements:
+        return {"title": "", "reference_id": "", "value": "", "price": None}
+    first = elements[0] or {}
+    return {
+        "title": str(first.get("title") or "").strip(),
+        "reference_id": str(first.get("reference_id") or "").strip(),
+        "value": str(first.get("value") or "").strip(),
+        "price": first.get("price") or None,
+    }
+
+
+def _status_name(order: Dict[str, Any]) -> str:
+    return str((order.get("status") or {}).get("name") or "").strip()
+
+
+def _status_id(order: Dict[str, Any]) -> str:
+    return str((order.get("status") or {}).get("id") or "").strip()
+
+
+def _is_cod_payment(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
+    payment = _price_element_info(order, "payment")
+    reference_id = str(payment.get("reference_id") or "").strip()
+    if reference_id and reference_id in settings["cod_payment_ids"]:
+        return True
+    payment_title = _normalize_text(payment.get("title"))
+    return any(pattern and pattern in payment_title for pattern in settings["cod_payment_patterns_normalized"])
+
+
+def _is_paid_online(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
+    return _normalize_text(_status_name(order)) in settings["paid_statuses_normalized"]
+
+
+def _is_cod_fulfillable(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
+    return (
+        _normalize_text(_status_name(order)) in settings["cod_statuses_normalized"]
+        and _is_cod_payment(order, settings)
+    )
+
+
+def _is_fulfillable_order(order: Dict[str, Any], settings: Dict[str, Any]) -> Tuple[bool, str]:
+    if _is_paid_online(order, settings):
+        return True, "paid_online"
+    if _is_cod_fulfillable(order, settings):
+        return True, "cod_waiting"
+    return False, "not_ready"
+
+
+def _is_personal_pickup(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
+    shipping = _price_element_info(order, "shipping")
+    reference_id = str(shipping.get("reference_id") or "").strip()
+    if reference_id and reference_id in settings["personal_pickup_shipping_ids"]:
+        return True
+    shipping_title = _normalize_text(shipping.get("title"))
+    return any(name and name in shipping_title for name in settings["personal_pickup_shipping_names_normalized"])
+
+
+def _order_items(order: Dict[str, Any]) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    for item in order.get("items") or []:
+        quantity = _to_float(item.get("quantity"))
+        if quantity <= 0:
+            continue
+        items.append(
+            {
+                "label": str(item.get("item_label") or "").strip(),
+                "quantity": quantity,
+                "ean": str(item.get("ean") or "").strip(),
+                "import_code": str(item.get("import_code") or "").strip(),
+                "warehouse_number": str(item.get("warehouse_number") or "").strip(),
+            }
+        )
+    return items
+
+
+def _public_order_row(order: Dict[str, Any], settings: Dict[str, Any]) -> Dict[str, Any]:
+    payment = _price_element_info(order, "payment")
+    shipping = _price_element_info(order, "shipping")
+    fulfillable, reason = _is_fulfillable_order(order, settings)
+    is_pickup = _is_personal_pickup(order, settings)
+    status_name = _status_name(order)
+    status_norm = _normalize_text(status_name)
+    pickup_action_allowed = (
+        is_pickup
+        and status_norm != settings["shipped_status_name_normalized"]
+        and status_norm in settings["pickup_action_statuses_normalized"]
+    )
+    return {
+        "id": order.get("id"),
+        "order_num": order.get("order_num"),
+        "purchase_at": order.get("pur_date"),
+        "last_change": order.get("last_change"),
+        "status": status_name,
+        "status_id": _status_id(order),
+        "sum": (order.get("sum") or {}).get("formatted"),
+        "sum_value": _to_float((order.get("sum") or {}).get("value")),
+        "payment": payment,
+        "shipping": shipping,
+        "items": _order_items(order),
+        "fulfillable": fulfillable,
+        "fulfillment_reason": reason,
+        "personal_pickup": is_pickup,
+        "pickup_action_allowed": pickup_action_allowed,
+    }
+
+
+def build_roy_orders_snapshot(
+    *,
+    project: str,
+    orders: List[Dict[str, Any]],
+    settings: Dict[str, Any],
+    scan: Optional[Dict[str, Any]] = None,
+    generated_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    if not settings["enabled"]:
+        raise ValueError(f"ROY operations dashboard is not enabled for project '{project}'.")
+
+    rows = [_public_order_row(order, settings) for order in orders]
+    fulfillable_orders = [row for row in rows if row["fulfillable"]]
+    pickup_orders = [row for row in rows if row["personal_pickup"] and row["status"] != settings["shipped_status_name"]]
+    paid_orders = [row for row in fulfillable_orders if row["fulfillment_reason"] == "paid_online"]
+    cod_orders = [row for row in fulfillable_orders if row["fulfillment_reason"] == "cod_waiting"]
+
+    status_counts: Dict[str, int] = defaultdict(int)
+    for row in fulfillable_orders:
+        status_counts[str(row.get("status") or "")] += 1
+
+    generated = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    fulfillable_orders.sort(key=lambda row: (str(row.get("purchase_at") or ""), str(row.get("order_num") or "")))
+    pickup_orders.sort(key=lambda row: (str(row.get("purchase_at") or ""), str(row.get("order_num") or "")))
+
+    return {
+        "project": project,
+        "generated_at": generated,
+        "auto_refresh_seconds": settings["auto_refresh_seconds"],
+        "summary": {
+            "fulfillable_orders": len(fulfillable_orders),
+            "paid_online_orders": len(paid_orders),
+            "cod_waiting_orders": len(cod_orders),
+            "personal_pickups": len(pickup_orders),
+            "pickup_actions_available": len([row for row in pickup_orders if row["pickup_action_allowed"]]),
+            "fulfillable_value": round(sum(float(row.get("sum_value") or 0.0) for row in fulfillable_orders), 2),
+            "status_counts": dict(sorted(status_counts.items())),
+        },
+        "scan": scan or {},
+        "orders": fulfillable_orders,
+        "personal_pickups": pickup_orders,
+    }
+
+
+def _build_client(project: str, project_settings: Dict[str, Any]) -> Client:
+    api_url = resolve_biznisweb_api_url(project, project_settings)
+    api_token = os.getenv("BIZNISWEB_API_TOKEN")
+    if not api_token:
+        raise RuntimeError(f"BIZNISWEB_API_TOKEN not found for project '{project}'")
+    timeout = int(os.getenv("BIZNISWEB_API_TIMEOUT_SEC", os.getenv("REPORT_HTTP_READ_TIMEOUT_SEC", "30")))
+    transport = RequestsHTTPTransport(
+        url=api_url,
+        headers={"BW-API-Key": f"Token {api_token}"},
+        verify=True,
+        retries=3,
+        timeout=timeout,
+    )
+    return Client(transport=transport, fetch_schema_from_transport=False)
+
+
+def fetch_open_orders_for_roy_operations(project: str, settings: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    project_settings = load_project_settings(project)
+    client = _build_client(project, project_settings)
+
+    orders: List[Dict[str, Any]] = []
+    cursor: Optional[int] = None
+    page_count = 0
+    has_next_page = True
+    empty_fulfillable_pages = 0
+    oldest_order_at: Optional[str] = None
+    fulfillable_seen = 0
+    pickup_seen = 0
+    stop_reason = "api_exhausted"
+
+    while has_next_page and page_count < settings["scan_max_pages"]:
+        params: Dict[str, Any] = {
+            "limit": 30,
+            "order_by": "pur_date",
+            "sort": "DESC",
+        }
+        if cursor is not None:
+            params["cursor"] = cursor
+
+        result = client.execute(ROY_OPERATIONS_ORDER_QUERY, variable_values={"params": params})
+        payload = result.get("getOrderList") or {}
+        page_orders = [order for order in (payload.get("data") or []) if order]
+        orders.extend(page_orders)
+        page_count += 1
+
+        page_fulfillable = sum(1 for order in page_orders if _is_fulfillable_order(order, settings)[0])
+        page_pickups = sum(1 for order in page_orders if _is_personal_pickup(order, settings))
+        fulfillable_seen += page_fulfillable
+        pickup_seen += page_pickups
+        if page_fulfillable or page_pickups:
+            empty_fulfillable_pages = 0
+        else:
+            empty_fulfillable_pages += 1
+
+        for order in page_orders:
+            pur_date = str(order.get("pur_date") or "")
+            if pur_date and (oldest_order_at is None or pur_date < oldest_order_at):
+                oldest_order_at = pur_date
+
+        page_info = payload.get("pageInfo") or {}
+        has_next_page = bool(page_info.get("hasNextPage"))
+        cursor = page_info.get("nextCursor")
+        if cursor in ("", None):
+            has_next_page = False
+        if (
+            has_next_page
+            and page_count >= settings["scan_min_pages"]
+            and settings["stop_after_empty_fulfillable_pages"] > 0
+            and empty_fulfillable_pages >= settings["stop_after_empty_fulfillable_pages"]
+        ):
+            has_next_page = False
+            stop_reason = "empty_fulfillable_pages"
+
+    limit_reached = bool(has_next_page and page_count >= settings["scan_max_pages"])
+    if limit_reached:
+        stop_reason = "scan_max_pages"
+
+    scan = {
+        "orders_scanned": len(orders),
+        "pages_scanned": page_count,
+        "scan_max_pages": settings["scan_max_pages"],
+        "scan_min_pages": settings["scan_min_pages"],
+        "stop_after_empty_fulfillable_pages": settings["stop_after_empty_fulfillable_pages"],
+        "empty_fulfillable_pages_at_stop": empty_fulfillable_pages,
+        "fulfillable_seen_during_scan": fulfillable_seen,
+        "personal_pickups_seen_during_scan": pickup_seen,
+        "oldest_order_at_scanned": oldest_order_at,
+        "limit_reached": limit_reached,
+        "stop_reason": stop_reason,
+        "source": "biznisweb_api_desc_purchase_date_payment_shipping_filter",
+    }
+    return orders, scan
+
+
+def _sum_series(series: Dict[str, Any], keys: Iterable[str], indexes: Iterable[int]) -> float:
+    total = 0.0
+    for key in keys:
+        values = series.get(key) or []
+        for index in indexes:
+            if 0 <= index < len(values):
+                total += _to_float(values[index])
+    return total
+
+
+def _sum_first_available_series(series: Dict[str, Any], keys: Iterable[str], indexes: Iterable[int]) -> float:
+    for key in keys:
+        values = series.get(key)
+        if values:
+            return _sum_series(series, (key,), indexes)
+    return 0.0
+
+
+def _month_label(month_key: str) -> str:
+    try:
+        dt = datetime.strptime(month_key, "%Y-%m")
+    except ValueError:
+        return month_key
+    return dt.strftime("%B %Y")
+
+
+def _compute_kpi_metrics_from_series(series: Dict[str, Any], indexes: List[int]) -> Dict[str, Any]:
+    revenue = _sum_series(series, ("revenue",), indexes)
+    orders = _sum_series(series, ("orders",), indexes)
+    product_cost = _sum_series(series, ("product_cost",), indexes)
+    packaging = _sum_series(series, ("packaging",), indexes)
+    shipping = _sum_series(series, ("shipping",), indexes)
+    total_ads = _sum_series(series, ("total_ads",), indexes)
+    profit = _sum_first_available_series(series, ("profit_without_fixed", "profit"), indexes)
+    profit_with_fixed = _sum_series(series, ("profit_with_fixed",), indexes)
+    pre_ad_contribution = revenue - product_cost - packaging - shipping
+    return {
+        "revenue": round(revenue, 2),
+        "profit": round(profit, 2),
+        "orders": round(orders, 2),
+        "aov": (revenue / orders) if orders > 0 else 0.0,
+        "cac": (total_ads / orders) if orders > 0 else None,
+        "roas": (revenue / total_ads) if total_ads > 0 else None,
+        "pre_ad_contribution_margin": (pre_ad_contribution / revenue * 100.0) if revenue > 0 else 0.0,
+        "post_ad_margin": (profit / revenue * 100.0) if revenue > 0 else 0.0,
+        "company_margin_with_fixed": (profit_with_fixed / revenue * 100.0) if revenue > 0 else 0.0,
+    }
+
+
+def _build_monthly_kpis_from_series(series: Dict[str, Any]) -> List[Dict[str, Any]]:
+    dates = [str(value or "") for value in series.get("dates") or []]
+    month_indexes: Dict[str, List[int]] = defaultdict(list)
+    for index, value in enumerate(dates):
+        if len(value) >= 7:
+            month_indexes[value[:7]].append(index)
+
+    months: List[Dict[str, Any]] = []
+    previous_metrics: Optional[Dict[str, Any]] = None
+    for month_key in sorted(month_indexes):
+        indexes = month_indexes[month_key]
+        metrics = _compute_kpi_metrics_from_series(series, indexes)
+        comparisons = {
+            key: {"vs_previous_month": _pct_change(metrics.get(key), previous_metrics.get(key) if previous_metrics else None)}
+            for key in metrics
+        }
+        months.append(
+            {
+                "key": month_key,
+                "label_en": _month_label(month_key),
+                "label_sk": month_key,
+                "date_from": dates[indexes[0]],
+                "date_to": dates[indexes[-1]],
+                "metrics": metrics,
+                "secondary_metrics": {"company_margin_with_fixed": round(_sum_series(series, ("profit_with_fixed",), indexes), 2)},
+                "comparisons": comparisons,
+            }
+        )
+        previous_metrics = metrics
+    return months
+
+
+def build_executive_kpi_snapshot(report_payload: Dict[str, Any]) -> Dict[str, Any]:
+    dashboard = report_payload.get("dashboard") if isinstance(report_payload.get("dashboard"), dict) else {}
+    kpis = dashboard.get("kpis") if isinstance(dashboard.get("kpis"), dict) else {}
+    series = dashboard.get("series") if isinstance(dashboard.get("series"), dict) else {}
+    return {
+        "metric_defs": kpis.get("metric_defs") or [],
+        "default_window": kpis.get("default_window") or "monthly",
+        "windows": kpis.get("windows") or {},
+        "comparisons": kpis.get("comparisons") or {},
+        "comparison_labels": kpis.get("comparison_labels") or {},
+        "months": _build_monthly_kpis_from_series(series),
+        "source_generated_at": report_payload.get("generated_at"),
+        "source_range": {
+            "date_from": report_payload.get("date_from"),
+            "date_to": report_payload.get("date_to"),
+        },
+    }
+
+
+def build_inventory_snapshot(report_payload: Dict[str, Any]) -> Dict[str, Any]:
+    dashboard = report_payload.get("dashboard") if isinstance(report_payload.get("dashboard"), dict) else {}
+    roy_inventory = dashboard.get("roy_product_demand") if isinstance(dashboard.get("roy_product_demand"), dict) else {}
+    summary = roy_inventory.get("summary") if isinstance(roy_inventory.get("summary"), dict) else {}
+    return {
+        "summary": summary or {},
+        "alert_rows": list(roy_inventory.get("alert_rows") or [])[:80],
+        "stock_risk_rows": list(roy_inventory.get("stock_risk_rows") or [])[:120],
+        "inventory_rows": list(roy_inventory.get("inventory_rows") or [])[:160],
+        "restock_priority_rows": list(roy_inventory.get("restock_priority_rows") or [])[:120],
+        "revenue_at_risk_rows": list(roy_inventory.get("revenue_at_risk_rows") or [])[:120],
+        "forecast_rows": list(roy_inventory.get("forecast_rows") or [])[:80],
+    }
+
+
+def generate_roy_operations_snapshot(project: str, report_payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    if project != "roy":
+        raise ValueError("ROY operations dashboard is only enabled for project 'roy'.")
+
+    load_project_env(project)
+    project_settings = load_project_settings(project)
+    settings = resolve_roy_operations_settings(project_settings)
+    orders, scan = fetch_open_orders_for_roy_operations(project, settings)
+    order_snapshot = build_roy_orders_snapshot(project=project, orders=orders, settings=settings, scan=scan)
+    payload = report_payload or {}
+    return {
+        "marker": "roy-operations-dashboard",
+        "project": project,
+        "generated_at": order_snapshot["generated_at"],
+        "auto_refresh_seconds": order_snapshot["auto_refresh_seconds"],
+        "orders": order_snapshot,
+        "executive_kpis": build_executive_kpi_snapshot(payload),
+        "inventory": build_inventory_snapshot(payload),
+    }
+
+
+def get_cached_roy_operations_snapshot(
+    project: str,
+    *,
+    report_payload: Optional[Dict[str, Any]] = None,
+    force_refresh: bool = False,
+) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    project_settings = load_project_settings(project)
+    settings = resolve_roy_operations_settings(project_settings)
+    if not settings["enabled"]:
+        raise ValueError(f"ROY operations dashboard is not enabled for project '{project}'.")
+
+    cache_key = project
+    now = time.monotonic()
+    cached = _CACHE.get(cache_key)
+    if cached and not force_refresh:
+        cached_at, payload = cached
+        if now - cached_at <= settings["cache_ttl_seconds"]:
+            result = copy.deepcopy(payload)
+            result["cache"] = {
+                "status": "fresh",
+                "age_seconds": round(now - cached_at, 1),
+                "ttl_seconds": settings["cache_ttl_seconds"],
+            }
+            return result
+
+    try:
+        payload = generate_roy_operations_snapshot(project, report_payload=report_payload)
+    except Exception as exc:
+        if cached:
+            cached_at, payload = cached
+            result = copy.deepcopy(payload)
+            result["cache"] = {
+                "status": "stale_after_error",
+                "age_seconds": round(now - cached_at, 1),
+                "ttl_seconds": settings["cache_ttl_seconds"],
+                "error": str(exc),
+            }
+            return result
+        raise
+
+    _CACHE[cache_key] = (now, copy.deepcopy(payload))
+    payload["cache"] = {
+        "status": "refreshed",
+        "age_seconds": 0,
+        "ttl_seconds": settings["cache_ttl_seconds"],
+    }
+    return payload
+
+
+def _resolve_shipped_status_id(client: Client, settings: Dict[str, Any]) -> int:
+    configured = int(settings.get("shipped_status_id") or 0)
+    if configured > 0:
+        return configured
+    result = client.execute(LIST_ORDER_STATUSES_QUERY, variable_values={"lang_code": "SK"})
+    target = settings["shipped_status_name_normalized"]
+    for row in result.get("listOrderStatuses") or []:
+        if _normalize_text(row.get("name")) == target:
+            return int(row["id"])
+    raise RuntimeError(f"Target status '{settings['shipped_status_name']}' not found in BiznisWeb.")
+
+
+def mark_personal_pickup_shipped(project: str, order_num: str) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    if project != "roy":
+        raise ValueError("Pickup shipping action is only enabled for project 'roy'.")
+
+    load_project_env(project)
+    project_settings = load_project_settings(project)
+    settings = resolve_roy_operations_settings(project_settings)
+    if not settings["enabled"]:
+        raise ValueError(f"ROY operations dashboard is not enabled for project '{project}'.")
+
+    order_num = str(order_num or "").strip()
+    if not order_num:
+        raise ValueError("Missing order number.")
+
+    client = _build_client(project, project_settings)
+    result = client.execute(
+        gql(
+            """
+query GetOrderForPickupAction($order_num: String!) {
+  getOrder(order_num: $order_num) {
+    order_num
+    pur_date
+    last_change
+    status { id name }
+    price_elements { type title value reference_id price { value formatted } }
+    items { item_label ean import_code warehouse_number quantity }
+    sum { value formatted }
+  }
+}
+"""
+        ),
+        variable_values={"order_num": order_num},
+    )
+    order = result.get("getOrder")
+    if not order:
+        raise ValueError(f"Order '{order_num}' not found.")
+
+    row = _public_order_row(order, settings)
+    if not row["personal_pickup"]:
+        raise ValueError(f"Order '{order_num}' is not configured as personal pickup.")
+    if _normalize_text(row["status"]) == settings["shipped_status_name_normalized"]:
+        raise ValueError(f"Order '{order_num}' is already in target status.")
+    if not row["pickup_action_allowed"]:
+        raise ValueError(f"Order '{order_num}' is not in an allowed pickup action status.")
+
+    status_id = _resolve_shipped_status_id(client, settings)
+    mutation_result = client.execute(
+        CHANGE_ORDER_STATUS_MUTATION,
+        variable_values={"order_num": order_num, "status_id": status_id},
+    )
+    _CACHE.pop(project, None)
+    return {
+        "ok": True,
+        "project": project,
+        "order_num": order_num,
+        "target_status_id": status_id,
+        "target_status_name": settings["shipped_status_name"],
+        "result": mutation_result.get("changeOrderStatus"),
+    }

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -1,0 +1,151 @@
+import json
+import unittest
+from pathlib import Path
+
+from live_dashboard_server import build_roy_operations_dashboard_html
+from roy_operations_dashboard import (
+    build_executive_kpi_snapshot,
+    build_roy_orders_snapshot,
+    resolve_roy_operations_settings,
+)
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def make_settings() -> dict:
+    return resolve_roy_operations_settings(
+        {
+            "operations_dashboard": {
+                "enabled": True,
+                "paid_statuses": ["Platba online - zaplatené"],
+                "cod_statuses": ["Čaká na vybavenie"],
+                "cod_payment_patterns": ["dobierka", "dobírka"],
+                "cod_payment_ids": ["7", "10"],
+                "personal_pickup_shipping_names": ["Osobný odber na sklade"],
+                "personal_pickup_shipping_ids": ["11"],
+                "pickup_action_statuses": ["Čaká na vybavenie", "Platba online - zaplatené"],
+                "shipped_status_name": "Odoslaná",
+                "shipped_status_id": 4,
+            }
+        }
+    )
+
+
+def price_element(kind: str, title: str, reference_id: str = "") -> dict:
+    return {
+        "type": kind,
+        "title": title,
+        "value": "",
+        "reference_id": reference_id,
+        "price": {"value": 0, "formatted": "0,00 €"},
+    }
+
+
+def make_order(
+    order_num: str,
+    status_name: str,
+    payment: dict,
+    shipping: dict,
+    pur_date: str = "2026-05-26 10:00:00",
+) -> dict:
+    return {
+        "id": order_num,
+        "order_num": order_num,
+        "pur_date": pur_date,
+        "last_change": pur_date,
+        "status": {"id": 1, "name": status_name, "color": "#fff"},
+        "price_elements": [shipping, payment],
+        "sum": {"value": 120.0, "formatted": "120,00 €"},
+        "items": [
+            {
+                "item_label": "Wachman HC800",
+                "ean": "123",
+                "import_code": "WA-HC800",
+                "warehouse_number": "W1",
+                "quantity": 2,
+            }
+        ],
+    }
+
+
+class RoyOperationsDashboardTests(unittest.TestCase):
+    def test_roy_settings_enable_operations_dashboard_and_lead_times(self) -> None:
+        project_settings = json.loads((ROOT_DIR / "projects" / "roy" / "settings.json").read_text(encoding="utf-8"))
+        operations = resolve_roy_operations_settings(project_settings)
+        inventory = project_settings["inventory_model"]
+
+        self.assertTrue(operations["enabled"])
+        self.assertEqual(90, operations["auto_refresh_seconds"])
+        self.assertEqual(4, operations["shipped_status_id"])
+        self.assertIn("Čaká na vybavenie", operations["cod_statuses"])
+        self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["wachman"])
+        self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["roy"])
+        self.assertEqual(12, inventory["lead_time_working_days_by_brand"]["maco_stop"])
+        self.assertEqual(3, inventory["lead_time_working_days_by_family"]["memory_storage"])
+
+    def test_snapshot_includes_paid_and_cod_orders_only_for_fulfillment(self) -> None:
+        settings = make_settings()
+        pickup_shipping = price_element("shipping", "Osobný odber na sklade", "11")
+        packeta_shipping = price_element("shipping", "Packeta - výdajné miesto", "9")
+        orders = [
+            make_order("R-1", "Platba online - zaplatené", price_element("payment", "Okamžitá platba online", "18"), packeta_shipping),
+            make_order("R-2", "Čaká na vybavenie", price_element("payment", "Dobierkou", "7"), pickup_shipping),
+            make_order("R-3", "Čaká na vybavenie", price_element("payment", "Bankovým prevodom", "6"), packeta_shipping),
+            make_order("R-4", "Odoslaná", price_element("payment", "Dobierkou", "7"), pickup_shipping),
+        ]
+
+        snapshot = build_roy_orders_snapshot(project="roy", orders=orders, settings=settings)
+
+        self.assertEqual(2, snapshot["summary"]["fulfillable_orders"])
+        self.assertEqual(1, snapshot["summary"]["paid_online_orders"])
+        self.assertEqual(1, snapshot["summary"]["cod_waiting_orders"])
+        self.assertEqual(["R-1", "R-2"], [row["order_num"] for row in snapshot["orders"]])
+        self.assertEqual(["R-2"], [row["order_num"] for row in snapshot["personal_pickups"]])
+        self.assertTrue(snapshot["personal_pickups"][0]["pickup_action_allowed"])
+
+    def test_executive_kpis_build_calendar_months_from_series(self) -> None:
+        payload = {
+            "generated_at": "2026-05-26T10:00:00Z",
+            "date_from": "2026-04-01",
+            "date_to": "2026-05-02",
+            "dashboard": {
+                "kpis": {
+                    "metric_defs": [{"key": "revenue", "label_en": "Revenue"}],
+                    "windows": {"monthly": {"metrics": {"revenue": 300}}},
+                    "comparisons": {},
+                },
+                "series": {
+                    "dates": ["2026-04-30", "2026-05-01", "2026-05-02"],
+                    "revenue": [100, 50, 70],
+                    "orders": [2, 1, 1],
+                    "total_ads": [10, 0, 10],
+                    "product_cost": [40, 20, 30],
+                    "packaging": [1, 1, 1],
+                    "shipping": [0, 0, 0],
+                    "profit_without_fixed": [49, 29, 29],
+                    "profit_with_fixed": [40, 20, 20],
+                },
+            },
+        }
+
+        snapshot = build_executive_kpi_snapshot(payload)
+
+        self.assertEqual(["2026-04", "2026-05"], [row["key"] for row in snapshot["months"]])
+        may = snapshot["months"][1]
+        self.assertEqual(120, may["metrics"]["revenue"])
+        self.assertEqual(2, may["metrics"]["orders"])
+        self.assertEqual(60, may["metrics"]["aov"])
+        self.assertIsNotNone(may["comparisons"]["revenue"]["vs_previous_month"])
+
+    def test_html_contains_roy_operations_markers(self) -> None:
+        html = build_roy_operations_dashboard_html("roy")
+
+        self.assertIn('data-marker="roy-operations-dashboard"', html)
+        self.assertIn("/api/operations/", html)
+        self.assertIn("Executive KPI deck", html)
+        self.assertIn("Osobné odbery", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
- Adds a ROY operations dashboard at `/production/roy` with the existing Executive KPI payload, calendar-month KPI switching, live fulfillment orders, personal-pickup handling, and inventory alert tables.
- Adds server-side validation and a POST action that marks eligible ROY personal-pickup orders as `Odoslaná` in BiznisWeb.
- Updates ROY stock lead times and makes the App Runner deploy workflow project-aware for a separate ROY service.

## Validation
- `python -m py_compile live_dashboard_server.py roy_operations_dashboard.py export_orders.py`
- `python -m unittest`
- `python scripts\security_ci.py`
- `python scripts\reporting_qa_smoke.py`
- `git diff --check`
- YAML parse for updated workflows
- extracted App Runner deploy Bash script passes `bash -n`
- local `/production/roy` and `/api/operations/roy/live?refresh=1` smoke-tested
- in-app browser smoke verified KPI month switching, inventory tab rendering, and no console errors

## Deployment Notes
- Draft PR because production App Runner deployment is still pending.
- ROY deploy needs `ROY_LIVE_DASHBOARD_AUTH_PASSWORD` configured and latest report artifacts available in S3 under the configured `latest/` prefix.
