### PR TITLE
Map ROY MACO STOP set demand to components

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2656,3 +2656,22 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - final host marker: `PRODUCTION_SMOKE_OK:roy:7bae84d5e8364db3b0cd3f00d2c63639:172.31.18.226`
 - Next exact step:
   - watch the next scheduled daily reports once and confirm the generated report artifacts still show expected product grouping
+
+### 2026-05-26 (ROY MACO STOP large set component demand)
+- Branch: `codex/roy-maco-stop-set-components`
+- Change:
+  - ROY inventory model now treats each sold `Set MACO STOP VELKY` as component demand for:
+    - `Najsilnejsi sprej na medvede MACO STOP Extreme 300ml hmla`
+    - `Puzdro MACO STOP na sprej 300ml`
+    - `Zvoncek na medvede, plasic medvedov`
+  - the configured bundle SKU remains excluded from operational restock/alert demand once the demand is shifted to components
+  - component rows inherit bundle order/unit/revenue relevance for the historical restock threshold, so components sold only through the set can still trigger ROY stock alerts
+  - added regression coverage proving three set sales produce three component alert/restock rows and no standalone set alert/restock row
+- Local verification:
+  - `python -m py_compile export_orders.py dashboard_modern.py live_dashboard_server.py roy_operations_dashboard.py`
+  - `python -m unittest tests.test_roy_inventory_model tests.test_roy_operations_dashboard`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, wait for ECR build, deploy/refresh ROY App Runner live dashboard, then verify `/production/roy`

--- a/export_orders.py
+++ b/export_orders.py
@@ -9396,6 +9396,9 @@ class BizniWebExporter:
             inventory_products_df["bundle_component_recent_30d_units"] = 0.0
             inventory_products_df["bundle_component_recent_90d_units"] = 0.0
             inventory_products_df["bundle_component_forecast_30d_units"] = 0.0
+            inventory_products_df["bundle_component_order_count"] = 0.0
+            inventory_products_df["bundle_component_total_units"] = 0.0
+            inventory_products_df["bundle_component_source_revenue"] = 0.0
 
             if bundle_component_rules:
                 for rule in bundle_component_rules:
@@ -9416,6 +9419,15 @@ class BizniWebExporter:
                     inventory_products_df.loc[bundle_mask, "bundle_sku_flag"] = True
                     if bool(rule.get("exclude_bundle_from_alerts", False)):
                         inventory_products_df.loc[bundle_mask, "exclude_bundle_from_alerts_flag"] = True
+                    bundle_orders = float(
+                        inventory_products_df.loc[bundle_mask, "orders"].sum()
+                    )
+                    bundle_units = float(
+                        inventory_products_df.loc[bundle_mask, "units"].sum()
+                    )
+                    bundle_revenue = float(
+                        inventory_products_df.loc[bundle_mask, "revenue"].sum()
+                    )
                     bundle_recent_30d_units = float(
                         inventory_products_df.loc[bundle_mask, "recent_30d_units"].sum()
                     )
@@ -9425,6 +9437,15 @@ class BizniWebExporter:
                     bundle_forecast_30d_units = float(
                         inventory_products_df.loc[bundle_mask, "forecast_30d_units"].sum()
                     )
+                    bundle_first_sale = pd.to_datetime(
+                        inventory_products_df.loc[bundle_mask, "first_sale"],
+                        errors="coerce",
+                    ).min()
+                    bundle_last_sale = pd.to_datetime(
+                        inventory_products_df.loc[bundle_mask, "last_sale"],
+                        errors="coerce",
+                    ).max()
+                    component_match_seen = False
                     for component_rule in component_rules:
                         component_patterns = [
                             str(pattern).strip()
@@ -9439,6 +9460,19 @@ class BizniWebExporter:
                         )
                         if not component_mask.any():
                             continue
+                        component_match_seen = True
+                        inventory_products_df.loc[
+                            component_mask,
+                            "bundle_component_order_count",
+                        ] += bundle_orders
+                        inventory_products_df.loc[
+                            component_mask,
+                            "bundle_component_total_units",
+                        ] += bundle_units * component_qty
+                        inventory_products_df.loc[
+                            component_mask,
+                            "bundle_component_source_revenue",
+                        ] += bundle_revenue
                         inventory_products_df.loc[
                             component_mask,
                             "bundle_component_recent_30d_units",
@@ -9451,6 +9485,59 @@ class BizniWebExporter:
                             component_mask,
                             "bundle_component_forecast_30d_units",
                         ] += bundle_forecast_30d_units * component_qty
