### PR TITLE
[codex] Zero-fill ROY Facebook delivery chart dates

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -204,9 +204,25 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- ROY MACO STOP large set component demand is deployed to the live operations dashboard. Next exact step: monitor the next scheduled ROY report once and confirm the alert counts stay consistent with the live dashboard.
+- ROY Facebook spend audit found that Meta reports zero spend for `2026-05-18..2026-05-23`, but campaign `SK-Sale-Fotopasce-ACQ` is active again with spend on `2026-05-25..2026-05-26`. Next exact step: merge/deploy the dashboard zero-fill fix, then verify the live ROY report shows zero-spend days instead of omitting them from the Facebook delivery chart.
 
 ## 9) Change Log
+
+### 2026-05-27 (ROY Facebook spend audit)
+- Checked ROY Facebook Ads source path:
+  - financial/reporting spend comes from Meta account-level daily insights via `FacebookAdsClient.get_daily_spend()`;
+  - the modern dashboard `Daily spend, clicks and impressions` chart uses `fb_detailed_metrics` from Meta account-level insights.
+- Live Meta API read-only check for account `act_1374274514249768`:
+  - `2026-05-18..2026-05-23`: Facebook spend `0.00 EUR`, no campaign rows.
+  - `2026-05-25`: Facebook spend `4.76 EUR`.
+  - `2026-05-26`: Facebook spend `14.12 EUR`.
+  - campaign/adset/ad source: `SK-Sale-Fotopasce-ACQ` / `SK-Interest` / `SK-Fotopasce-4G-Video-V1`, all reported `ACTIVE`.
+- Found a dashboard visualization issue: `fb_daily` payload only included dates returned by Meta, so zero-spend days were omitted from the Facebook delivery chart instead of plotted as `0`.
+- Added a code fix on branch `codex/roy-fb-spend-zero-fill` to zero-fill missing dates in `dashboard_modern.py`, with a unit test in `tests/test_dashboard_modern.py`.
+- Verified locally:
+  - `python -m unittest tests.test_dashboard_modern`
+  - `python -m py_compile dashboard_modern.py`
+  - `python -m unittest discover -s tests`
 
 ### 2026-05-26 (ROY App Runner live dashboard deployed)
 - Merged deployment fix PRs into `main`:

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -655,6 +655,45 @@ def _profit_status_class(value: Any) -> str:
     return "neutral"
 
 
