### PR TITLE
Show 100 ROY inventory products

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2519,3 +2519,13 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - authenticated API returned `active_orders=26`, `manufacturing_products=21`, `units_to_make=48.0`, `orders_scanned=300`
 - Next exact step:
   - test the public URL on an actual phone; if a branded URL is wanted, attach a custom App Runner domain such as `vyroba.vevo.sk`
+
+### 2026-05-26 (ROY inventory tab 100 visible products)
+- Branch: `codex/roy-inventory-100`
+- Change:
+  - `/production/roy` inventory tab now renders the first `100` stock products in the browser instead of the previous `80`
+  - added a dashboard HTML regression assertion for the `visibleInventoryLimit = 100` marker
+- Local verification:
+  - `python -m unittest tests.test_roy_operations_dashboard tests.test_live_dashboard_auth tests.test_live_dashboard_mobile`
+- Next exact step:
+  - open PR, merge to `main`, deploy the live dashboard App Runner service, then verify the public ROY URL shows at least 100 inventory rows when enough rows exist

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -1293,6 +1293,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       const summary = inv.summary || {};
       const alerts = inv.alert_rows || [];
       const inventoryRows = inv.inventory_rows || [];
+      const visibleInventoryLimit = 100;
       el('inventoryAlertMeta').textContent = `${fmtInt(summary.alert_delivery_count)} alertov · snapshot ${text(summary.inventory_snapshot_date)}`;
       el('alertRowsBody').innerHTML = alerts.length ? alerts.slice(0, 30).map(inventoryAlertRow).join('') : '<tr><td colspan="8" class="muted">Bez kritických skladových alertov.</td></tr>';
       el('inventoryMeta').textContent = `${fmtInt(summary.inventory_products_with_stock)} produktov so skladom · coverage ${fmtPct(summary.inventory_cost_coverage_units_pct)}`;
@@ -1303,7 +1304,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         metric('Dead stock', fmtMoney(summary.dead_stock_cost_value), `${fmtInt(summary.dead_stock_count)} položiek`),
         metric('Tržby v riziku', fmtMoney(summary.revenue_at_risk_30d), `zisk ${fmtMoney(summary.profit_at_risk_30d)}`),
       ].join('');
-      el('inventoryRowsBody').innerHTML = inventoryRows.length ? inventoryRows.slice(0, 80).map((row) => `<tr>
+      el('inventoryRowsBody').innerHTML = inventoryRows.length ? inventoryRows.slice(0, visibleInventoryLimit).map((row) => `<tr>
         <td><strong>${safe(row.product)}</strong><div class="muted mono">${safe(row.sku)}</div></td>
         <td>${fmtQty(row.available_quantity)} ks</td>
         <td>${fmtMoney(row.inventory_cost_value)}</td>

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -145,6 +145,7 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("/api/operations/", html)
         self.assertIn("Executive KPI deck", html)
         self.assertIn("Osobné odbery", html)
+        self.assertIn("visibleInventoryLimit = 100", html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- render the first 100 ROY inventory products instead of 80
- add a dashboard HTML regression assertion for the visible inventory limit
- update PROJECT_STATE.md

## Tests
- python -m unittest tests.test_roy_operations_dashboard tests.test_live_dashboard_auth tests.test_live_dashboard_mobile