### PR TITLE
Raise ROY dashboard row limits

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2544,3 +2544,16 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - `git diff --check`
 - Next exact step:
   - open/merge PR, rebuild ECR, deploy ROY App Runner, verify deploy smoke and public `/production/roy`
+
+### 2026-05-26 (ROY live dashboard inventory row payload limits)
+- Branch: `codex/roy-dashboard-row-limits`
+- Change:
+  - modern ROY dashboard payload now serializes up to `160` inventory rows, `120` stock alert rows, and `120` restock priority rows
+  - live ROY dashboard UI now renders up to `100` stock alert rows and `100` inventory rows when enough rows exist
+  - App Runner API adapter now keeps up to `120` stock alert rows from the reporting payload
+- Local verification:
+  - `python -m py_compile dashboard_modern.py live_dashboard_server.py roy_operations_dashboard.py export_orders.py`
+  - `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_live_dashboard_auth tests.test_live_dashboard_mobile`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, rebuild ECR, deploy ROY App Runner, verify public `/production/roy` API returns at least `100` inventory rows when the source snapshot has enough stocked products

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1290,7 +1290,7 @@ def generate_modern_dashboard(
             "days_of_cover",
             "stock_risk_level",
         ],
-        limit=12,
+        limit=160,
     )
     roy_stock_risk_rows = _frame_rows(
         (roy_product_demand or {}).get("stock_risk_rows"),
@@ -1340,7 +1340,7 @@ def generate_modern_dashboard(
             "alert_30d_revenue",
             "projected_stockout_date",
         ],
-        limit=12,
+        limit=120,
     )
     roy_restock_priority_rows = _frame_rows(
         (roy_product_demand or {}).get("restock_priority_rows"),
@@ -1358,7 +1358,7 @@ def generate_modern_dashboard(
             "projected_stockout_date",
             "cost_coverage_pct",
         ],
-        limit=12,
+        limit=120,
     )
     roy_revenue_at_risk_rows = _frame_rows(
         (roy_product_demand or {}).get("revenue_at_risk_rows"),

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -1293,9 +1293,10 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       const summary = inv.summary || {};
       const alerts = inv.alert_rows || [];
       const inventoryRows = inv.inventory_rows || [];
+      const visibleInventoryAlertLimit = 100;
       const visibleInventoryLimit = 100;
       el('inventoryAlertMeta').textContent = `${fmtInt(summary.alert_delivery_count)} alertov · snapshot ${text(summary.inventory_snapshot_date)}`;
-      el('alertRowsBody').innerHTML = alerts.length ? alerts.slice(0, 30).map(inventoryAlertRow).join('') : '<tr><td colspan="8" class="muted">Bez kritických skladových alertov.</td></tr>';
+      el('alertRowsBody').innerHTML = alerts.length ? alerts.slice(0, visibleInventoryAlertLimit).map(inventoryAlertRow).join('') : '<tr><td colspan="8" class="muted">Bez kritických skladových alertov.</td></tr>';
       el('inventoryMeta').textContent = `${fmtInt(summary.inventory_products_with_stock)} produktov so skladom · coverage ${fmtPct(summary.inventory_cost_coverage_units_pct)}`;
       el('inventorySummaryGrid').innerHTML = [
         metric('Nákupná hodnota bez DPH', fmtMoney(summary.inventory_cost_value), `${fmtQty(summary.inventory_available_units)} ks skladom`),

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -547,7 +547,7 @@ def build_inventory_snapshot(report_payload: Dict[str, Any]) -> Dict[str, Any]:
     summary = roy_inventory.get("summary") if isinstance(roy_inventory.get("summary"), dict) else {}
     return {
         "summary": summary or {},
-        "alert_rows": list(roy_inventory.get("alert_rows") or [])[:80],
+        "alert_rows": list(roy_inventory.get("alert_rows") or [])[:120],
         "stock_risk_rows": list(roy_inventory.get("stock_risk_rows") or [])[:120],
         "inventory_rows": list(roy_inventory.get("inventory_rows") or [])[:160],
         "restock_priority_rows": list(roy_inventory.get("restock_priority_rows") or [])[:120],

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -147,6 +147,7 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("/api/operations/", html)
         self.assertIn("Executive KPI deck", html)
         self.assertIn("Osobné odbery", html)
+        self.assertIn("visibleInventoryAlertLimit = 100", html)
         self.assertIn("visibleInventoryLimit = 100", html)
 
 


### PR DESCRIPTION
## Summary
- serialize up to 160 ROY inventory rows into the reporting payload
- serialize up to 120 alert/restock rows for ROY stock planning
- render up to 100 stock alerts and 100 inventory rows in the live dashboard UI
- update PROJECT_STATE.md

## Tests
- python -m py_compile dashboard_modern.py live_dashboard_server.py roy_operations_dashboard.py export_orders.py
- python -m unittest tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_live_dashboard_auth tests.test_live_dashboard_mobile
- git diff --check