+def _build_fb_daily_payload(
+    date_from: datetime,
+    date_to: datetime,
+    fb_detailed_metrics: Optional[dict],
+) -> Dict[str, List[Any]]:
+    payload: Dict[str, List[Any]] = {
+        "dates": [],
+        "spend": [],
+        "impressions": [],
+        "clicks": [],
+        "ctr": [],
+        "cpc": [],
+        "cpm": [],
+        "reach": [],
+    }
+    if not fb_detailed_metrics:
+        return payload
+
+    metrics_by_date = {str(key): value or {} for key, value in fb_detailed_metrics.items()}
+    date_keys = [
+        date.strftime("%Y-%m-%d")
+        for date in pd.date_range(start=date_from, end=date_to, freq="D")
+    ]
+    if not date_keys:
+        date_keys = sorted(metrics_by_date)
+
+    for date_key in date_keys:
+        row = metrics_by_date.get(date_key, {})
+        payload["dates"].append(date_key)
+        payload["spend"].append(round(_num(row.get("spend")), 2))
+        payload["impressions"].append(round(_num(row.get("impressions")), 2))
+        payload["clicks"].append(round(_num(row.get("clicks")), 2))
+        payload["ctr"].append(round(_num(row.get("ctr")), 2))
+        payload["cpc"].append(round(_num(row.get("cpc")), 2))
+        payload["cpm"].append(round(_num(row.get("cpm")), 2))
+        payload["reach"].append(round(_num(row.get("reach")), 2))
+    return payload
+
+
 def generate_modern_dashboard(
     date_agg: pd.DataFrame,
     items_agg: pd.DataFrame,
@@ -968,19 +1007,7 @@ def generate_modern_dashboard(
             "lifetime_orders": [round(_num(v), 2) for v in ltv_by_date.get("total_lifetime_orders", pd.Series([0] * len(ltv_by_date))).tolist()],
         }
 
-    fb_daily_payload = {"dates": [], "spend": [], "impressions": [], "clicks": [], "ctr": [], "cpc": [], "cpm": [], "reach": []}
-    if fb_detailed_metrics:
-        sorted_rows = sorted(fb_detailed_metrics.items(), key=lambda item: item[0])
-        fb_daily_payload = {
-            "dates": [str(k) for k, _ in sorted_rows],
-            "spend": [round(_num(v.get("spend")), 2) for _, v in sorted_rows],
-            "impressions": [round(_num(v.get("impressions")), 2) for _, v in sorted_rows],
-            "clicks": [round(_num(v.get("clicks")), 2) for _, v in sorted_rows],
-            "ctr": [round(_num(v.get("ctr")), 2) for _, v in sorted_rows],
-            "cpc": [round(_num(v.get("cpc")), 2) for _, v in sorted_rows],
-            "cpm": [round(_num(v.get("cpm")), 2) for _, v in sorted_rows],
-            "reach": [round(_num(v.get("reach")), 2) for _, v in sorted_rows],
-        }
+    fb_daily_payload = _build_fb_daily_payload(date_from, date_to, fb_detailed_metrics)
 
     fb_campaign_rows = []
     if fb_campaigns:

--- a/tests/test_dashboard_modern.py
+++ b/tests/test_dashboard_modern.py
@@ -1,0 +1,28 @@
+import unittest
+from datetime import datetime
+
+from dashboard_modern import _build_fb_daily_payload
+
+
+class DashboardModernTests(unittest.TestCase):
+    def test_fb_daily_payload_zero_fills_missing_report_dates(self) -> None:
+        payload = _build_fb_daily_payload(
+            datetime(2026, 5, 1),
+            datetime(2026, 5, 4),
+            {
+                "2026-05-01": {"spend": 10.24, "clicks": 80, "impressions": 3924},
+                "2026-05-03": {"spend": 10.09, "clicks": 120, "impressions": 5630},
+            },
+        )
+
+        self.assertEqual(
+            ["2026-05-01", "2026-05-02", "2026-05-03", "2026-05-04"],
+            payload["dates"],
+        )
+        self.assertEqual([10.24, 0.0, 10.09, 0.0], payload["spend"])
+        self.assertEqual([80.0, 0.0, 120.0, 0.0], payload["clicks"])
+        self.assertEqual([3924.0, 0.0, 5630.0, 0.0], payload["impressions"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- Zero-fill missing dates in the modern dashboard Facebook daily delivery payload.
- Add a unit test covering gaps in Meta daily metrics.
- Record the ROY Facebook spend audit in `PROJECT_STATE.md`.

## Why
Meta account-level insights omit days with no delivery. The ROY dashboard used those returned dates directly, so zero-spend days could disappear from the `Daily spend, clicks and impressions` chart and visually imply continuous spend.

## Audit notes
- `2026-05-18..2026-05-23`: Meta API returned `0.00 EUR` Facebook spend and no campaign rows.
- `2026-05-25`: Meta API returned `4.76 EUR` spend.
- `2026-05-26`: Meta API returned `14.12 EUR` spend.
- The spend source was `SK-Sale-Fotopasce-ACQ` / `SK-Interest` / `SK-Fotopasce-4G-Video-V1`, all reported `ACTIVE` by Meta.

## Validation
- `python -m unittest tests.test_dashboard_modern`
- `python -m py_compile dashboard_modern.py`
- `python -m unittest discover -s tests`
