### PR TITLE
Limit ROY MACO STOP set spray match to hmla

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2675,3 +2675,17 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - `git diff --check`
 - Next exact step:
   - open/merge PR, wait for ECR build, deploy/refresh ROY App Runner live dashboard, then verify `/production/roy`
+
+### 2026-05-26 (ROY MACO STOP large set hmla-specific component)
+- Branch: `codex/roy-maco-stop-set-hmla-specific`
+- Change:
+  - tightened the MACO STOP set spray component pattern to `300ml hmla`, so sold sets do not add demand to `MACO STOP Extreme 300ml gel`
+  - extended the regression test with a `300ml gel` inventory row and asserted it is not included in set-driven alert/restock rows
+- Local verification:
+  - `python -m py_compile export_orders.py`
+  - `python -m unittest tests.test_roy_inventory_model tests.test_roy_operations_dashboard`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, wait for ECR build, deploy/refresh ROY App Runner live dashboard, then verify `/production/roy` with the hmla-specific rule

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -138,9 +138,9 @@
         "components": [
           {
             "component_patterns": [
-              "maco stop extreme 300ml",
-              "najsilnejsi sprej na medvede maco stop extreme 300ml",
-              "a legerosebb medve spray maco stop extreme 300ml"
+              "najsilnejsi sprej na medvede maco stop extreme 300ml hmla",
+              "maco stop extreme 300ml hmla",
+              "maco stop extreme 300 ml hmla"
             ],
             "quantity": 1
           },

--- a/tests/test_roy_inventory_model.py
+++ b/tests/test_roy_inventory_model.py
@@ -157,6 +157,10 @@ class RoyInventoryModelTests(unittest.TestCase):
                     "MACO-EXTREME-300",
                     "Najsilnejší sprej na medvede MACO STOP Extreme 300ml hmla",
                 ),
+                inventory_row(
+                    "MACO-EXTREME-300-GEL",
+                    "Najsilnejší sprej na medvede MACO STOP Extreme 300ml gel",
+                ),
                 inventory_row("MACO-HOLSTER-300", "Puzdro MACO STOP na sprej 300ml"),
                 inventory_row("BEAR-BELL", "Zvonček na medvede, plašič medveďov"),
             ]
@@ -184,6 +188,8 @@ class RoyInventoryModelTests(unittest.TestCase):
         self.assertTrue(expected_component_skus.issubset(set(restock_rows["sku"])))
         self.assertNotIn("SET-MACO-LARGE", set(alert_rows["sku"]))
         self.assertNotIn("SET-MACO-LARGE", set(restock_rows["sku"]))
+        self.assertNotIn("MACO-EXTREME-300-GEL", set(alert_rows["sku"]))
+        self.assertNotIn("MACO-EXTREME-300-GEL", set(restock_rows["sku"]))
 
         for component_sku in expected_component_skus:
             row = alert_rows.loc[alert_rows["sku"] == component_sku].iloc[0]


### PR DESCRIPTION
## Summary
- tighten the ROY MACO STOP large set spray component pattern to 300ml hmla
- add a regression assertion that the 300ml gel SKU is not treated as a set component
- record the follow-up in PROJECT_STATE.md

## Verification
- python -m py_compile export_orders.py
- python -m unittest tests.test_roy_inventory_model tests.test_roy_operations_dashboard
- python scripts\\reporting_qa_smoke.py
- python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- git diff --check