### PR TITLE
Use import code identity in reporting

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model
+          python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2599,3 +2599,18 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - browser UI smoke verified overview `Skladové upozornenia` renders `18` alert rows and `Sklad` tab renders `100` rows with first visible SKU `WD0021`
 - Next exact step:
   - review live restock grouping for Micro SD language variants and tune any remaining aliases only where BiznisWeb import code is missing
+
+### 2026-05-26 (VEVO and ROY reporting product identity uses import code)
+- Branch: `codex/reporting-import-code-product-identity`
+- Change:
+  - enabled `product_identity.prefer_import_code` for VEVO as well as ROY
+  - reporting aggregations already run through `add_reporting_product_identity_columns`, so `date_product_agg`, `items_agg`, product margins/trends, ROY demand analytics, and dashboard payloads now use import-code-first identity for both projects
+  - added a shared regression test proving VEVO and ROY reporting collapse translated names with the same import code into one `items_agg` product row
+  - ECR build workflow now runs `tests.test_reporting_product_identity`
+- Local verification:
+  - `python -m py_compile export_orders.py dashboard_modern.py live_dashboard_server.py roy_operations_dashboard.py`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, rebuild ECR, then run production reporting smoke for `all` to verify VEVO and ROY reporting tasks on the production-equivalent host

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -11,6 +11,9 @@
     "timezone": "Europe/Bratislava",
     "task_family": "vevo-reporting-daily"
   },
+  "product_identity": {
+    "prefer_import_code": true
+  },
   "expense_match_mode": "title_first",
   "product_name_aliases_file": "product_name_aliases.json",
   "production_board": {

--- a/tests/test_reporting_product_identity.py
+++ b/tests/test_reporting_product_identity.py
@@ -1,0 +1,77 @@
+import unittest
+from datetime import datetime
+
+import pandas as pd
+
+from export_orders import BizniWebExporter
+
+
+class ReportingIdentityExporter(BizniWebExporter):
+    def __init__(self, project_name: str):
+        super().__init__(
+            api_url="https://example.test/graphql",
+            api_token="test-token",
+            project_name=project_name,
+            output_tag=f"{project_name}-identity-test",
+        )
+
+
+def reporting_item(
+    order_num: str,
+    product_sku: str,
+    item_label: str,
+    item_import_code: str,
+    revenue: float,
+    quantity: float = 1.0,
+) -> dict:
+    return {
+        "order_num": order_num,
+        "customer_email": f"{order_num.lower()}@example.test",
+        "purchase_date": "2026-05-01 10:00:00",
+        "purchase_date_only": "2026-05-01",
+        "product_sku": product_sku,
+        "item_label": item_label,
+        "item_ean": "",
+        "item_import_code": item_import_code,
+        "item_quantity": quantity,
+        "item_total_without_tax": revenue,
+        "total_expense": revenue * 0.4,
+        "profit_before_ads": revenue * 0.6,
+        "fb_ads_daily_spend": 0.0,
+        "google_ads_daily_spend": 0.0,
+    }
+
+
+class ReportingProductIdentityTests(unittest.TestCase):
+    def test_vevo_and_roy_reporting_prefer_import_code_identity(self) -> None:
+        for project in ("vevo", "roy"):
+            with self.subTest(project=project):
+                exporter = ReportingIdentityExporter(project)
+                self.assertTrue(exporter._prefer_import_code_product_identity())
+
+                item_df = pd.DataFrame(
+                    [
+                        reporting_item("R-HU", "H-HU", "Micro SD CARD 32GB adapterrel", "12474", 12),
+                        reporting_item("R-CZ", "H-CZ", "Micro SD CARD 32GB s adaptérem", "12474", 18),
+                    ]
+                )
+
+                canonical_df = exporter.add_reporting_product_identity_columns(item_df)
+                self.assertEqual(["12474"], canonical_df["product_sku"].drop_duplicates().tolist())
+
+                _, _, items_agg, _, _ = exporter.create_aggregated_reports(
+                    canonical_df,
+                    datetime(2026, 5, 1),
+                    datetime(2026, 5, 1),
+                    fb_daily_spend={},
+                    google_ads_daily_spend={},
+                )
+
+                self.assertEqual(1, len(items_agg))
+                self.assertEqual("12474", items_agg.iloc[0]["product_sku"])
+                self.assertEqual(2, int(items_agg.iloc[0]["total_quantity"]))
+                self.assertEqual(30, float(items_agg.iloc[0]["total_revenue"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable import-code-first product identity for VEVO reporting as well as ROY
- add a shared regression test proving VEVO and ROY reporting aggregates translated names with the same import code into one product row
- add the new identity regression test to the ECR build workflow
- update PROJECT_STATE.md

## Tests
- python -m py_compile export_orders.py dashboard_modern.py live_dashboard_server.py roy_operations_dashboard.py
- python scripts\\reporting_qa_smoke.py
- python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- git diff --check