### PR TITLE
Handle ROY S3 artifact env conflicts

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -248,7 +248,12 @@ jobs:
               item.get("name"): item.get("value")
               for item in task_def["containerDefinitions"][0].get("environment", [])
           }
-          print("true" if env.get("REPORT_S3_BUCKET") != bucket or env.get("REPORT_S3_PREFIX") != prefix else "false")
+          secret_names = {
+              item.get("name")
+              for item in task_def["containerDefinitions"][0].get("secrets", [])
+          }
+          has_conflicting_secret = bool({"REPORT_S3_BUCKET", "REPORT_S3_PREFIX"} & secret_names)
+          print("true" if has_conflicting_secret or env.get("REPORT_S3_BUCKET") != bucket or env.get("REPORT_S3_PREFIX") != prefix else "false")
           PY
             )"
             if [[ "${NEEDS_REPORT_TASK_UPDATE}" == "true" ]]; then
@@ -285,6 +290,11 @@ jobs:
               {"name": "REPORT_S3_PREFIX", "value": prefix},
           ])
           container["environment"] = env
+          container["secrets"] = [
+              item
+              for item in container.get("secrets", [])
+              if item.get("name") not in {"REPORT_S3_BUCKET", "REPORT_S3_PREFIX"}
+          ]
           json.dump(task, sys.stdout)
           PY
               REGISTERED_TASK_DEFINITION_ARN="$(aws ecs register-task-definition \

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -214,6 +214,7 @@ Bootstrap entrypoints:
   - PR `#80` was merged to `main` as `32ba4e05a86cb909253b42ca1e5f5f9157dd012c`.
   - ECR build run `26453851082` succeeded after the merge.
   - App Runner deploy run `26453973092` created/updated service `biznisweb-roy-operations-dashboard`, but failed smoke because the runtime had no ROY latest KPI artifact: `Executive KPI windows missing`.
+  - First retry run `26455029828` failed before ECS refresh because the existing ROY task definition had `REPORT_S3_BUCKET` as a container secret and the workflow also added it as an environment variable.
   - Hard-gate context from the failed deploy:
     - instance-id: `N/A (AWS App Runner managed service)`
     - private IP: `N/A (AWS App Runner managed service)`
@@ -227,6 +228,7 @@ Bootstrap entrypoints:
   - workflow ensures the bucket exists with public access blocked and AES256 server-side encryption enabled.
   - workflow grants the ROY reporting task role `s3:GetObject` / `s3:PutObject` access under `daily-reports/roy-sk/*`.
   - workflow registers a new ROY reporting task definition revision with `REPORT_S3_BUCKET` and `REPORT_S3_PREFIX` when needed, then updates the daily schedule target to that revision.
+  - task definition mutation removes conflicting `REPORT_S3_BUCKET` / `REPORT_S3_PREFIX` container secrets before writing explicit environment variables.
   - before App Runner smoke, workflow runs a one-off ECS/Fargate ROY report refresh, verifies a localhost marker in the task logs, verifies S3 `latest/dashboard_payload_latest.json`, and asserts KPI windows/months plus inventory summary.
 - Local verification:
   - YAML parse for `.github/workflows/deploy-live-dashboard-apprunner.yml`


### PR DESCRIPTION
## Summary
- remove REPORT_S3_BUCKET / REPORT_S3_PREFIX from ECS container secrets when registering the explicit S3 env revision
- force task definition update when those names exist as secrets, fixing the RegisterTaskDefinition conflict from deploy run 26455029828
- record the failed retry and fix in PROJECT_STATE.md

## Verification
- YAML parse for all workflow files
- extracted deploy Bash script passes bash -n
- python -m unittest tests.test_roy_operations_dashboard
- python scripts\\security_ci.py
- git diff --check