### PR TITLE
Use ROY import code product identity

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2570,3 +2570,19 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - browser UI smoke verified overview `Skladové upozornenia` renders `23` alert rows and the `Sklad` tab renders `100` inventory rows with meta `610 produktov so skladom`
 - Next exact step:
   - review real alert quality in `/production/roy`; adjust `historical_restock_min_revenue` upward if low-value accessories create too much noise
+
+### 2026-05-26 (ROY product identity uses BiznisWeb import code)
+- Branch: `codex/roy-import-code-product-identity`
+- Change:
+  - ROY reporting now prefers BiznisWeb `import_code` as the canonical `product_sku` before EAN/title-hash fallback
+  - same import code now groups translated product names together, e.g. HU/CZ/SK Micro SD variants become one product when the import code matches
+  - inventory snapshot grouping now uses the same import-code-first product identity as historical demand
+  - product expense lookup keeps compatibility with warehouse number, import code, EAN, current SKU, and legacy title-hash keys so existing ROY cost mappings still resolve
+  - added regression tests for import-code identity and legacy cost fallback
+- Local verification:
+  - `python -m py_compile export_orders.py live_dashboard_server.py roy_operations_dashboard.py dashboard_modern.py`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, rebuild ECR, deploy ROY App Runner, then verify public API shows import-code SKU values for ROY inventory/restock rows

--- a/export_orders.py
+++ b/export_orders.py
@@ -1669,21 +1669,53 @@ class BizniWebExporter:
         }
 
     @staticmethod
-    def get_product_sku(ean: str, title: str) -> str:
+    def _normalize_product_identifier(value: Any) -> str:
+        if value is None or pd.isna(value):
+            return ""
+        text = str(value).strip()
+        if not text or text.lower() in {"nan", "none", "null"}:
+            return ""
+        if re.fullmatch(r"\d+\.0+", text):
+            text = text.split(".", 1)[0]
+        return text.upper()
+
+    @staticmethod
+    def get_product_sku(
+        ean: Any,
+        title: Any,
+        import_code: Any = None,
+        prefer_import_code: bool = False,
+    ) -> str:
         """
         Get a consistent product SKU/identifier.
-        Uses EAN if available, otherwise creates a short hash from the title.
+        Uses project-configured import code first, then EAN, otherwise a short title hash.
         """
-        if pd.notna(ean) and str(ean).strip() and str(ean).strip() != '':
-            return str(ean).strip()
+        import_code_candidate = BizniWebExporter._normalize_product_identifier(import_code)
+        if prefer_import_code and import_code_candidate:
+            return import_code_candidate
+        ean_candidate = BizniWebExporter._normalize_product_identifier(ean)
+        if ean_candidate:
+            return ean_candidate
+        if import_code_candidate:
+            return import_code_candidate
         # Create a short hash from the title (8 characters)
         title_hash = hashlib.md5(str(title).encode()).hexdigest()[:8].upper()
         return f"H-{title_hash}"
 
+    def _prefer_import_code_product_identity(self) -> bool:
+        config = self.project_settings.get("product_identity") or {}
+        return bool(config.get("prefer_import_code", False))
+
     def add_product_sku_column(self, df: pd.DataFrame) -> pd.DataFrame:
         """Add a consistent product_sku column to the dataframe."""
+        prefer_import_code = self._prefer_import_code_product_identity()
         df['product_sku'] = df.apply(
-            lambda row: self.get_product_sku(row.get('item_ean'), row.get('item_label', 'Unknown')),
+            lambda row: self.get_product_sku(
+                row.get('item_ean'),
+                row.get('item_label', 'Unknown'),
+                import_code=row.get('item_import_code'),
+                prefer_import_code=prefer_import_code,
+            ),
             axis=1
         )
         return df
@@ -1703,8 +1735,18 @@ class BizniWebExporter:
         """Prepare project-scoped canonical product keys for downstream reporting analyses."""
         df['raw_item_label'] = df.get('item_label', '')
         df['raw_product_sku'] = df.get('product_sku', '')
+        df['raw_item_import_code'] = df.get('item_import_code', '')
         df['item_label'] = df['item_label'].apply(self.canonicalize_reporting_product_label)
-        df['product_sku'] = df['item_label'].apply(lambda label: self.get_product_sku('', label or 'Unknown'))
+        prefer_import_code = self._prefer_import_code_product_identity()
+        df['product_sku'] = df.apply(
+            lambda row: self.get_product_sku(
+                row.get('item_ean'),
+                row.get('item_label', 'Unknown'),
+                import_code=row.get('item_import_code'),
+                prefer_import_code=prefer_import_code,
+            ),
+            axis=1,
+        )
         return df
 
     @staticmethod
@@ -1751,21 +1793,28 @@ class BizniWebExporter:
         item_label: str,
         import_code: Any = None,
         warehouse_number: Any = None,
+        ean: Any = None,
     ) -> Tuple[Optional[float], Optional[str]]:
         product_sku_candidate = str(product_sku or "").strip()
