### PR TITLE
Align ROY artifact deploy validation

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -442,10 +442,11 @@ jobs:
           payload_path = data_dir / "dashboard_payload_latest.json"
           payload = json.loads(payload_path.read_text(encoding="utf-8"))
           dashboard = payload.get("dashboard") or {}
-          kpis = dashboard.get("executive_kpis") or {}
-          inventory = dashboard.get("inventory_model") or {}
-          assert kpis.get("windows"), "Executive KPI windows missing in generated payload"
-          assert kpis.get("months"), "Executive KPI months missing in generated payload"
+          kpis = dashboard.get("kpis") or {}
+          series = dashboard.get("series") or {}
+          inventory = dashboard.get("roy_product_demand") or {}
+          assert kpis.get("windows"), "KPI windows missing in generated payload"
+          assert series.get("dates"), "KPI source series dates missing in generated payload"
           assert inventory.get("summary"), "Inventory summary missing in generated payload"
           marker_dir = Path("/tmp/live-dashboard-marker")
           marker_dir.mkdir(parents=True, exist_ok=True)
@@ -453,7 +454,7 @@ jobs:
               "marker": "LIVE_ARTIFACT_MARKER_OK",
               "project": project,
               "payload_path": str(payload_path),
-              "kpi_months": len(kpis.get("months") or []),
+              "kpi_series_days": len(series.get("dates") or []),
               "inventory_alerts": (inventory.get("summary") or {}).get("alert_delivery_count"),
           }
           (marker_dir / "marker.json").write_text(json.dumps(marker, ensure_ascii=False), encoding="utf-8")
@@ -608,14 +609,15 @@ jobs:
           import json
           payload = json.load(open("/tmp/roy-dashboard-payload-latest.json", encoding="utf-8"))
           dashboard = payload.get("dashboard") or {}
-          kpis = dashboard.get("executive_kpis") or {}
-          inventory = dashboard.get("inventory_model") or {}
-          assert kpis.get("windows"), "S3 Executive KPI windows missing"
-          assert kpis.get("months"), "S3 Executive KPI months missing"
+          kpis = dashboard.get("kpis") or {}
+          series = dashboard.get("series") or {}
+          inventory = dashboard.get("roy_product_demand") or {}
+          assert kpis.get("windows"), "S3 KPI windows missing"
+          assert series.get("dates"), "S3 KPI source series dates missing"
           assert inventory.get("summary"), "S3 inventory summary missing"
           print(
               "ROY_LIVE_ARTIFACTS_OK:"
-              f"kpi_months={len(kpis.get('months') or [])}:"
+              f"kpi_series_days={len(series.get('dates') or [])}:"
               f"inventory_alerts={(inventory.get('summary') or {}).get('alert_delivery_count')}"
           )
           PY

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -215,6 +215,7 @@ Bootstrap entrypoints:
   - ECR build run `26453851082` succeeded after the merge.
   - App Runner deploy run `26453973092` created/updated service `biznisweb-roy-operations-dashboard`, but failed smoke because the runtime had no ROY latest KPI artifact: `Executive KPI windows missing`.
   - First retry run `26455029828` failed before ECS refresh because the existing ROY task definition had `REPORT_S3_BUCKET` as a container secret and the workflow also added it as an environment variable.
+  - Second retry run `26455259337` reached ECS/Fargate refresh and logged hard-gate context (`private-ip=172.31.35.172`, task definition `roy-reporting-daily:4`, S3 latest artifact path), but the refresh task exited `1` because the workflow marker assertion checked obsolete payload keys (`dashboard.executive_kpis` / `dashboard.inventory_model`) instead of the actual ROY dashboard contract.
   - Hard-gate context from the failed deploy:
     - instance-id: `N/A (AWS App Runner managed service)`
     - private IP: `N/A (AWS App Runner managed service)`
@@ -229,6 +230,7 @@ Bootstrap entrypoints:
   - workflow grants the ROY reporting task role `s3:GetObject` / `s3:PutObject` access under `daily-reports/roy-sk/*`.
   - workflow registers a new ROY reporting task definition revision with `REPORT_S3_BUCKET` and `REPORT_S3_PREFIX` when needed, then updates the daily schedule target to that revision.
   - task definition mutation removes conflicting `REPORT_S3_BUCKET` / `REPORT_S3_PREFIX` container secrets before writing explicit environment variables.
+  - artifact marker validation now checks the same payload keys used by the ROY operations runtime: `dashboard.kpis`, `dashboard.series`, and `dashboard.roy_product_demand`.
   - before App Runner smoke, workflow runs a one-off ECS/Fargate ROY report refresh, verifies a localhost marker in the task logs, verifies S3 `latest/dashboard_payload_latest.json`, and asserts KPI windows/months plus inventory summary.
 - Local verification:
   - YAML parse for `.github/workflows/deploy-live-dashboard-apprunner.yml`


### PR DESCRIPTION
## Summary
- validate ROY latest artifacts against the actual dashboard payload contract (dashboard.kpis, dashboard.series, dashboard.roy_product_demand)
- record deploy run 26455259337 hard-gate context and root cause in PROJECT_STATE.md

## Verification
- YAML parse for all workflow files
- extracted deploy Bash script passes bash -n
- local ROY dashboard_payload_latest.json contract assertion
- python -m unittest tests.test_roy_operations_dashboard
- python scripts\\security_ci.py
- git diff --check