+                        if pd.notna(bundle_first_sale):
+                            current_first_sale = pd.to_datetime(
+                                inventory_products_df.loc[component_mask, "first_sale"],
+                                errors="coerce",
+                            )
+                            inventory_products_df.loc[component_mask, "first_sale"] = current_first_sale.where(
+                                current_first_sale.notna() & (current_first_sale <= bundle_first_sale),
+                                bundle_first_sale,
+                            )
+                        if pd.notna(bundle_last_sale):
+                            current_last_sale = pd.to_datetime(
+                                inventory_products_df.loc[component_mask, "last_sale"],
+                                errors="coerce",
+                            )
+                            inventory_products_df.loc[component_mask, "last_sale"] = current_last_sale.where(
+                                current_last_sale.notna() & (current_last_sale >= bundle_last_sale),
+                                bundle_last_sale,
+                            )
+                    if component_match_seen and bool(rule.get("exclude_bundle_from_alerts", False)):
+                        inventory_products_df.loc[
+                            bundle_mask,
+                            [
+                                "orders",
+                                "units",
+                                "revenue",
+                                "profit_without_fixed",
+                                "profit_with_fixed",
+                                "recent_30d_units",
+                                "recent_30d_revenue",
+                                "recent_30d_profit_without_fixed",
+                                "recent_30d_profit_with_fixed",
+                                "recent_90d_units",
+                                "recent_90d_revenue",
+                                "recent_90d_profit_without_fixed",
+                                "recent_90d_profit_with_fixed",
+                                "forecast_30d_units",
+                                "forecast_30d_revenue",
+                            ],
+                        ] = 0.0
+                        inventory_products_df.loc[bundle_mask, ["first_sale", "last_sale"]] = pd.NaT
+
+            inventory_products_df["historical_restock_relevant_flag"] = (
+                (
+                    (inventory_products_df["orders"] >= historical_restock_min_orders)
+                    & (inventory_products_df["units"] >= historical_restock_min_units)
+                    & (inventory_products_df["revenue"] >= historical_restock_min_revenue)
+                )
+                | (
+                    (inventory_products_df["bundle_component_order_count"] >= historical_restock_min_orders)
+                    & (inventory_products_df["bundle_component_total_units"] >= historical_restock_min_units)
+                    & (inventory_products_df["bundle_component_source_revenue"] >= historical_restock_min_revenue)
+                )
+            )
 
             inventory_products_df["margin_without_fixed_pct"] = np.where(
                 inventory_products_df["revenue"] != 0,

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -150,6 +150,14 @@
               "puzdro na spreje 300ml univerzal"
             ],
             "quantity": 1
+          },
+          {
+            "component_patterns": [
+              "zvonček na medvede, plašič medveďov",
+              "zvoncek na medvede",
+              "plasic medvedov"
+            ],
+            "quantity": 1
           }
         ]
       }

--- a/tests/test_roy_inventory_model.py
+++ b/tests/test_roy_inventory_model.py
@@ -43,6 +43,28 @@ def item_row(
     }
 
 
+def inventory_row(
+    sku: str,
+    product: str,
+    available_quantity: float = 0.0,
+    inventory_cost_value: float = 0.0,
+    inventory_retail_value: float = 0.0,
+) -> dict:
+    return {
+        "reporting_sku": sku,
+        "reporting_product": product,
+        "active": True,
+        "available_quantity": available_quantity,
+        "available_quantity_raw": available_quantity,
+        "quantity": available_quantity,
+        "quantity_raw": available_quantity,
+        "mapped_available_quantity": available_quantity if inventory_cost_value else 0.0,
+        "inventory_cost_value": inventory_cost_value,
+        "inventory_retail_value": inventory_retail_value,
+        "mapped_inventory_retail_value": inventory_retail_value if inventory_cost_value else 0.0,
+    }
+
+
 class RoyInventoryModelTests(unittest.TestCase):
     def test_roy_reporting_product_identity_prefers_import_code_across_languages(self) -> None:
         exporter = RoyInventoryModelExporter(inventory_snapshot=pd.DataFrame())