-        import_code_candidate = str(import_code or "").strip()
+        import_code_candidate = self._normalize_product_identifier(import_code)
+        ean_candidate = self._normalize_product_identifier(ean)
         warehouse_number_candidate = str(warehouse_number or "").strip()
         title_candidate = str(item_label or "").strip()
+        legacy_title_sku_candidate = self.get_product_sku("", title_candidate)
 
         exact_compound_candidates = [
             (self._compose_expense_key(title_candidate, warehouse_number_candidate), "mapped_compound_key"),
             (self._compose_expense_key(title_candidate, import_code_candidate), "mapped_compound_key"),
+            (self._compose_expense_key(title_candidate, ean_candidate), "mapped_compound_key"),
             (self._compose_expense_key(title_candidate, product_sku_candidate), "mapped_compound_key"),
+            (self._compose_expense_key(title_candidate, legacy_title_sku_candidate), "mapped_compound_key"),
         ]
         exact_identifier_candidates = [
             (warehouse_number_candidate, "mapped_product_identifier"),
             (import_code_candidate, "mapped_product_identifier"),
+            (ean_candidate, "mapped_product_identifier"),
             (product_sku_candidate, "mapped_product_sku"),
+            (legacy_title_sku_candidate, "mapped_legacy_title_hash"),
         ]
         exact_candidates = (
             [*exact_compound_candidates, (title_candidate, "mapped_item_label"), *exact_identifier_candidates]
@@ -1787,14 +1836,24 @@ class BizniWebExporter:
                 "mapped_compound_key_normalized",
             ),
             (
+                self._compose_expense_key(normalized_title_candidate, self._normalize_match_text(ean)),
+                "mapped_compound_key_normalized",
+            ),
+            (
                 self._compose_expense_key(normalized_title_candidate, self._normalize_match_text(product_sku)),
+                "mapped_compound_key_normalized",
+            ),
+            (
+                self._compose_expense_key(normalized_title_candidate, self._normalize_match_text(legacy_title_sku_candidate)),
                 "mapped_compound_key_normalized",
             ),
         ]
         normalized_identifier_candidates = [
             (self._normalize_match_text(warehouse_number), "mapped_product_identifier_normalized"),
             (self._normalize_match_text(import_code), "mapped_product_identifier_normalized"),
+            (self._normalize_match_text(ean), "mapped_product_identifier_normalized"),
             (self._normalize_match_text(product_sku), "mapped_product_sku_normalized"),
+            (self._normalize_match_text(legacy_title_sku_candidate), "mapped_legacy_title_hash_normalized"),
         ]
         normalized_candidates = (
             [*normalized_compound_candidates, (normalized_title_candidate, "mapped_item_label_normalized"), *normalized_identifier_candidates]
@@ -1943,6 +2002,7 @@ class BizniWebExporter:
         max_retries = 3
         page_count = 0
         rows: List[Dict[str, Any]] = []
+        prefer_import_code = self._prefer_import_code_product_identity()
 
         while has_next_page:
             variables = {
@@ -1981,9 +2041,19 @@ class BizniWebExporter:
                 active = bool(product.get("active", False))
                 ean = str(product.get("ean") or "").strip()
                 import_code = str(product.get("import_code") or "").strip()
-                raw_product_sku = self.get_product_sku(ean, title)
+                raw_product_sku = self.get_product_sku(
+                    ean,
+                    title,
+                    import_code=import_code,
+                    prefer_import_code=prefer_import_code,
+                )
                 reporting_product = self.canonicalize_reporting_product_label(title) or title
-                reporting_sku = self.get_product_sku("", reporting_product or "Unknown")
+                reporting_sku = self.get_product_sku(
+                    ean,
+                    reporting_product or "Unknown",
+                    import_code=import_code,
+                    prefer_import_code=prefer_import_code,
+                )
 
                 product_price = product.get("price") or {}
                 product_final_price = product.get("final_price") or {}
@@ -2032,6 +2102,7 @@ class BizniWebExporter:
                         title,
                         import_code=import_code,
                         warehouse_number=warehouse_number,
+                        ean=ean,
                     )
                     inventory_cost_value = (
                         round(float(cost_per_unit) * available_quantity, 2)
@@ -3705,12 +3776,17 @@ class BizniWebExporter:
                     item_total_with_tax = item_total_without_tax * tax_multiplier
                 item_tax_amount = item_total_with_tax - item_total_without_tax
                 
-                # Get expense per item from mapping (using product_sku - EAN or hash)
+                # Get expense per item from mapping (using project product identity - import code, EAN, or hash)
                 item_label = item.get('item_label', '')
                 item_ean = item.get('ean', '')
                 item_import_code = item.get('import_code')
                 item_warehouse_number = item.get('warehouse_number')
-                product_sku = self.get_product_sku(item_ean, item_label)
+                product_sku = self.get_product_sku(
+                    item_ean,
+                    item_label,
+                    import_code=item_import_code,
+                    prefer_import_code=self._prefer_import_code_product_identity(),
+                )
 
                 # Optional exclusion for zero-priced gift lines (e.g. free promo gifts).
                 if (
@@ -3749,6 +3825,7 @@ class BizniWebExporter:
                         item_label,
                         import_code=item_import_code,
                         warehouse_number=item_warehouse_number,
+                        ean=item_ean,
                     )
                     if expense_per_item is None:
                         expense_per_item = (
@@ -4064,7 +4141,7 @@ class BizniWebExporter:
                 logger.warning(f"Removed {removed_rows} duplicated flattened rows before analytics")
                 print(f"Deduplication: removed {removed_rows} duplicated item rows")
 
-        # Add consistent product SKU column (EAN if available, otherwise hash of title)
+        # Add consistent product SKU column (project import code if enabled, then EAN, otherwise title hash)
         df = self.add_product_sku_column(df)
         # Add canonical order-level net revenue (unified revenue definition for report analytics)
         df = self.add_order_revenue_net_column(df)

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -13,6 +13,9 @@
   "live_dashboard_artifacts": {
     "s3_prefix": "daily-reports/roy-sk"
   },
+  "product_identity": {
+    "prefer_import_code": true
+  },
   "packaging_cost_per_order": 0.05,
   "shipping_net_per_order": -0.2,
   "fixed_monthly_cost": 5500,

--- a/tests/test_roy_inventory_model.py
+++ b/tests/test_roy_inventory_model.py
@@ -26,11 +26,15 @@ def item_row(
     purchase_datetime: str,
     quantity: float,
     revenue: float,
+    item_import_code: str = "",
+    item_ean: str = "",
 ) -> dict:
     return {
         "order_num": order_num,
         "product_sku": product_sku,
         "item_label": item_label,
+        "item_import_code": item_import_code,
+        "item_ean": item_ean,
         "purchase_datetime": purchase_datetime,
         "item_quantity": quantity,
         "item_total_without_tax": revenue,
@@ -40,6 +44,55 @@ def item_row(
 
 
 class RoyInventoryModelTests(unittest.TestCase):
+    def test_roy_reporting_product_identity_prefers_import_code_across_languages(self) -> None:
+        exporter = RoyInventoryModelExporter(inventory_snapshot=pd.DataFrame())
+        item_df = pd.DataFrame(
+            [
+                item_row(
+                    "R-HU",
+                    "H-HU",
+                    "Micro SD CARD 32GB adapterrel",
+                    "2026-05-01",
+                    1,
+                    12,
+                    item_import_code="12474",
+                ),
+                item_row(
+                    "R-CZ",
+                    "H-CZ",
+                    "Micro SD CARD 32GB s adaptérem",
+                    "2026-05-02",
+                    1,
+                    12,
+                    item_import_code="12474",
+                ),
+            ]
+        )
+
+        canonical_df = exporter.add_reporting_product_identity_columns(item_df)
+
+        self.assertEqual(["12474"], canonical_df["product_sku"].drop_duplicates().tolist())
+        self.assertEqual(["H-HU", "H-CZ"], canonical_df["raw_product_sku"].tolist())
+        self.assertEqual(["12474", "12474"], canonical_df["raw_item_import_code"].tolist())
+
+    def test_product_expense_mapping_falls_back_to_legacy_title_hash(self) -> None:
+        exporter = RoyInventoryModelExporter(inventory_snapshot=pd.DataFrame())
+        legacy_title_hash = exporter.get_product_sku("", "Micro SD CARD 32GB adapterrel")
+        exporter.product_expenses_exact = {legacy_title_hash: 4.5}
+        exporter.product_expenses_normalized = {
+            exporter._normalize_match_text(legacy_title_hash): 4.5,
+        }
+
+        cost, source = exporter._resolve_product_expense(
+            product_sku="12474",
+            item_label="Micro SD CARD 32GB adapterrel",
+            import_code="12474",
+            ean="8590000000000",
+        )
+
+        self.assertEqual(4.5, cost)
+        self.assertEqual("mapped_legacy_title_hash", source)
+
     def test_restock_alerts_include_relevant_historical_products_without_inventory_rows(self) -> None:
         exporter = RoyInventoryModelExporter(inventory_snapshot=pd.DataFrame())
         item_df = pd.DataFrame(

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -85,6 +85,7 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(3, inventory["lead_time_working_days_by_family"]["memory_storage"])
         self.assertEqual(5, inventory["default_lead_time_working_days"])
         self.assertEqual(3, inventory["historical_restock_min_orders"])
+        self.assertTrue(project_settings["product_identity"]["prefer_import_code"])
 
     def test_snapshot_includes_paid_and_cod_orders_only_for_fulfillment(self) -> None:
         settings = make_settings()


### PR DESCRIPTION
## Summary
- make ROY product identity prefer BiznisWeb import_code before EAN/title hash
- use the same identity for ROY inventory snapshot grouping and historical demand analytics
- keep product expense compatibility with import code, EAN, warehouse number, current SKU, and legacy title-hash keys
- add regression coverage for translated names sharing one import code
- update PROJECT_STATE.md

## Tests
- python -m py_compile export_orders.py live_dashboard_server.py roy_operations_dashboard.py dashboard_modern.py
- python scripts\\reporting_qa_smoke.py
- python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model
- git diff --check