### PR TITLE
Expand ROY restock alert coverage

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard
+          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2529,3 +2529,18 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - `python -m unittest tests.test_roy_operations_dashboard tests.test_live_dashboard_auth tests.test_live_dashboard_mobile`
 - Next exact step:
   - open PR, merge to `main`, deploy the live dashboard App Runner service, then verify the public ROY URL shows at least 100 inventory rows when enough rows exist
+
+### 2026-05-26 (ROY restock alerts include relevant historical sellers)
+- Branch: `codex/roy-restock-relevant-products`
+- Change:
+  - ROY inventory model now adds historically relevant sold SKUs into restock analysis even when they are missing from the current BiznisWeb inventory snapshot
+  - historical restock relevance threshold is configurable and currently requires at least `3` orders, `3` units, and `50` EUR net revenue
+  - products without a brand/family lead-time override now use default `5` working days for reorder timing
+  - alert/restock/revenue-at-risk rows now require the historical relevance threshold, so one-off or two-off products are filtered out
+  - ECR build workflow now runs `tests.test_roy_inventory_model`
+- Local verification:
+  - `python scripts\reporting_qa_smoke.py`
+  - `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, rebuild ECR, deploy ROY App Runner, verify deploy smoke and public `/production/roy`

--- a/export_orders.py
+++ b/export_orders.py
@@ -8662,6 +8662,25 @@ class BizniWebExporter:
             reorder_cover_days,
             int(inventory_config.get("hero_reorder_cover_days", watch_days_of_cover) or watch_days_of_cover),
         )
+        default_lead_time_working_days = max(
+            0,
+            int(inventory_config.get("default_lead_time_working_days", 0) or 0),
+        )
+        include_historical_restock_products = bool(
+            inventory_config.get("include_historical_restock_products", True)
+        )
+        historical_restock_min_orders = max(
+            1,
+            int(inventory_config.get("historical_restock_min_orders", 3) or 3),
+        )
+        historical_restock_min_units = max(
+            1.0,
+            float(inventory_config.get("historical_restock_min_units", 3) or 3),
+        )
+        historical_restock_min_revenue = max(
+            0.0,
+            float(inventory_config.get("historical_restock_min_revenue", 0) or 0),
+        )
         forecast_uplift_weights_raw = inventory_config.get("forecast_uplift_weights") or {}
         forecast_uplift_weights = {
             "high": float(forecast_uplift_weights_raw.get("high", 0.5) or 0.5),
@@ -9039,58 +9058,128 @@ class BizniWebExporter:
                 inventory_fetch_error = str(exc)[:240]
                 logger.warning("Roy inventory snapshot unavailable: %s", inventory_fetch_error)
 
-        if not inventory_frame.empty:
-            inventory_frame["inventory_cost_value"] = pd.to_numeric(
-                inventory_frame["inventory_cost_value"],
-                errors="coerce",
-            ).fillna(0.0)
-            inventory_frame["inventory_retail_value"] = pd.to_numeric(
-                inventory_frame["inventory_retail_value"],
-                errors="coerce",
-            ).fillna(0.0)
-            inventory_frame["mapped_inventory_retail_value"] = pd.to_numeric(
-                inventory_frame["mapped_inventory_retail_value"],
-                errors="coerce",
-            ).fillna(0.0)
-            inventory_frame["available_quantity"] = pd.to_numeric(
-                inventory_frame["available_quantity"],
-                errors="coerce",
-            ).fillna(0.0)
-            inventory_frame["available_quantity_raw"] = pd.to_numeric(
-                inventory_frame["available_quantity_raw"],
-                errors="coerce",
-            ).fillna(0.0)
-            inventory_frame["quantity"] = pd.to_numeric(
-                inventory_frame["quantity"],
-                errors="coerce",
-            ).fillna(0.0)
-            inventory_frame["quantity_raw"] = pd.to_numeric(
-                inventory_frame["quantity_raw"],
-                errors="coerce",
-            ).fillna(0.0)
-            inventory_frame["mapped_available_quantity"] = pd.to_numeric(
-                inventory_frame["mapped_available_quantity"],
-                errors="coerce",
-            ).fillna(0.0)
+        inventory_base_columns = [
+            "sku",
+            "product",
+            "active",
+            "warehouse_rows",
+            "available_quantity",
+            "available_quantity_raw",
+            "quantity",
+            "quantity_raw",
+            "mapped_available_quantity",
+            "inventory_cost_value",
+            "inventory_retail_value",
+            "mapped_inventory_retail_value",
+            "history_only_inventory_flag",
+        ]
 
-            inventory_products_df = (
-                inventory_frame.groupby("reporting_sku")
-                .agg(
-                    product=("reporting_product", "first"),
-                    active=("active", "max"),
-                    warehouse_rows=("reporting_sku", "size"),
-                    available_quantity=("available_quantity", "sum"),
-                    available_quantity_raw=("available_quantity_raw", "sum"),
-                    quantity=("quantity", "sum"),
-                    quantity_raw=("quantity_raw", "sum"),
-                    mapped_available_quantity=("mapped_available_quantity", "sum"),
-                    inventory_cost_value=("inventory_cost_value", "sum"),
-                    inventory_retail_value=("inventory_retail_value", "sum"),
-                    mapped_inventory_retail_value=("mapped_inventory_retail_value", "sum"),
+        if inventory_enabled and inventory_status != "error":
+            if not inventory_frame.empty:
+                inventory_frame["inventory_cost_value"] = pd.to_numeric(
+                    inventory_frame["inventory_cost_value"],
+                    errors="coerce",
+                ).fillna(0.0)
+                inventory_frame["inventory_retail_value"] = pd.to_numeric(
+                    inventory_frame["inventory_retail_value"],
+                    errors="coerce",
+                ).fillna(0.0)
+                inventory_frame["mapped_inventory_retail_value"] = pd.to_numeric(
+                    inventory_frame["mapped_inventory_retail_value"],
+                    errors="coerce",
+                ).fillna(0.0)
+                inventory_frame["available_quantity"] = pd.to_numeric(
+                    inventory_frame["available_quantity"],
+                    errors="coerce",
+                ).fillna(0.0)
+                inventory_frame["available_quantity_raw"] = pd.to_numeric(
+                    inventory_frame["available_quantity_raw"],
+                    errors="coerce",
+                ).fillna(0.0)
+                inventory_frame["quantity"] = pd.to_numeric(
+                    inventory_frame["quantity"],
+                    errors="coerce",
+                ).fillna(0.0)
+                inventory_frame["quantity_raw"] = pd.to_numeric(
+                    inventory_frame["quantity_raw"],
+                    errors="coerce",
+                ).fillna(0.0)
+                inventory_frame["mapped_available_quantity"] = pd.to_numeric(
+                    inventory_frame["mapped_available_quantity"],
+                    errors="coerce",
+                ).fillna(0.0)
+
+                inventory_products_df = (
+                    inventory_frame.groupby("reporting_sku")
+                    .agg(
+                        product=("reporting_product", "first"),
+                        active=("active", "max"),
+                        warehouse_rows=("reporting_sku", "size"),
+                        available_quantity=("available_quantity", "sum"),
+                        available_quantity_raw=("available_quantity_raw", "sum"),
+                        quantity=("quantity", "sum"),
+                        quantity_raw=("quantity_raw", "sum"),
+                        mapped_available_quantity=("mapped_available_quantity", "sum"),
+                        inventory_cost_value=("inventory_cost_value", "sum"),
+                        inventory_retail_value=("inventory_retail_value", "sum"),
+                        mapped_inventory_retail_value=("mapped_inventory_retail_value", "sum"),
+                    )
+                    .reset_index()
+                    .rename(columns={"reporting_sku": "sku"})
                 )
-                .reset_index()
-                .rename(columns={"reporting_sku": "sku"})
-            )
+                inventory_products_df["history_only_inventory_flag"] = False
+            else:
+                inventory_products_df = pd.DataFrame(columns=inventory_base_columns)
+
+            if include_historical_restock_products and not product_summary.empty:
+                relevant_historical_products = product_summary.loc[
+                    (product_summary["orders"] >= historical_restock_min_orders)
+                    & (product_summary["units"] >= historical_restock_min_units)
+                    & (product_summary["revenue"] >= historical_restock_min_revenue)
+                ].copy()
+                if not relevant_historical_products.empty:
+                    existing_skus = set(inventory_products_df["sku"].fillna("").astype(str))
+                    missing_historical_products = relevant_historical_products.loc[
+                        ~relevant_historical_products["product_sku"].fillna("").astype(str).isin(existing_skus)
+                    ]
+                    if not missing_historical_products.empty:
+                        history_only_rows = pd.DataFrame(
+                            {
+                                "sku": missing_historical_products["product_sku"].astype(str),
+                                "product": missing_historical_products["product"].astype(str),
+                                "active": False,
+                                "warehouse_rows": 0,
+                                "available_quantity": 0.0,
+                                "available_quantity_raw": 0.0,
+                                "quantity": 0.0,
+                                "quantity_raw": 0.0,
+                                "mapped_available_quantity": 0.0,
+                                "inventory_cost_value": 0.0,
+                                "inventory_retail_value": 0.0,
+                                "mapped_inventory_retail_value": 0.0,
+                                "history_only_inventory_flag": True,
+                            }
+                        )
+                        inventory_products_df = pd.concat(
+                            [inventory_products_df, history_only_rows[inventory_base_columns]],
+                            ignore_index=True,
+                        )
+
+            for column in (
+                "warehouse_rows",
+                "available_quantity",
+                "available_quantity_raw",
+                "quantity",
+                "quantity_raw",
+                "mapped_available_quantity",
+                "inventory_cost_value",
+                "inventory_retail_value",
+                "mapped_inventory_retail_value",
+            ):
+                inventory_products_df[column] = pd.to_numeric(
+                    inventory_products_df[column],
+                    errors="coerce",
+                ).fillna(0.0)
 
             inventory_products_df["cost_per_unit"] = np.where(
                 inventory_products_df["mapped_available_quantity"] > 0,
@@ -9173,6 +9262,11 @@ class BizniWebExporter:
                     errors="coerce",
                 ).fillna(0.0)
 
+            inventory_products_df["historical_restock_relevant_flag"] = (
+                (inventory_products_df["orders"] >= historical_restock_min_orders)
+                & (inventory_products_df["units"] >= historical_restock_min_units)
+                & (inventory_products_df["revenue"] >= historical_restock_min_revenue)
+            )
             inventory_products_df["last_sale"] = pd.to_datetime(inventory_products_df["last_sale"], errors="coerce")
             inventory_products_df["first_sale"] = pd.to_datetime(inventory_products_df["first_sale"], errors="coerce")
             inventory_products_df["forecast_confidence"] = (
@@ -9208,7 +9302,7 @@ class BizniWebExporter:
             )
             inventory_products_df["lead_time_working_days"] = brand_lead_time.where(
                 brand_lead_time > 0,
-                family_lead_time,
+                family_lead_time.where(family_lead_time > 0, default_lead_time_working_days),
             )
             inventory_products_df["lead_time_calendar_days"] = np.ceil(
                 inventory_products_df["lead_time_working_days"] * (7.0 / 5.0)
@@ -9340,6 +9434,15 @@ class BizniWebExporter:
                 inventory_products_df.loc[no_recent_units_mask, "effective_forecast_30d_units"]
                 * inventory_products_df.loc[no_recent_units_mask, "forecast_uplift_weight"]
             )
+            historical_unit_fallback_mask = (
+                inventory_products_df["historical_restock_relevant_flag"]
+                & (inventory_products_df["alert_30d_units"] <= 0)
+                & (inventory_products_df["effective_recent_90d_units"] > 0)
+            )
+            inventory_products_df.loc[historical_unit_fallback_mask, "alert_30d_units"] = (
+                inventory_products_df.loc[historical_unit_fallback_mask, "effective_recent_90d_units"]
+                * (30.0 / 90.0)
+            )
             inventory_products_df["daily_units_for_alert"] = inventory_products_df["alert_30d_units"] / 30.0
             inventory_products_df["days_of_cover"] = np.where(
                 inventory_products_df["daily_units_for_alert"] > 0,
@@ -9358,6 +9461,15 @@ class BizniWebExporter:
             inventory_products_df.loc[no_recent_revenue_mask, "alert_30d_revenue"] = (
                 inventory_products_df.loc[no_recent_revenue_mask, "forecast_30d_revenue"]
                 * inventory_products_df.loc[no_recent_revenue_mask, "forecast_uplift_weight"]
+            )
+            historical_revenue_fallback_mask = (
+                inventory_products_df["historical_restock_relevant_flag"]
+                & (inventory_products_df["alert_30d_revenue"] <= 0)
+                & (inventory_products_df["recent_90d_revenue"] > 0)
+            )
+            inventory_products_df.loc[historical_revenue_fallback_mask, "alert_30d_revenue"] = (
+                inventory_products_df.loc[historical_revenue_fallback_mask, "recent_90d_revenue"]
+                * (30.0 / 90.0)
             )
             inventory_products_df["alert_30d_profit_estimate"] = (
                 inventory_products_df["alert_30d_revenue"] * inventory_products_df["recent_margin_with_fixed_pct"] / 100.0
@@ -9630,6 +9742,7 @@ class BizniWebExporter:
             alert_rows_df = (
                 inventory_products_df.loc[
                     inventory_products_df["risk_30d_flag"]
+                    & inventory_products_df["historical_restock_relevant_flag"]
                     & ~inventory_products_df["alert_excluded_flag"]
                     & (inventory_products_df["alert_30d_units"] > 0)
                 ]
@@ -9648,6 +9761,7 @@ class BizniWebExporter:
             revenue_at_risk_rows_df = (
                 inventory_products_df.loc[
                     inventory_products_df["risk_45d_flag"]
+                    & inventory_products_df["historical_restock_relevant_flag"]
                     & ~inventory_products_df["alert_excluded_flag"]
                     & (inventory_products_df["alert_30d_revenue"] > 0)
                 ]
@@ -9657,6 +9771,7 @@ class BizniWebExporter:
             restock_priority_rows_df = (
                 inventory_products_df.loc[
                     inventory_products_df["risk_45d_flag"]
+                    & inventory_products_df["historical_restock_relevant_flag"]
                     & ~inventory_products_df["alert_excluded_flag"]
                     & (inventory_products_df["alert_30d_units"] > 0)
                 ]
@@ -9746,6 +9861,9 @@ class BizniWebExporter:
                 "inventory_fetch_error": inventory_fetch_error,
                 "inventory_snapshot_date": snapshot_ts.strftime("%Y-%m-%d"),
                 "inventory_products_total": int(len(inventory_products_df)),
+                "history_only_inventory_products": int(inventory_products_df["history_only_inventory_flag"].sum()) if not inventory_products_df.empty else 0,
+                "historical_restock_relevant_products": int(inventory_products_df["historical_restock_relevant_flag"].sum()) if not inventory_products_df.empty else 0,
+                "default_lead_time_working_days": int(default_lead_time_working_days),
                 "inventory_products_with_stock": int((inventory_products_df["available_quantity"] > 0).sum()) if not inventory_products_df.empty else 0,
                 "inventory_active_products_with_stock": int(
                     ((inventory_products_df["active"] == True) & (inventory_products_df["available_quantity"] > 0)).sum()

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -84,6 +84,11 @@
     },
     "reorder_cover_days": 30,
     "hero_reorder_cover_days": 45,
+    "default_lead_time_working_days": 5,
+    "include_historical_restock_products": true,
+    "historical_restock_min_orders": 3,
+    "historical_restock_min_units": 3,
+    "historical_restock_min_revenue": 50,
     "hero_brand_keys": [
       "wachman",
       "maco_stop",

--- a/tests/test_roy_inventory_model.py
+++ b/tests/test_roy_inventory_model.py
@@ -1,0 +1,80 @@
+import unittest
+
+import pandas as pd
+
+from export_orders import BizniWebExporter
+
+
+class RoyInventoryModelExporter(BizniWebExporter):
+    def __init__(self, inventory_snapshot: pd.DataFrame):
+        super().__init__(
+            api_url="https://example.test/graphql",
+            api_token="test-token",
+            project_name="roy",
+            output_tag="inventory-model-test",
+        )
+        self.inventory_snapshot = inventory_snapshot
+
+    def fetch_product_inventory_snapshot(self, lang_code: str = "SK", page_limit: int = 30) -> pd.DataFrame:
+        return self.inventory_snapshot.copy()
+
+
+def item_row(
+    order_num: str,
+    product_sku: str,
+    item_label: str,
+    purchase_datetime: str,
+    quantity: float,
+    revenue: float,
+) -> dict:
+    return {
+        "order_num": order_num,
+        "product_sku": product_sku,
+        "item_label": item_label,
+        "purchase_datetime": purchase_datetime,
+        "item_quantity": quantity,
+        "item_total_without_tax": revenue,
+        "cm2_profit": revenue * 0.4,
+        "cm3_profit": revenue * 0.3,
+    }
+
+
+class RoyInventoryModelTests(unittest.TestCase):
+    def test_restock_alerts_include_relevant_historical_products_without_inventory_rows(self) -> None:
+        exporter = RoyInventoryModelExporter(inventory_snapshot=pd.DataFrame())
+        item_df = pd.DataFrame(
+            [
+                item_row("R-1", "GEN-RELEVANT", "Generic Charger", "2026-05-01", 2, 120),
+                item_row("R-2", "GEN-RELEVANT", "Generic Charger", "2026-05-10", 2, 120),
+                item_row("R-3", "GEN-RELEVANT", "Generic Charger", "2026-05-20", 2, 120),
+                item_row("R-4", "GEN-NOISE", "One-off Accessory", "2026-05-11", 1, 40),
+                item_row("R-5", "GEN-NOISE", "One-off Accessory", "2026-05-21", 1, 40),
+            ]
+        )
+
+        result = exporter.analyze_roy_product_demand_analytics(
+            df=pd.DataFrame(),
+            orders_df=pd.DataFrame(),
+            item_df=item_df,
+        )
+
+        alert_rows = result["alert_rows"]
+        restock_rows = result["restock_priority_rows"]
+        self.assertIn("GEN-RELEVANT", set(alert_rows["sku"]))
+        self.assertIn("GEN-RELEVANT", set(restock_rows["sku"]))
+        self.assertNotIn("GEN-NOISE", set(alert_rows["sku"]))
+        self.assertNotIn("GEN-NOISE", set(restock_rows["sku"]))
+
+        alert_row = alert_rows.loc[alert_rows["sku"] == "GEN-RELEVANT"].iloc[0]
+        self.assertEqual("Out of stock", alert_row["stock_risk_level"])
+        self.assertEqual(5, int(alert_row["lead_time_working_days"]))
+        self.assertTrue(bool(alert_row["history_only_inventory_flag"]))
+        self.assertGreater(float(alert_row["suggested_reorder_units"]), 0)
+
+        summary = result["summary"]
+        self.assertEqual(1, summary["history_only_inventory_products"])
+        self.assertEqual(1, summary["historical_restock_relevant_products"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -83,6 +83,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["roy"])
         self.assertEqual(12, inventory["lead_time_working_days_by_brand"]["maco_stop"])
         self.assertEqual(3, inventory["lead_time_working_days_by_family"]["memory_storage"])
+        self.assertEqual(5, inventory["default_lead_time_working_days"])
+        self.assertEqual(3, inventory["historical_restock_min_orders"])
 
     def test_snapshot_includes_paid_and_cod_orders_only_for_fulfillment(self) -> None:
         settings = make_settings()


### PR DESCRIPTION
## Summary
- include relevant historical ROY sellers in restock analysis even when missing from the current inventory snapshot
- add configurable historical relevance thresholds: 3 orders, 3 units, 50 EUR net revenue
- use a default 5 working day lead time for products without brand/family overrides
- filter alert/restock/revenue-at-risk rows to relevant historical sellers so one-off/two-off products stay out
- add inventory model regression tests and wire them into the ECR build workflow

## Tests
- python scripts\\reporting_qa_smoke.py
- python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model
- git diff --check