@@ -127,6 +149,53 @@ class RoyInventoryModelTests(unittest.TestCase):
         summary = result["summary"]
         self.assertEqual(1, summary["history_only_inventory_products"])
         self.assertEqual(1, summary["historical_restock_relevant_products"])
+
+    def test_maco_stop_large_set_demand_is_shifted_to_components(self) -> None:
+        inventory_snapshot = pd.DataFrame(
+            [
+                inventory_row(
+                    "MACO-EXTREME-300",
+                    "Najsilnejší sprej na medvede MACO STOP Extreme 300ml hmla",
+                ),
+                inventory_row("MACO-HOLSTER-300", "Puzdro MACO STOP na sprej 300ml"),
+                inventory_row("BEAR-BELL", "Zvonček na medvede, plašič medveďov"),
+            ]
+        )
+        exporter = RoyInventoryModelExporter(inventory_snapshot=inventory_snapshot)
+        item_df = pd.DataFrame(
+            [
+                item_row("R-1", "SET-MACO-LARGE", "Set MACO STOP VEĽKÝ", "2026-05-01", 1, 120),
+                item_row("R-2", "SET-MACO-LARGE", "Set MACO STOP VEĽKÝ", "2026-05-10", 1, 120),
+                item_row("R-3", "SET-MACO-LARGE", "Set MACO STOP VEĽKÝ", "2026-05-20", 1, 120),
+            ]
+        )
+
+        result = exporter.analyze_roy_product_demand_analytics(
+            df=pd.DataFrame(),
+            orders_df=pd.DataFrame(),
+            item_df=item_df,
+        )
+
+        alert_rows = result["alert_rows"]
+        restock_rows = result["restock_priority_rows"]
+        expected_component_skus = {"MACO-EXTREME-300", "MACO-HOLSTER-300", "BEAR-BELL"}
+
+        self.assertTrue(expected_component_skus.issubset(set(alert_rows["sku"])))
+        self.assertTrue(expected_component_skus.issubset(set(restock_rows["sku"])))
+        self.assertNotIn("SET-MACO-LARGE", set(alert_rows["sku"]))
+        self.assertNotIn("SET-MACO-LARGE", set(restock_rows["sku"]))
+
+        for component_sku in expected_component_skus:
+            row = alert_rows.loc[alert_rows["sku"] == component_sku].iloc[0]
+            self.assertEqual("Out of stock", row["stock_risk_level"])
+            self.assertEqual(3.0, float(row["bundle_component_recent_30d_units"]))
+            self.assertEqual(3.0, float(row["alert_30d_units"]))
+            self.assertTrue(bool(row["historical_restock_relevant_flag"]))
+
+        summary = result["summary"]
+        self.assertEqual(1, summary["bundle_component_rule_count"])
+        self.assertEqual(9.0, float(summary["bundle_component_adjustment_30d_units"]))
+        self.assertGreaterEqual(summary["historical_restock_relevant_products"], 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -86,6 +86,9 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(5, inventory["default_lead_time_working_days"])
         self.assertEqual(3, inventory["historical_restock_min_orders"])
         self.assertTrue(project_settings["product_identity"]["prefer_import_code"])
+        maco_bundle_rule = inventory["bundle_component_rules"][0]
+        self.assertEqual(3, len(maco_bundle_rule["components"]))
+        self.assertTrue(maco_bundle_rule["exclude_bundle_from_alerts"])
 
     def test_snapshot_includes_paid_and_cod_orders_only_for_fulfillment(self) -> None:
         settings = make_settings()


### PR DESCRIPTION
## Summary
- add bear bell as the third component of the ROY MACO STOP large set
- shift configured bundle demand into component restock demand and suppress standalone bundle demand in operational alerts
- add regression coverage for set-to-components restock behavior

## Verification
- python -m py_compile export_orders.py dashboard_modern.py live_dashboard_server.py roy_operations_dashboard.py
- python -m unittest tests.test_roy_inventory_model tests.test_roy_operations_dashboard
- python scripts\\reporting_qa_smoke.py
- python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- git diff --check