### PR TITLE
[codex] Add ROY dashboard performance and inbound workflow

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -743,6 +743,11 @@ jobs:
               "Action": ["s3:GetObject"],
               "Resource": [f"arn:aws:s3:::{bucket}/{prefix}/latest/*"],
           })
+          policy["Statement"].append({
+              "Effect": "Allow",
+              "Action": ["s3:GetObject", "s3:PutObject"],
+              "Resource": [f"arn:aws:s3:::{bucket}/{prefix}/operations/*"],
+          })
           json.dump(policy, open("instance-policy.json", "w", encoding="utf-8"), indent=2)
           PY
           fi

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-05-21
+Last updated: 2026-05-27
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -204,9 +204,27 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- ROY Facebook spend audit found that Meta reports zero spend for `2026-05-18..2026-05-23`, but campaign `SK-Sale-Fotopasce-ACQ` is active again with spend on `2026-05-25..2026-05-26`. Next exact step: merge/deploy the dashboard zero-fill fix, then verify the live ROY report shows zero-spend days instead of omitting them from the Facebook delivery chart.
+- ROY operations dashboard performance/inbound workflow is implemented on branch `codex/roy-dashboard-top-margin-workflow`. Next exact step: open/merge PR, run ECR build, deploy App Runner, then verify `/production/roy` with live API/UI smoke.
 
 ## 9) Change Log
+
+### 2026-05-27 (ROY operations performance and inbound workflow)
+- Branch: `codex/roy-dashboard-top-margin-workflow`
+- Change:
+  - ROY reporting payload now emits top product rows by revenue, top product rows by profit, and loss-product rows.
+  - ROY live operations API now exposes top 3 brands by revenue/profit, top 10 products by revenue/profit, and loss-product warnings.
+  - loss-product warnings can be acknowledged from the live dashboard and are persisted in ROY operations state.
+  - low-stock products can be marked as ordered by entering ordered units and expected arrival date.
+  - inbound ordered units are counted in the live dashboard stock-risk calculation, so sufficiently covered products are removed from reorder alerts.
+  - inbound markers auto-clear after the next BiznisWeb stock increase for the SKU.
+  - App Runner instance policy now grants state persistence access to `operations/*` under the live dashboard S3 artifact prefix.
+- Local verification:
+  - `python -m py_compile export_orders.py dashboard_modern.py roy_operations_dashboard.py live_dashboard_server.py daily_report_runner.py`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, run ECR build, deploy App Runner, then verify production API/UI and record deploy run IDs.
 
 ### 2026-05-27 (ROY Facebook spend audit)
 - Checked ROY Facebook Ads source path:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -204,9 +204,25 @@ Bootstrap entrypoints:
   - the daily email summary builder now reads the dashboard payload and appends a `SKLADOVE ALERTY` section with top reorder actions
 
 ## 8) Next Exact Step
-- ROY MACO STOP large set component demand is deployed to the live operations dashboard. Next exact step: monitor the next scheduled ROY report once and confirm the alert counts stay consistent with the live dashboard.
+- ROY Facebook spend audit found that Meta reports zero spend for `2026-05-18..2026-05-23`, but campaign `SK-Sale-Fotopasce-ACQ` is active again with spend on `2026-05-25..2026-05-26`. Next exact step: merge/deploy the dashboard zero-fill fix, then verify the live ROY report shows zero-spend days instead of omitting them from the Facebook delivery chart.
 
 ## 9) Change Log
+
+### 2026-05-27 (ROY Facebook spend audit)
+- Checked ROY Facebook Ads source path:
+  - financial/reporting spend comes from Meta account-level daily insights via `FacebookAdsClient.get_daily_spend()`;
+  - the modern dashboard `Daily spend, clicks and impressions` chart uses `fb_detailed_metrics` from Meta account-level insights.
+- Live Meta API read-only check for account `act_1374274514249768`:
+  - `2026-05-18..2026-05-23`: Facebook spend `0.00 EUR`, no campaign rows.
+  - `2026-05-25`: Facebook spend `4.76 EUR`.
+  - `2026-05-26`: Facebook spend `14.12 EUR`.
+  - campaign/adset/ad source: `SK-Sale-Fotopasce-ACQ` / `SK-Interest` / `SK-Fotopasce-4G-Video-V1`, all reported `ACTIVE`.
+- Found a dashboard visualization issue: `fb_daily` payload only included dates returned by Meta, so zero-spend days were omitted from the Facebook delivery chart instead of plotted as `0`.
+- Added a code fix on branch `codex/roy-fb-spend-zero-fill` to zero-fill missing dates in `dashboard_modern.py`, with a unit test in `tests/test_dashboard_modern.py`.
+- Verified locally:
+  - `python -m unittest tests.test_dashboard_modern`
+  - `python -m py_compile dashboard_modern.py`
+  - `python -m unittest discover -s tests`
 
 ### 2026-05-26 (ROY App Runner live dashboard deployed)
 - Merged deployment fix PRs into `main`:

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -655,6 +655,45 @@ def _profit_status_class(value: Any) -> str:
     return "neutral"
 
 
+def _build_fb_daily_payload(
+    date_from: datetime,
+    date_to: datetime,
+    fb_detailed_metrics: Optional[dict],
+) -> Dict[str, List[Any]]:
+    payload: Dict[str, List[Any]] = {
+        "dates": [],
+        "spend": [],
+        "impressions": [],
+        "clicks": [],
+        "ctr": [],
+        "cpc": [],
+        "cpm": [],
+        "reach": [],
+    }
+    if not fb_detailed_metrics:
+        return payload
+
+    metrics_by_date = {str(key): value or {} for key, value in fb_detailed_metrics.items()}
+    date_keys = [
+        date.strftime("%Y-%m-%d")
+        for date in pd.date_range(start=date_from, end=date_to, freq="D")
+    ]
+    if not date_keys:
+        date_keys = sorted(metrics_by_date)
+
+    for date_key in date_keys:
+        row = metrics_by_date.get(date_key, {})
+        payload["dates"].append(date_key)
+        payload["spend"].append(round(_num(row.get("spend")), 2))
+        payload["impressions"].append(round(_num(row.get("impressions")), 2))
+        payload["clicks"].append(round(_num(row.get("clicks")), 2))
+        payload["ctr"].append(round(_num(row.get("ctr")), 2))
+        payload["cpc"].append(round(_num(row.get("cpc")), 2))
+        payload["cpm"].append(round(_num(row.get("cpm")), 2))
+        payload["reach"].append(round(_num(row.get("reach")), 2))
+    return payload
+
+
 def generate_modern_dashboard(
     date_agg: pd.DataFrame,
     items_agg: pd.DataFrame,
@@ -968,19 +1007,7 @@ def generate_modern_dashboard(
             "lifetime_orders": [round(_num(v), 2) for v in ltv_by_date.get("total_lifetime_orders", pd.Series([0] * len(ltv_by_date))).tolist()],
         }
 
-    fb_daily_payload = {"dates": [], "spend": [], "impressions": [], "clicks": [], "ctr": [], "cpc": [], "cpm": [], "reach": []}
-    if fb_detailed_metrics:
-        sorted_rows = sorted(fb_detailed_metrics.items(), key=lambda item: item[0])
-        fb_daily_payload = {
-            "dates": [str(k) for k, _ in sorted_rows],
-            "spend": [round(_num(v.get("spend")), 2) for _, v in sorted_rows],
-            "impressions": [round(_num(v.get("impressions")), 2) for _, v in sorted_rows],
-            "clicks": [round(_num(v.get("clicks")), 2) for _, v in sorted_rows],
-            "ctr": [round(_num(v.get("ctr")), 2) for _, v in sorted_rows],
-            "cpc": [round(_num(v.get("cpc")), 2) for _, v in sorted_rows],
-            "cpm": [round(_num(v.get("cpm")), 2) for _, v in sorted_rows],
-            "reach": [round(_num(v.get("reach")), 2) for _, v in sorted_rows],
-        }
+    fb_daily_payload = _build_fb_daily_payload(date_from, date_to, fb_detailed_metrics)
 
     fb_campaign_rows = []
     if fb_campaigns:

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1314,8 +1314,14 @@ def generate_modern_dashboard(
             "inventory_retail_value",
             "cost_coverage_pct",
             "days_since_last_sale",
+            "alert_30d_units",
+            "lead_time_working_days",
             "days_of_cover",
+            "projected_stockout_date",
             "stock_risk_level",
+            "reorder_by_date",
+            "suggested_reorder_units",
+            "reorder_action_label",
         ],
         limit=160,
     )
@@ -1366,6 +1372,8 @@ def generate_modern_dashboard(
             "reorder_action_label",
             "alert_30d_revenue",
             "projected_stockout_date",
+            "reorder_now_flag",
+            "prepare_po_flag",
         ],
         limit=120,
     )
@@ -1384,6 +1392,10 @@ def generate_modern_dashboard(
             "recent_margin_with_fixed_pct",
             "projected_stockout_date",
             "cost_coverage_pct",
+            "lead_time_working_days",
+            "reorder_by_date",
+            "suggested_reorder_units",
+            "reorder_action_label",
         ],
         limit=120,
     )
@@ -1491,6 +1503,57 @@ def generate_modern_dashboard(
             "margin_without_fixed_pct",
         ],
         limit=12,
+    )
+    roy_product_revenue_rows = _frame_rows(
+        (roy_product_demand or {}).get("product_revenue_rows"),
+        [
+            "sku",
+            "product",
+            "orders",
+            "units",
+            "revenue",
+            "profit_without_fixed",
+            "profit_with_fixed",
+            "margin_without_fixed_pct",
+            "margin_with_fixed_pct",
+            "first_sale",
+            "last_sale",
+        ],
+        limit=20,
+    )
+    roy_product_profit_rows = _frame_rows(
+        (roy_product_demand or {}).get("product_profit_rows"),
+        [
+            "sku",
+            "product",
+            "orders",
+            "units",
+            "revenue",
+            "profit_without_fixed",
+            "profit_with_fixed",
+            "margin_without_fixed_pct",
+            "margin_with_fixed_pct",
+            "first_sale",
+            "last_sale",
+        ],
+        limit=20,
+    )
+    roy_loss_product_rows = _frame_rows(
+        (roy_product_demand or {}).get("loss_product_rows"),
+        [
+            "sku",
+            "product",
+            "orders",
+            "units",
+            "revenue",
+            "profit_without_fixed",
+            "profit_with_fixed",
+            "margin_without_fixed_pct",
+            "margin_with_fixed_pct",
+            "first_sale",
+            "last_sale",
+        ],
+        limit=80,
     )
 
     heatmap_rows = _frame_rows(day_hour_heatmap, ["day_name", "hour", "orders"], limit=None)
@@ -2001,6 +2064,9 @@ def generate_modern_dashboard(
             "forecast_accuracy_rows": roy_forecast_accuracy_rows,
             "brand_revenue_rows": roy_brand_revenue_rows,
             "brand_profit_rows": roy_brand_profit_rows,
+            "product_revenue_rows": roy_product_revenue_rows,
+            "product_profit_rows": roy_product_profit_rows,
+            "loss_product_rows": roy_loss_product_rows,
         },
         "daily_margin_rows": daily_margin_rows,
         "payday_window_rows": payday_window_rows,

--- a/export_orders.py
+++ b/export_orders.py
@@ -8579,6 +8579,9 @@ class BizniWebExporter:
                 "forecast_accuracy_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
+                "product_revenue_rows": pd.DataFrame(),
+                "product_profit_rows": pd.DataFrame(),
+                "loss_product_rows": pd.DataFrame(),
             }
 
         print("\nAnalyzing Roy product demand analytics...")
@@ -8604,6 +8607,9 @@ class BizniWebExporter:
                 "forecast_accuracy_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
+                "product_revenue_rows": pd.DataFrame(),
+                "product_profit_rows": pd.DataFrame(),
+                "loss_product_rows": pd.DataFrame(),
             }
 
         demand_df = item_df.copy()
@@ -8627,6 +8633,9 @@ class BizniWebExporter:
                 "forecast_accuracy_rows": pd.DataFrame(),
                 "brand_revenue_rows": pd.DataFrame(),
                 "brand_profit_rows": pd.DataFrame(),
+                "product_revenue_rows": pd.DataFrame(),
+                "product_profit_rows": pd.DataFrame(),
+                "loss_product_rows": pd.DataFrame(),
             }
 
         numeric_columns = ["item_quantity", "item_total_without_tax", "cm2_profit", "cm3_profit"]
@@ -8649,6 +8658,73 @@ class BizniWebExporter:
                 last_sale=("purchase_datetime", "max"),
             )
             .reset_index()
+        )
+        product_summary["margin_with_fixed_pct"] = np.where(
+            product_summary["revenue"] != 0,
+            (product_summary["profit_with_fixed"] / product_summary["revenue"]) * 100.0,
+            0.0,
+        )
+        product_summary["margin_without_fixed_pct"] = np.where(
+            product_summary["revenue"] != 0,
+            (product_summary["profit_without_fixed"] / product_summary["revenue"]) * 100.0,
+            0.0,
+        )
+        product_display_summary = product_summary.loc[
+            (product_summary["revenue"] >= 50.0) | (product_summary["orders"] >= 3)
+        ].copy()
+        if not product_display_summary.empty:
+            product_display_summary = product_display_summary.rename(columns={"product_sku": "sku"})
+            product_display_summary["first_sale"] = pd.to_datetime(
+                product_display_summary["first_sale"],
+                errors="coerce",
+            ).dt.strftime("%Y-%m-%d")
+            product_display_summary["last_sale"] = pd.to_datetime(
+                product_display_summary["last_sale"],
+                errors="coerce",
+            ).dt.strftime("%Y-%m-%d")
+            product_display_summary = product_display_summary[
+                [
+                    "sku",
+                    "product",
+                    "orders",
+                    "units",
+                    "revenue",
+                    "profit_without_fixed",
+                    "profit_with_fixed",
+                    "margin_without_fixed_pct",
+                    "margin_with_fixed_pct",
+                    "first_sale",
+                    "last_sale",
+                ]
+            ]
+            for column in [
+                "units",
+                "revenue",
+                "profit_without_fixed",
+                "profit_with_fixed",
+                "margin_without_fixed_pct",
+                "margin_with_fixed_pct",
+            ]:
+                product_display_summary[column] = product_display_summary[column].round(
+                    1 if column in {"units", "margin_without_fixed_pct", "margin_with_fixed_pct"} else 2
+                )
+
+        product_revenue_rows_df = (
+            product_display_summary.sort_values(["revenue", "profit_with_fixed"], ascending=[False, False]).reset_index(drop=True)
+            if not product_display_summary.empty else pd.DataFrame()
+        )
+        product_profit_rows_df = (
+            product_display_summary.sort_values(["profit_with_fixed", "revenue"], ascending=[False, False]).reset_index(drop=True)
+            if not product_display_summary.empty else pd.DataFrame()
+        )
+        loss_product_rows_df = (
+            product_display_summary.loc[
+                (product_display_summary["profit_without_fixed"] < 0)
+                | (product_display_summary["profit_with_fixed"] < 0)
+            ]
+            .sort_values(["profit_without_fixed", "profit_with_fixed", "revenue"], ascending=[True, True, False])
+            .reset_index(drop=True)
+            if not product_display_summary.empty else pd.DataFrame()
         )
 
         weekly = (
@@ -9352,12 +9428,18 @@ class BizniWebExporter:
                 .astype(str)
                 .replace({"nan": "Low", "": "Low"})
             )
-            inventory_products_df[["brand_key", "brand_label"]] = inventory_products_df["product"].apply(
-                lambda value: pd.Series(self._extract_product_brand(value))
-            )
-            inventory_products_df[["family_key", "family_label"]] = inventory_products_df["product"].apply(
-                lambda value: pd.Series(self._extract_product_family(value))
-            )
+            if inventory_products_df.empty:
+                inventory_products_df["brand_key"] = pd.Series(dtype="object")
+                inventory_products_df["brand_label"] = pd.Series(dtype="object")
+                inventory_products_df["family_key"] = pd.Series(dtype="object")
+                inventory_products_df["family_label"] = pd.Series(dtype="object")
+            else:
+                inventory_products_df[["brand_key", "brand_label"]] = inventory_products_df["product"].apply(
+                    lambda value: pd.Series(self._extract_product_brand(value))
+                )
+                inventory_products_df[["family_key", "family_label"]] = inventory_products_df["product"].apply(
+                    lambda value: pd.Series(self._extract_product_family(value))
+                )
             inventory_products_df["strategic_stock_flag"] = inventory_products_df["brand_key"].isin(hero_brand_keys)
             brand_lead_time = (
                 inventory_products_df["brand_key"]
@@ -10146,13 +10228,17 @@ class BizniWebExporter:
             "forecast_accuracy_rows": forecast_accuracy_rows_df,
             "brand_revenue_rows": brand_revenue_rows_df,
             "brand_profit_rows": brand_profit_rows_df,
+            "product_revenue_rows": product_revenue_rows_df,
+            "product_profit_rows": product_profit_rows_df,
+            "loss_product_rows": loss_product_rows_df,
         }
         print(
             f"Roy product demand analytics complete: growing={len(growing_rows_df)}, "
             f"declining={len(declining_rows_df)}, forecasted={len(forecast_rows_df)}, "
             f"inventory_rows={len(inventory_rows_df)}, alert_rows={len(alert_rows_df)}, "
             f"restock_rows={len(restock_priority_rows_df)}, "
-            f"forecast_backtests={len(forecast_accuracy_rows_df)}, brands={len(brand_summary)}"
+            f"forecast_backtests={len(forecast_accuracy_rows_df)}, brands={len(brand_summary)}, "
+            f"loss_products={len(loss_product_rows_df)}"
         )
         return result
 

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -16,9 +16,12 @@ from urllib.parse import parse_qs, quote, unquote, urlparse
 
 from production_board import get_cached_production_board_snapshot, resolve_production_board_settings
 from roy_operations_dashboard import (
+    acknowledge_loss_product,
+    clear_inbound_stock_order,
     get_cached_roy_operations_snapshot,
     mark_personal_pickup_shipped,
     resolve_roy_operations_settings,
+    set_inbound_stock_order,
 )
 from reporting_core import load_project_settings
 
@@ -984,12 +987,17 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     .items { display:grid; gap:3px; max-width:560px; }
     .item-line { display:flex; justify-content:space-between; gap:10px; border-top:1px solid #edf0eb; padding-top:3px; }
     .layout-2 { display:grid; grid-template-columns:minmax(0,1fr) minmax(420px,.42fr); gap:12px; align-items:start; }
+    .performance-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px; align-items:start; }
     .pickup-list { display:grid; gap:8px; max-height:620px; overflow:auto; }
     .pickup { border:1px solid var(--line); border-radius:8px; padding:10px; background:#fff; }
     .pickup-top { display:flex; justify-content:space-between; gap:10px; align-items:flex-start; }
     .pickup-title { font-weight:850; font-size:16px; }
     .checkline { display:flex; gap:8px; align-items:center; margin-top:9px; font-weight:800; }
     .checkline input { width:19px; height:19px; }
+    .stock-action { display:grid; grid-template-columns:82px 138px auto; gap:6px; align-items:center; min-width:290px; }
+    .stock-action input { min-height:34px; border:1px solid var(--line); border-radius:6px; padding:0 8px; font-weight:700; width:100%; }
+    .stock-action button { min-height:34px; padding:0 9px; }
+    .inbound-note { margin-top:5px; color:var(--green); font-size:12px; font-weight:800; }
     .hidden { display:none !important; }
     .error,.ok { margin-bottom:12px; padding:10px 12px; border-radius:8px; border:1px solid rgba(170,47,47,.25); color:var(--red); background:var(--red-bg); }
     .ok { color:var(--green); background:var(--green-bg); border-color:rgba(17,115,75,.25); }
@@ -997,6 +1005,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       .alert-grid { grid-template-columns:repeat(3,minmax(150px,1fr)); }
       .kpi-grid { grid-template-columns:repeat(2,minmax(220px,1fr)); }
       .layout-2 { grid-template-columns:1fr; }
+      .performance-grid { grid-template-columns:1fr; }
     }
     @media (max-width:720px) {
       main { width:100%; padding:10px 8px 26px; }
@@ -1007,6 +1016,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       .alert-grid,.kpi-grid { grid-template-columns:1fr; }
       .panel-head,.kpi-controls { align-items:flex-start; flex-direction:column; }
       button,a.button,select { min-height:42px; }
+      .stock-action { grid-template-columns:1fr; min-width:220px; }
       table { min-width:860px; }
     }
   </style>
@@ -1081,8 +1091,66 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         </div>
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Produkt</th><th>Riziko</th><th>Sklad</th><th>30d dopyt</th><th>Cover</th><th>Vypredanie</th><th>Objednať do</th><th>Návrh</th></tr></thead>
+            <thead><tr><th>Produkt</th><th>Riziko</th><th>Sklad</th><th>Objednané</th><th>30d dopyt</th><th>Cover</th><th>Vypredanie</th><th>Objednať do</th><th>Návrh</th></tr></thead>
             <tbody id="alertRowsBody"></tbody>
+          </table>
+        </div>
+      </article>
+      <article class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Top značky</h2>
+            <p id="brandPerformanceMeta">-</p>
+          </div>
+        </div>
+        <div class="performance-grid panel-body">
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Značka podľa obratu</th><th>Obrat</th><th>Zisk</th><th>Marža</th></tr></thead>
+              <tbody id="brandRevenueBody"></tbody>
+            </table>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Značka podľa zisku</th><th>Zisk</th><th>Obrat</th><th>Marža</th></tr></thead>
+              <tbody id="brandProfitBody"></tbody>
+            </table>
+          </div>
+        </div>
+      </article>
+      <article class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Top produkty</h2>
+            <p id="productPerformanceMeta">-</p>
+          </div>
+        </div>
+        <div class="performance-grid panel-body">
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Produkt podľa obratu</th><th>Obrat</th><th>Zisk</th><th>Kusy</th></tr></thead>
+              <tbody id="productRevenueBody"></tbody>
+            </table>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Produkt podľa zisku</th><th>Zisk</th><th>Obrat</th><th>Kusy</th></tr></thead>
+              <tbody id="productProfitBody"></tbody>
+            </table>
+          </div>
+        </div>
+      </article>
+      <article class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Produkty v strate</h2>
+            <p id="lossProductMeta">-</p>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Produkt</th><th>Obrat</th><th>Zisk bez fixu</th><th>Zisk s fixom</th><th>Marža</th><th>Potvrdené</th></tr></thead>
+            <tbody id="lossProductBody"></tbody>
           </table>
         </div>
       </article>
@@ -1108,10 +1176,16 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         </div>
         <div class="panel-body">
           <div class="alert-grid" id="inventorySummaryGrid"></div>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Objednaný produkt</th><th>Objednané kusy</th><th>ETA</th><th>Sklad pri zadaní</th><th>Aktuálny sklad</th><th>Akcia</th></tr></thead>
+              <tbody id="inboundRowsBody"></tbody>
+            </table>
+          </div>
         </div>
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Produkt</th><th>Sklad</th><th>Nákupná hodnota</th><th>Predajná hodnota</th><th>Cover</th><th>Vypredanie</th><th>Lead time</th><th>Reorder</th></tr></thead>
+            <thead><tr><th>Produkt</th><th>Sklad</th><th>Nákupná hodnota</th><th>Predajná hodnota</th><th>Cover</th><th>Vypredanie</th><th>Lead time</th><th>Objednané</th><th>Reorder</th></tr></thead>
             <tbody id="inventoryRowsBody"></tbody>
           </table>
         </div>
@@ -1130,6 +1204,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     const fmtRatio = (value) => value === null || value === undefined ? 'N/A' : `${new Intl.NumberFormat('sk-SK', { maximumFractionDigits:2 }).format(Number(value || 0))}x`;
     const text = (value, fallback='-') => value === null || value === undefined || value === '' ? fallback : String(value);
     const safe = (value) => text(value, '').replace(/[&<>"']/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+    const cssEscape = (value) => window.CSS && CSS.escape ? CSS.escape(String(value)) : String(value).replace(/["\\]/g, '\\$&');
     let latestData = null;
     let refreshTimer = null;
     let kpiScope = 'monthly';
@@ -1149,11 +1224,36 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     function metric(label, value, note, tone='info') {
       return `<article class="metric"><div class="label">${safe(label)}</div><div class="value">${safe(value)}</div><div class="note">${safe(note)}</div></article>`;
     }
+    function compactProductCell(row) {
+      return `<strong>${safe(row.product || row.brand_label || row.group_label || '-')}</strong><div class="muted mono">${safe(row.sku || row.brand_key || row.group_key || '')}</div>`;
+    }
+    function inboundStatus(row) {
+      const units = Number(row.inbound_ordered_units || 0);
+      if (!units) return '<span class="muted">-</span>';
+      return `<div><span class="badge good">${fmtQty(units)} ks</span><div class="inbound-note">ETA ${safe(row.inbound_expected_arrival_date || '-')}</div></div>`;
+    }
+    function inboundControls(row) {
+      const sku = safe(row.sku);
+      const product = safe(row.product);
+      const available = Number(row.available_quantity || 0);
+      const units = Number(row.inbound_ordered_units || 0);
+      const eta = safe(row.inbound_expected_arrival_date || '');
+      const clear = units > 0 ? `<button type="button" data-clear-inbound="${sku}">Zrušiť</button>` : '';
+      return `<div>
+        ${inboundStatus(row)}
+        <div class="stock-action" style="margin-top:6px;">
+          <input type="number" min="0.1" step="1" value="${units || ''}" placeholder="ks" data-inbound-units="${sku}">
+          <input type="date" value="${eta}" data-inbound-eta="${sku}">
+          <button type="button" data-save-inbound="${sku}" data-product="${product}" data-baseline="${available}">Uložiť</button>
+        </div>
+        ${clear}
+      </div>`;
+    }
     function badgeClass(value) {
       const v = String(value || '').toLowerCase();
       if (v.includes('negative') || v.includes('out of stock') || v.includes('critical') || v.includes('urgent') || v.includes('order now')) return 'bad';
-      if (v.includes('low') || v.includes('watch') || v.includes('prepare') || v.includes('plan')) return 'warn';
-      if (v.includes('healthy') || v.includes('ok')) return 'good';
+      if (v.includes('partially') || v.includes('low') || v.includes('watch') || v.includes('prepare') || v.includes('plan')) return 'warn';
+      if (v.includes('inbound') || v.includes('healthy') || v.includes('ok')) return 'good';
       return 'info';
     }
     function formatKpiValue(key, value) {
@@ -1233,6 +1333,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         metric('Osobné odbery', fmtInt(orders.personal_pickups), `${fmtInt(orders.pickup_actions_available)} akcií dostupných`),
         metric('Kritický sklad', fmtInt(inv.stock_risk_critical_count), `${fmtInt(inv.stock_risk_30d_count)} položiek v 30d riziku`),
         metric('Objednať teraz', fmtInt(inv.alert_reorder_now_count), `${fmtInt(inv.alert_prepare_po_count)} pripraviť PO`),
+        metric('Objednané na ceste', fmtQty(inv.inbound_ordered_units), `${fmtInt(inv.inbound_order_count)} položiek · ETA ${text(inv.inbound_next_arrival_date)}`),
         metric('Hodnota skladu', fmtMoney(inv.inventory_cost_value), `predajná ${fmtMoney(inv.inventory_retail_value)}`),
       ].join('');
     }
@@ -1276,11 +1377,52 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         </article>`).join('') : '<p class="muted">Žiadne osobné odbery.</p>';
       el('pickupList').querySelectorAll('[data-ship-pickup]').forEach((input) => input.addEventListener('change', () => markPickupShipped(input)));
     }
+    function brandRevenueRow(row) {
+      return `<tr><td>${compactProductCell(row)}</td><td>${fmtMoney(row.revenue)}</td><td>${fmtMoney(row.profit_with_fixed)}</td><td>${fmtPct(row.margin_with_fixed_pct)}</td></tr>`;
+    }
+    function brandProfitRow(row) {
+      return `<tr><td>${compactProductCell(row)}</td><td>${fmtMoney(row.profit_with_fixed)}</td><td>${fmtMoney(row.revenue)}</td><td>${fmtPct(row.margin_with_fixed_pct)}</td></tr>`;
+    }
+    function productRevenueRow(row) {
+      return `<tr><td>${compactProductCell(row)}</td><td>${fmtMoney(row.revenue)}</td><td>${fmtMoney(row.profit_with_fixed)}</td><td>${fmtQty(row.units)} ks</td></tr>`;
+    }
+    function productProfitRow(row) {
+      return `<tr><td>${compactProductCell(row)}</td><td>${fmtMoney(row.profit_with_fixed)}</td><td>${fmtMoney(row.revenue)}</td><td>${fmtQty(row.units)} ks</td></tr>`;
+    }
+    function lossProductRow(row) {
+      return `<tr>
+        <td>${compactProductCell(row)}</td>
+        <td>${fmtMoney(row.revenue)}</td>
+        <td><span class="${Number(row.profit_without_fixed || 0) < 0 ? 'negative' : 'neutral'}">${fmtMoney(row.profit_without_fixed)}</span></td>
+        <td><span class="${Number(row.profit_with_fixed || 0) < 0 ? 'negative' : 'neutral'}">${fmtMoney(row.profit_with_fixed)}</span></td>
+        <td>${fmtPct(row.margin_with_fixed_pct)}</td>
+        <td><label class="checkline" style="margin-top:0;"><input type="checkbox" data-ack-loss="${safe(row.sku)}" data-product="${safe(row.product)}"> viem</label></td>
+      </tr>`;
+    }
+    function renderPerformance(data) {
+      const perf = data.performance || {};
+      const brandRevenue = perf.brand_revenue_rows || [];
+      const brandProfit = perf.brand_profit_rows || [];
+      const productRevenue = perf.product_revenue_rows || [];
+      const productProfit = perf.product_profit_rows || [];
+      const losses = perf.loss_product_rows || [];
+      el('brandPerformanceMeta').textContent = `${fmtInt(brandRevenue.length)} podľa obratu · ${fmtInt(brandProfit.length)} podľa zisku`;
+      el('brandRevenueBody').innerHTML = brandRevenue.length ? brandRevenue.map(brandRevenueRow).join('') : '<tr><td colspan="4" class="muted">Značky zatiaľ nie sú dostupné.</td></tr>';
+      el('brandProfitBody').innerHTML = brandProfit.length ? brandProfit.map(brandProfitRow).join('') : '<tr><td colspan="4" class="muted">Značky zatiaľ nie sú dostupné.</td></tr>';
+      el('productPerformanceMeta').textContent = `${fmtInt(productRevenue.length)} podľa obratu · ${fmtInt(productProfit.length)} podľa zisku`;
+      el('productRevenueBody').innerHTML = productRevenue.length ? productRevenue.map(productRevenueRow).join('') : '<tr><td colspan="4" class="muted">Produkty zatiaľ nie sú dostupné.</td></tr>';
+      el('productProfitBody').innerHTML = productProfit.length ? productProfit.map(productProfitRow).join('') : '<tr><td colspan="4" class="muted">Produkty zatiaľ nie sú dostupné.</td></tr>';
+      const hidden = Number(perf.acknowledged_loss_product_count || 0);
+      el('lossProductMeta').textContent = losses.length ? `${fmtInt(losses.length)} nepotvrdených · ${fmtInt(hidden)} potvrdených skrytých` : `${fmtInt(hidden)} potvrdených skrytých`;
+      el('lossProductBody').innerHTML = losses.length ? losses.map(lossProductRow).join('') : '<tr><td colspan="6" class="muted">Bez nepotvrdených stratových produktov.</td></tr>';
+      el('lossProductBody').querySelectorAll('[data-ack-loss]').forEach((input) => input.addEventListener('change', () => acknowledgeLossProduct(input)));
+    }
     function inventoryAlertRow(row) {
       return `<tr>
         <td><strong>${safe(row.product)}</strong><div class="muted mono">${safe(row.sku)}</div></td>
         <td><span class="badge ${badgeClass(row.stock_risk_level || row.reorder_action_label)}">${safe(row.stock_risk_level || row.reorder_action_label)}</span></td>
         <td>${fmtQty(row.available_quantity)} ks</td>
+        <td>${inboundControls(row)}</td>
         <td>${fmtQty(row.alert_30d_units)} ks</td>
         <td>${row.days_of_cover === null || row.days_of_cover === undefined ? 'N/A' : `${fmtQty(row.days_of_cover)} dní`}</td>
         <td>${safe(row.projected_stockout_date)}</td>
@@ -1293,10 +1435,11 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       const summary = inv.summary || {};
       const alerts = inv.alert_rows || [];
       const inventoryRows = inv.inventory_rows || [];
+      const inboundRows = inv.inbound_order_rows || [];
       const visibleInventoryAlertLimit = 100;
       const visibleInventoryLimit = 100;
       el('inventoryAlertMeta').textContent = `${fmtInt(summary.alert_delivery_count)} alertov · snapshot ${text(summary.inventory_snapshot_date)}`;
-      el('alertRowsBody').innerHTML = alerts.length ? alerts.slice(0, visibleInventoryAlertLimit).map(inventoryAlertRow).join('') : '<tr><td colspan="8" class="muted">Bez kritických skladových alertov.</td></tr>';
+      el('alertRowsBody').innerHTML = alerts.length ? alerts.slice(0, visibleInventoryAlertLimit).map(inventoryAlertRow).join('') : '<tr><td colspan="9" class="muted">Bez kritických skladových alertov.</td></tr>';
       el('inventoryMeta').textContent = `${fmtInt(summary.inventory_products_with_stock)} produktov so skladom · coverage ${fmtPct(summary.inventory_cost_coverage_units_pct)}`;
       el('inventorySummaryGrid').innerHTML = [
         metric('Nákupná hodnota bez DPH', fmtMoney(summary.inventory_cost_value), `${fmtQty(summary.inventory_available_units)} ks skladom`),
@@ -1304,7 +1447,16 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         metric('45d watchlist', fmtInt(summary.stock_risk_45d_count), `${fmtInt(summary.out_of_stock_recent_demand_count)} vypredané s dopytom`),
         metric('Dead stock', fmtMoney(summary.dead_stock_cost_value), `${fmtInt(summary.dead_stock_count)} položiek`),
         metric('Tržby v riziku', fmtMoney(summary.revenue_at_risk_30d), `zisk ${fmtMoney(summary.profit_at_risk_30d)}`),
+        metric('Inbound objednávky', fmtQty(summary.inbound_ordered_units), `${fmtInt(summary.inbound_order_count)} položiek · ETA ${text(summary.inbound_next_arrival_date)}`),
       ].join('');
+      el('inboundRowsBody').innerHTML = inboundRows.length ? inboundRows.map((row) => `<tr>
+        <td><strong>${safe(row.product)}</strong><div class="muted mono">${safe(row.sku)}</div></td>
+        <td>${fmtQty(row.ordered_units)} ks</td>
+        <td>${safe(row.expected_arrival_date)}</td>
+        <td>${fmtQty(row.baseline_available_quantity)} ks</td>
+        <td>${fmtQty(row.current_available_quantity)} ks</td>
+        <td><button type="button" data-clear-inbound="${safe(row.sku)}">Zrušiť</button></td>
+      </tr>`).join('') : '<tr><td colspan="6" class="muted">Žiadne ručne zadané inbound objednávky.</td></tr>';
       el('inventoryRowsBody').innerHTML = inventoryRows.length ? inventoryRows.slice(0, visibleInventoryLimit).map((row) => `<tr>
         <td><strong>${safe(row.product)}</strong><div class="muted mono">${safe(row.sku)}</div></td>
         <td>${fmtQty(row.available_quantity)} ks</td>
@@ -1313,8 +1465,11 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         <td>${row.days_of_cover === null || row.days_of_cover === undefined ? 'N/A' : `${fmtQty(row.days_of_cover)} dní`}</td>
         <td>${safe(row.projected_stockout_date)}</td>
         <td>${fmtInt(row.lead_time_working_days)} pracovných dní</td>
+        <td>${inboundStatus(row)}</td>
         <td>${safe(row.reorder_action_label)}<div class="muted">${safe(row.reorder_by_date)} · ${fmtQty(row.suggested_reorder_units)} ks</div></td>
-      </tr>`).join('') : '<tr><td colspan="8" class="muted">Skladový payload zatiaľ nie je dostupný.</td></tr>';
+      </tr>`).join('') : '<tr><td colspan="9" class="muted">Skladový payload zatiaľ nie je dostupný.</td></tr>';
+      document.querySelectorAll('[data-save-inbound]').forEach((button) => button.addEventListener('click', () => saveInboundOrder(button)));
+      document.querySelectorAll('[data-clear-inbound]').forEach((button) => button.addEventListener('click', () => clearInboundOrder(button)));
     }
     function showMessage(message, ok=false) {
       el('messageBox').className = ok ? 'ok' : 'error';
@@ -1332,6 +1487,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       renderOrders(data);
       renderPickups(data);
       renderInventory(data);
+      renderPerformance(data);
     }
     async function loadDashboard(force=false) {
       el('refreshBtn').disabled = true;
@@ -1361,6 +1517,74 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         const data = await response.json();
         if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
         showMessage(`Objednávka ${orderNum} je zmenená na Odoslaná.`, true);
+        await loadDashboard(true);
+      } catch (error) {
+        input.checked = false;
+        input.disabled = false;
+        showMessage(error instanceof Error ? error.message : String(error));
+      }
+    }
+    async function saveInboundOrder(button) {
+      const sku = button.dataset.saveInbound;
+      const unitsInput = document.querySelector(`[data-inbound-units="${cssEscape(sku)}"]`);
+      const etaInput = document.querySelector(`[data-inbound-eta="${cssEscape(sku)}"]`);
+      const units = Number(unitsInput ? unitsInput.value : 0);
+      const eta = etaInput ? etaInput.value : '';
+      if (!units || units <= 0 || !eta) {
+        showMessage('Zadaj počet objednaných kusov aj očakávaný dátum príchodu.');
+        return;
+      }
+      button.disabled = true;
+      try {
+        const response = await fetch(`/api/operations/${encodeURIComponent(project)}/inbound/${encodeURIComponent(sku)}`, {
+          method:'POST',
+          cache:'no-store',
+          headers:{ 'Content-Type':'application/json' },
+          body: JSON.stringify({
+            product: button.dataset.product || '',
+            ordered_units: units,
+            expected_arrival_date: eta,
+            baseline_available_quantity: Number(button.dataset.baseline || 0),
+          }),
+        });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        showMessage(`Inbound objednávka pre ${sku} je uložená.`, true);
+        await loadDashboard(true);
+      } catch (error) {
+        showMessage(error instanceof Error ? error.message : String(error));
+      } finally {
+        button.disabled = false;
+      }
+    }
+    async function clearInboundOrder(button) {
+      const sku = button.dataset.clearInbound;
+      button.disabled = true;
+      try {
+        const response = await fetch(`/api/operations/${encodeURIComponent(project)}/inbound/${encodeURIComponent(sku)}/clear`, { method:'POST', cache:'no-store' });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        showMessage(`Inbound objednávka pre ${sku} je zrušená.`, true);
+        await loadDashboard(true);
+      } catch (error) {
+        showMessage(error instanceof Error ? error.message : String(error));
+      } finally {
+        button.disabled = false;
+      }
+    }
+    async function acknowledgeLossProduct(input) {
+      const sku = input.dataset.ackLoss;
+      input.disabled = true;
+      try {
+        const response = await fetch(`/api/operations/${encodeURIComponent(project)}/loss-product/${encodeURIComponent(sku)}/ack`, {
+          method:'POST',
+          cache:'no-store',
+          headers:{ 'Content-Type':'application/json' },
+          body: JSON.stringify({ product: input.dataset.product || '' }),
+        });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        showMessage(`Produkt ${sku} je potvrdený a skrytý zo stratových upozornení.`, true);
         await loadDashboard(true);
       } catch (error) {
         input.checked = false;
@@ -1400,6 +1624,18 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
 
     def _send_text(self, text: str, *, content_type: str, status: int = 200) -> None:
         self._send_bytes(text.encode("utf-8"), content_type=content_type, status=status)
+
+    def _read_json_body(self) -> Dict[str, Any]:
+        length = int(self.headers.get("Content-Length") or "0")
+        if length <= 0:
+            return {}
+        if length > 32_768:
+            raise ValueError("Request body is too large.")
+        raw = self.rfile.read(length)
+        payload = json.loads(raw.decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("JSON request body must be an object.")
+        return payload
 
     def _send_auth_required(self) -> None:
         body = b"Authentication required."
@@ -1599,6 +1835,70 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 return
             try:
                 self._send_json(mark_personal_pickup_shipped(project, order_num))
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=400)
+            return
+
+        if (
+            len(parts) == 5
+            and parts[0] == "api"
+            and parts[1] == "operations"
+            and parts[3] == "inbound"
+        ):
+            project = parts[2]
+            sku = unquote(parts[4])
+            if project not in projects:
+                self._send_json({"error": f"Unknown project '{project}'."}, status=404)
+                return
+            try:
+                body = self._read_json_body()
+                self._send_json(
+                    set_inbound_stock_order(
+                        project,
+                        sku,
+                        product=str(body.get("product") or ""),
+                        ordered_units=body.get("ordered_units"),
+                        expected_arrival_date=body.get("expected_arrival_date"),
+                        baseline_available_quantity=body.get("baseline_available_quantity", 0),
+                    )
+                )
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=400)
+            return
+
+        if (
+            len(parts) == 6
+            and parts[0] == "api"
+            and parts[1] == "operations"
+            and parts[3] == "inbound"
+            and parts[5] == "clear"
+        ):
+            project = parts[2]
+            sku = unquote(parts[4])
+            if project not in projects:
+                self._send_json({"error": f"Unknown project '{project}'."}, status=404)
+                return
+            try:
+                self._send_json(clear_inbound_stock_order(project, sku))
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=400)
+            return
+
+        if (
+            len(parts) == 6
+            and parts[0] == "api"
+            and parts[1] == "operations"
+            and parts[3] == "loss-product"
+            and parts[5] == "ack"
+        ):
+            project = parts[2]
+            sku = unquote(parts[4])
+            if project not in projects:
+                self._send_json({"error": f"Unknown project '{project}'."}, status=404)
+                return
+            try:
+                body = self._read_json_body()
+                self._send_json(acknowledge_loss_product(project, sku, product=str(body.get("product") or "")))
             except Exception as exc:
                 self._send_json({"error": str(exc)}, status=400)
             return

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import copy
+import json
+import math
 import os
 import time
 import unicodedata
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from gql import Client, gql
@@ -109,6 +112,217 @@ query ListOrderStatuses($lang_code: CountryCodeAlpha2!) {
 
 
 _CACHE: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+STATE_VERSION = 1
+
+
+def _empty_operations_state() -> Dict[str, Any]:
+    return {
+        "version": STATE_VERSION,
+        "loss_acknowledgements": {},
+        "inbound_orders": {},
+        "auto_cleared_inbound_orders": [],
+    }
+
+
+def _project_env_name(project: str) -> str:
+    return "".join(ch if ch.isalnum() else "_" for ch in str(project or "").upper())
+
+
+def _state_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _local_state_path(project: str) -> Path:
+    configured = os.getenv("ROY_OPERATIONS_STATE_PATH", "").strip()
+    if configured:
+        return Path(configured)
+    return Path(__file__).resolve().parent / "data" / project / "operations_state.json"
+
+
+def _state_s3_location(project: str, project_settings: Dict[str, Any]) -> Optional[Tuple[str, str, str]]:
+    s3_settings = project_settings.get("live_dashboard_artifacts") or {}
+    env_project = _project_env_name(project)
+    bucket = (
+        os.getenv(f"LIVE_DASHBOARD_STATE_S3_BUCKET_{env_project}", "").strip()
+        or os.getenv("LIVE_DASHBOARD_STATE_S3_BUCKET", "").strip()
+        or os.getenv(f"LIVE_DASHBOARD_S3_BUCKET_{env_project}", "").strip()
+        or os.getenv("LIVE_DASHBOARD_S3_BUCKET", "").strip()
+        or os.getenv(f"REPORT_S3_BUCKET_{env_project}", "").strip()
+        or os.getenv("REPORT_S3_BUCKET", "").strip()
+        or str(s3_settings.get("s3_bucket") or "").strip()
+    )
+    prefix = (
+        os.getenv(f"LIVE_DASHBOARD_STATE_S3_PREFIX_{env_project}", "").strip()
+        or os.getenv("LIVE_DASHBOARD_STATE_S3_PREFIX", "").strip()
+        or os.getenv(f"LIVE_DASHBOARD_S3_PREFIX_{env_project}", "").strip()
+        or os.getenv("LIVE_DASHBOARD_S3_PREFIX", "").strip()
+        or os.getenv(f"REPORT_S3_PREFIX_{env_project}", "").strip()
+        or os.getenv("REPORT_S3_PREFIX", "").strip()
+        or str(s3_settings.get("s3_prefix") or "").strip()
+        or f"daily-reports/{project}"
+    ).strip("/")
+    region = (
+        os.getenv(f"AWS_REGION_{env_project}", "").strip()
+        or os.getenv("AWS_REGION", "eu-central-1").strip()
+        or "eu-central-1"
+    )
+    if not bucket:
+        return None
+    return bucket, f"{prefix}/operations/state.json", region
+
+
+def _normalize_operations_state(raw: Any) -> Dict[str, Any]:
+    state = _empty_operations_state()
+    if not isinstance(raw, dict):
+        return state
+    state["version"] = int(raw.get("version") or STATE_VERSION)
+    for section in ("loss_acknowledgements", "inbound_orders"):
+        values = raw.get(section) if isinstance(raw.get(section), dict) else {}
+        state[section] = {
+            str(key).strip(): value
+            for key, value in values.items()
+            if str(key).strip() and isinstance(value, dict)
+        }
+    cleared = raw.get("auto_cleared_inbound_orders")
+    if isinstance(cleared, list):
+        state["auto_cleared_inbound_orders"] = [row for row in cleared[-50:] if isinstance(row, dict)]
+    return state
+
+
+def load_roy_operations_state(project: str, project_settings: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    project_settings = project_settings or load_project_settings(project)
+    location = _state_s3_location(project, project_settings)
+    if location is not None:
+        bucket, key, region = location
+        try:
+            import boto3  # type: ignore
+
+            response = boto3.client("s3", region_name=region).get_object(Bucket=bucket, Key=key)
+            return _normalize_operations_state(json.loads(response["Body"].read().decode("utf-8")))
+        except Exception:
+            pass
+
+    path = _local_state_path(project)
+    if not path.exists():
+        return _empty_operations_state()
+    try:
+        return _normalize_operations_state(json.loads(path.read_text(encoding="utf-8")))
+    except Exception:
+        return _empty_operations_state()
+
+
+def save_roy_operations_state(
+    project: str,
+    state: Dict[str, Any],
+    project_settings: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    project_settings = project_settings or load_project_settings(project)
+    normalized = _normalize_operations_state(state)
+    body = json.dumps(normalized, ensure_ascii=False, indent=2).encode("utf-8")
+    location = _state_s3_location(project, project_settings)
+    if location is not None:
+        bucket, key, region = location
+        import boto3  # type: ignore
+
+        boto3.client("s3", region_name=region).put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=body,
+            ContentType="application/json; charset=utf-8",
+            ServerSideEncryption="AES256",
+        )
+        return {"storage": "s3", "bucket": bucket, "key": key}
+
+    path = _local_state_path(project)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_bytes(body)
+    tmp_path.replace(path)
+    return {"storage": "local", "path": str(path)}
+
+
+def _validate_eta_date(value: Any) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        raise ValueError("Expected arrival date is required.")
+    try:
+        datetime.strptime(raw, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError("Expected arrival date must use YYYY-MM-DD format.") from exc
+    return raw
+
+
+def acknowledge_loss_product(project: str, sku: str, product: str = "") -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    if project != "roy":
+        raise ValueError("Loss product acknowledgement is only enabled for project 'roy'.")
+    sku = str(sku or "").strip()
+    if not sku:
+        raise ValueError("Missing product SKU.")
+    project_settings = load_project_settings(project)
+    state = load_roy_operations_state(project, project_settings)
+    state.setdefault("loss_acknowledgements", {})[sku] = {
+        "sku": sku,
+        "product": str(product or "").strip(),
+        "acknowledged_at": _state_now_iso(),
+    }
+    storage = save_roy_operations_state(project, state, project_settings)
+    _CACHE.pop(project, None)
+    return {"ok": True, "project": project, "sku": sku, "storage": storage}
+
+
+def set_inbound_stock_order(
+    project: str,
+    sku: str,
+    *,
+    product: str = "",
+    ordered_units: Any,
+    expected_arrival_date: Any,
+    baseline_available_quantity: Any = 0.0,
+) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    if project != "roy":
+        raise ValueError("Inbound stock tracking is only enabled for project 'roy'.")
+    sku = str(sku or "").strip()
+    if not sku:
+        raise ValueError("Missing product SKU.")
+    units = _to_float(ordered_units)
+    if units <= 0:
+        raise ValueError("Ordered units must be greater than zero.")
+    eta = _validate_eta_date(expected_arrival_date)
+    project_settings = load_project_settings(project)
+    state = load_roy_operations_state(project, project_settings)
+    existing = (state.get("inbound_orders") or {}).get(sku) or {}
+    now = _state_now_iso()
+    state.setdefault("inbound_orders", {})[sku] = {
+        "sku": sku,
+        "product": str(product or existing.get("product") or "").strip(),
+        "ordered_units": round(units, 2),
+        "expected_arrival_date": eta,
+        "baseline_available_quantity": round(_to_float(baseline_available_quantity), 2),
+        "created_at": existing.get("created_at") or now,
+        "updated_at": now,
+    }
+    storage = save_roy_operations_state(project, state, project_settings)
+    _CACHE.pop(project, None)
+    return {"ok": True, "project": project, "sku": sku, "storage": storage, "inbound_order": state["inbound_orders"][sku]}
+
+
+def clear_inbound_stock_order(project: str, sku: str) -> Dict[str, Any]:
+    project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
+    if project != "roy":
+        raise ValueError("Inbound stock tracking is only enabled for project 'roy'.")
+    sku = str(sku or "").strip()
+    if not sku:
+        raise ValueError("Missing product SKU.")
+    project_settings = load_project_settings(project)
+    state = load_roy_operations_state(project, project_settings)
+    removed = (state.get("inbound_orders") or {}).pop(sku, None)
+    storage = save_roy_operations_state(project, state, project_settings)
+    _CACHE.pop(project, None)
+    return {"ok": True, "project": project, "sku": sku, "removed": bool(removed), "storage": storage}
 
 
 def _normalize_text(value: Any) -> str:
@@ -541,11 +755,265 @@ def build_executive_kpi_snapshot(report_payload: Dict[str, Any]) -> Dict[str, An
     }
 
 
-def build_inventory_snapshot(report_payload: Dict[str, Any]) -> Dict[str, Any]:
+def build_commercial_snapshot(report_payload: Dict[str, Any], state: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    dashboard = report_payload.get("dashboard") if isinstance(report_payload.get("dashboard"), dict) else {}
+    roy_demand = dashboard.get("roy_product_demand") if isinstance(dashboard.get("roy_product_demand"), dict) else {}
+    acknowledged = set((state or {}).get("loss_acknowledgements") or {})
+
+    product_revenue_rows = list(roy_demand.get("product_revenue_rows") or [])
+    product_profit_rows = list(roy_demand.get("product_profit_rows") or [])
+    if not product_profit_rows:
+        product_profit_rows = list(dashboard.get("products") or [])
+
+    loss_rows = []
+    hidden_loss_count = 0
+    for row in list(roy_demand.get("loss_product_rows") or []):
+        sku = str(row.get("sku") or "").strip()
+        if sku and sku in acknowledged:
+            hidden_loss_count += 1
+            continue
+        loss_rows.append(row)
+
+    return {
+        "brand_revenue_rows": list(roy_demand.get("brand_revenue_rows") or [])[:3],
+        "brand_profit_rows": list(roy_demand.get("brand_profit_rows") or [])[:3],
+        "product_revenue_rows": product_revenue_rows[:10],
+        "product_profit_rows": product_profit_rows[:10],
+        "loss_product_rows": loss_rows[:80],
+        "acknowledged_loss_product_count": hidden_loss_count,
+    }
+
+
+def _inventory_row_collections(inventory: Dict[str, Any]) -> Iterable[Tuple[str, List[Dict[str, Any]]]]:
+    for key in (
+        "alert_rows",
+        "stock_risk_rows",
+        "inventory_rows",
+        "restock_priority_rows",
+        "revenue_at_risk_rows",
+        "forecast_rows",
+    ):
+        rows = inventory.get(key)
+        if isinstance(rows, list):
+            yield key, rows
+
+
+def _current_availability_by_sku(inventory: Dict[str, Any]) -> Dict[str, float]:
+    availability: Dict[str, float] = {}
+    for _, rows in _inventory_row_collections(inventory):
+        for row in rows:
+            sku = str(row.get("sku") or "").strip()
+            if not sku:
+                continue
+            value = _to_float(row.get("available_quantity"))
+            if sku not in availability or value > availability[sku]:
+                availability[sku] = value
+    return availability
+
+
+def _auto_clear_restocked_inbound_orders(state: Dict[str, Any], inventory: Dict[str, Any]) -> bool:
+    inbound = state.get("inbound_orders") if isinstance(state.get("inbound_orders"), dict) else {}
+    if not inbound:
+        return False
+    availability = _current_availability_by_sku(inventory)
+    cleared: List[Dict[str, Any]] = []
+    for sku, record in list(inbound.items()):
+        current_available = availability.get(str(sku))
+        if current_available is None:
+            continue
+        baseline = _to_float(record.get("baseline_available_quantity"))
+        if current_available > baseline + 1e-9:
+            removed = inbound.pop(sku)
+            cleared.append(
+                {
+                    "sku": sku,
+                    "product": removed.get("product"),
+                    "ordered_units": removed.get("ordered_units"),
+                    "expected_arrival_date": removed.get("expected_arrival_date"),
+                    "baseline_available_quantity": baseline,
+                    "restocked_available_quantity": round(current_available, 2),
+                    "cleared_at": _state_now_iso(),
+                    "reason": "stock_increased_after_inbound_marker",
+                }
+            )
+    if not cleared:
+        return False
+    history = state.setdefault("auto_cleared_inbound_orders", [])
+    history.extend(cleared)
+    state["auto_cleared_inbound_orders"] = history[-50:]
+    state["inbound_orders"] = inbound
+    return True
+
+
+def _apply_inbound_to_inventory(inventory: Dict[str, Any], state: Dict[str, Any], project_settings: Dict[str, Any]) -> None:
+    inbound = state.get("inbound_orders") if isinstance(state.get("inbound_orders"), dict) else {}
+    if not inbound:
+        inventory.setdefault("summary", {})["inbound_order_count"] = 0
+        inventory.setdefault("summary", {})["inbound_ordered_units"] = 0.0
+        return
+
+    model = project_settings.get("inventory_model") or {}
+    critical_days = max(1, int(model.get("critical_days_of_cover", 14) or 14))
+    warning_days = max(critical_days, int(model.get("warning_days_of_cover", 30) or 30))
+    watch_days = max(warning_days, int(model.get("watch_days_of_cover", 45) or 45))
+    reorder_cover_days = max(1, int(model.get("reorder_cover_days", warning_days) or warning_days))
+    hero_cover_days = max(reorder_cover_days, int(model.get("hero_reorder_cover_days", watch_days) or watch_days))
+
+    today = datetime.now(timezone.utc).date()
+    risk_30d = {"Negative stock", "Out of stock", "Critical", "Low"}
+    risk_45d = {"Negative stock", "Out of stock", "Critical", "Low", "Watch"}
+
+    def apply_to_row(row: Dict[str, Any]) -> None:
+        sku = str(row.get("sku") or "").strip()
+        record = inbound.get(sku)
+        if not record:
+            return
+        ordered_units = _to_float(record.get("ordered_units"))
+        if ordered_units <= 0:
+            return
+
+        available = _to_float(row.get("available_quantity"))
+        net_available = available + ordered_units
+        alert_30d_units = _to_float(row.get("alert_30d_units"))
+        if alert_30d_units <= 0:
+            alert_30d_units = _to_float(row.get("recent_30d_units")) or _to_float(row.get("forecast_30d_units"))
+        daily_units = alert_30d_units / 30.0 if alert_30d_units > 0 else 0.0
+        days_of_cover = (net_available / daily_units) if daily_units > 0 else None
+        lead_time_working = int(round(_to_float(row.get("lead_time_working_days"))))
+        lead_time_calendar = int(math.ceil(max(0, lead_time_working) * (7.0 / 5.0)))
+        target_cover = lead_time_calendar + (hero_cover_days if bool(row.get("strategic_stock_flag")) else reorder_cover_days)
+
+        existing_suggested = _to_float(row.get("suggested_reorder_units"))
+        if daily_units > 0:
+            suggested = max(math.ceil((daily_units * target_cover) - net_available), 0.0)
+        else:
+            suggested = max(existing_suggested - ordered_units, 0.0)
+
+        current_risk = str(row.get("stock_risk_level") or "")
+        available_raw = _to_float(row.get("available_quantity_raw", available))
+        if daily_units > 0:
+            if available_raw < 0 and net_available < 0:
+                current_risk = "Negative stock"
+            elif net_available <= 0:
+                current_risk = "Out of stock"
+            elif days_of_cover is not None and days_of_cover <= critical_days:
+                current_risk = "Critical"
+            elif days_of_cover is not None and days_of_cover <= warning_days:
+                current_risk = "Low"
+            elif days_of_cover is not None and days_of_cover <= watch_days:
+                current_risk = "Watch"
+            else:
+                current_risk = "Healthy"
+        elif net_available > 0 and current_risk in risk_45d:
+            current_risk = "Healthy"
+
+        projected_stockout_date = row.get("projected_stockout_date")
+        if days_of_cover is not None and days_of_cover > 0 and days_of_cover < 3650:
+            projected_stockout_date = (today + timedelta(days=int(math.ceil(days_of_cover)))).isoformat()
+        elif daily_units <= 0:
+            projected_stockout_date = None
+
+        expected_arrival_date = str(record.get("expected_arrival_date") or "").strip()
+        inbound_covers = bool(ordered_units > 0 and (suggested <= 0 or current_risk not in risk_30d))
+        row.update(
+            {
+                "inbound_ordered_units": round(ordered_units, 2),
+                "inbound_expected_arrival_date": expected_arrival_date,
+                "inbound_created_at": record.get("created_at"),
+                "inbound_updated_at": record.get("updated_at"),
+                "inbound_baseline_available_quantity": record.get("baseline_available_quantity"),
+                "net_available_quantity": round(net_available, 2),
+                "stock_risk_level": current_risk,
+                "days_of_cover": round(days_of_cover, 1) if days_of_cover is not None else row.get("days_of_cover"),
+                "projected_stockout_date": projected_stockout_date,
+                "suggested_reorder_units": round(suggested, 1),
+                "inbound_covers_reorder_flag": inbound_covers,
+            }
+        )
+        if inbound_covers:
+            row["reorder_action_label"] = "Inbound ordered"
+            row["reorder_now_flag"] = False
+            row["prepare_po_flag"] = False
+        elif ordered_units > 0 and str(row.get("reorder_action_label") or "") in {"Order now", "Prepare PO", "30d alert"}:
+            row["reorder_action_label"] = "Partially ordered"
+
+    for _, rows in _inventory_row_collections(inventory):
+        for row in rows:
+            apply_to_row(row)
+
+    def keep_30d(row: Dict[str, Any]) -> bool:
+        if bool(row.get("inbound_covers_reorder_flag")):
+            return False
+        return str(row.get("stock_risk_level") or "") in risk_30d
+
+    def keep_45d(row: Dict[str, Any]) -> bool:
+        if bool(row.get("inbound_covers_reorder_flag")):
+            return False
+        return str(row.get("stock_risk_level") or "") in risk_45d
+
+    inventory["alert_rows"] = [row for row in inventory.get("alert_rows", []) if keep_30d(row)]
+    inventory["restock_priority_rows"] = [row for row in inventory.get("restock_priority_rows", []) if keep_45d(row)]
+    inventory["revenue_at_risk_rows"] = [row for row in inventory.get("revenue_at_risk_rows", []) if keep_45d(row)]
+    inventory["stock_risk_rows"] = [row for row in inventory.get("stock_risk_rows", []) if keep_45d(row)]
+
+    summary = inventory.setdefault("summary", {})
+    active_inbound = [record for record in inbound.values() if _to_float(record.get("ordered_units")) > 0]
+    next_eta = min((str(record.get("expected_arrival_date")) for record in active_inbound if record.get("expected_arrival_date")), default=None)
+    availability = _current_availability_by_sku(inventory)
+    inventory["inbound_order_rows"] = sorted(
+        [
+            {
+                "sku": str(record.get("sku") or sku),
+                "product": str(record.get("product") or ""),
+                "ordered_units": round(_to_float(record.get("ordered_units")), 2),
+                "expected_arrival_date": record.get("expected_arrival_date"),
+                "baseline_available_quantity": _to_float(record.get("baseline_available_quantity")),
+                "current_available_quantity": round(availability.get(str(sku), _to_float(record.get("baseline_available_quantity"))), 2),
+                "created_at": record.get("created_at"),
+                "updated_at": record.get("updated_at"),
+            }
+            for sku, record in inbound.items()
+            if _to_float(record.get("ordered_units")) > 0
+        ],
+        key=lambda row: (str(row.get("expected_arrival_date") or "9999-99-99"), str(row.get("sku") or "")),
+    )
+    alert_rows = inventory.get("alert_rows", [])
+    restock_rows = inventory.get("restock_priority_rows", [])
+    revenue_risk_rows = inventory.get("revenue_at_risk_rows", [])
+    stock_risk_rows = inventory.get("stock_risk_rows", [])
+    summary.update(
+        {
+            "inbound_order_count": len(active_inbound),
+            "inbound_ordered_units": round(sum(_to_float(record.get("ordered_units")) for record in active_inbound), 1),
+            "inbound_next_arrival_date": next_eta,
+            "alert_delivery_count": len(alert_rows),
+            "alert_reorder_now_count": sum(1 for row in alert_rows if str(row.get("reorder_action_label") or "") == "Order now"),
+            "alert_prepare_po_count": sum(1 for row in alert_rows if str(row.get("reorder_action_label") or "") == "Prepare PO"),
+            "stock_risk_critical_count": sum(1 for row in stock_risk_rows if str(row.get("stock_risk_level") or "") in {"Negative stock", "Out of stock", "Critical"}),
+            "stock_risk_30d_count": sum(1 for row in stock_risk_rows if str(row.get("stock_risk_level") or "") in risk_30d),
+            "stock_risk_45d_count": sum(1 for row in stock_risk_rows if str(row.get("stock_risk_level") or "") in risk_45d),
+            "revenue_at_risk_30d": round(sum(_to_float(row.get("alert_30d_revenue")) for row in alert_rows), 2),
+            "profit_at_risk_30d": round(sum(_to_float(row.get("alert_30d_profit_estimate")) for row in alert_rows), 2),
+            "revenue_at_risk_45d": round(sum(_to_float(row.get("alert_30d_revenue")) for row in revenue_risk_rows), 2),
+            "profit_at_risk_45d": round(sum(_to_float(row.get("alert_30d_profit_estimate")) for row in revenue_risk_rows), 2),
+            "restock_priority_urgent_count": sum(1 for row in restock_rows if _to_float(row.get("restock_priority_score")) >= 80),
+            "restock_priority_high_count": sum(
+                1 for row in restock_rows if 60 <= _to_float(row.get("restock_priority_score")) < 80
+            ),
+        }
+    )
+
+
+def build_inventory_snapshot(
+    report_payload: Dict[str, Any],
+    *,
+    state: Optional[Dict[str, Any]] = None,
+    project_settings: Optional[Dict[str, Any]] = None,
+) -> Tuple[Dict[str, Any], bool]:
     dashboard = report_payload.get("dashboard") if isinstance(report_payload.get("dashboard"), dict) else {}
     roy_inventory = dashboard.get("roy_product_demand") if isinstance(dashboard.get("roy_product_demand"), dict) else {}
     summary = roy_inventory.get("summary") if isinstance(roy_inventory.get("summary"), dict) else {}
-    return {
+    inventory = {
         "summary": summary or {},
         "alert_rows": list(roy_inventory.get("alert_rows") or [])[:120],
         "stock_risk_rows": list(roy_inventory.get("stock_risk_rows") or [])[:120],
@@ -553,7 +1021,14 @@ def build_inventory_snapshot(report_payload: Dict[str, Any]) -> Dict[str, Any]:
         "restock_priority_rows": list(roy_inventory.get("restock_priority_rows") or [])[:120],
         "revenue_at_risk_rows": list(roy_inventory.get("revenue_at_risk_rows") or [])[:120],
         "forecast_rows": list(roy_inventory.get("forecast_rows") or [])[:80],
+        "inbound_order_rows": [],
     }
+    state_changed = False
+    if state is not None:
+        state_changed = _auto_clear_restocked_inbound_orders(state, inventory)
+        if project_settings is not None:
+            _apply_inbound_to_inventory(inventory, state, project_settings)
+    return inventory, state_changed
 
 
 def generate_roy_operations_snapshot(project: str, report_payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -567,6 +1042,14 @@ def generate_roy_operations_snapshot(project: str, report_payload: Optional[Dict
     orders, scan = fetch_open_orders_for_roy_operations(project, settings)
     order_snapshot = build_roy_orders_snapshot(project=project, orders=orders, settings=settings, scan=scan)
     payload = report_payload or {}
+    operations_state = load_roy_operations_state(project, project_settings)
+    inventory_snapshot, state_changed = build_inventory_snapshot(
+        payload,
+        state=operations_state,
+        project_settings=project_settings,
+    )
+    if state_changed:
+        save_roy_operations_state(project, operations_state, project_settings)
     return {
         "marker": "roy-operations-dashboard",
         "project": project,
@@ -574,7 +1057,13 @@ def generate_roy_operations_snapshot(project: str, report_payload: Optional[Dict
         "auto_refresh_seconds": order_snapshot["auto_refresh_seconds"],
         "orders": order_snapshot,
         "executive_kpis": build_executive_kpi_snapshot(payload),
-        "inventory": build_inventory_snapshot(payload),
+        "inventory": inventory_snapshot,
+        "performance": build_commercial_snapshot(payload, operations_state),
+        "operations_state": {
+            "inbound_order_count": len(operations_state.get("inbound_orders") or {}),
+            "acknowledged_loss_product_count": len(operations_state.get("loss_acknowledgements") or {}),
+            "auto_cleared_inbound_order_count": len(operations_state.get("auto_cleared_inbound_orders") or []),
+        },
     }
 
 

--- a/tests/test_dashboard_modern.py
+++ b/tests/test_dashboard_modern.py
@@ -1,0 +1,28 @@
+import unittest
+from datetime import datetime
+
+from dashboard_modern import _build_fb_daily_payload
+
+
+class DashboardModernTests(unittest.TestCase):
+    def test_fb_daily_payload_zero_fills_missing_report_dates(self) -> None:
+        payload = _build_fb_daily_payload(
+            datetime(2026, 5, 1),
+            datetime(2026, 5, 4),
+            {
+                "2026-05-01": {"spend": 10.24, "clicks": 80, "impressions": 3924},
+                "2026-05-03": {"spend": 10.09, "clicks": 120, "impressions": 5630},
+            },
+        )
+
+        self.assertEqual(
+            ["2026-05-01", "2026-05-02", "2026-05-03", "2026-05-04"],
+            payload["dates"],
+        )
+        self.assertEqual([10.24, 0.0, 10.09, 0.0], payload["spend"])
+        self.assertEqual([80.0, 0.0, 120.0, 0.0], payload["clicks"])
+        self.assertEqual([3924.0, 0.0, 5630.0, 0.0], payload["impressions"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_roy_inventory_model.py
+++ b/tests/test_roy_inventory_model.py
@@ -28,6 +28,8 @@ def item_row(
     revenue: float,
     item_import_code: str = "",
     item_ean: str = "",
+    cm2_profit: float | None = None,
+    cm3_profit: float | None = None,
 ) -> dict:
     return {
         "order_num": order_num,
@@ -38,8 +40,8 @@ def item_row(
         "purchase_datetime": purchase_datetime,
         "item_quantity": quantity,
         "item_total_without_tax": revenue,
-        "cm2_profit": revenue * 0.4,
-        "cm3_profit": revenue * 0.3,
+        "cm2_profit": revenue * 0.4 if cm2_profit is None else cm2_profit,
+        "cm3_profit": revenue * 0.3 if cm3_profit is None else cm3_profit,
     }
 
 
@@ -202,6 +204,27 @@ class RoyInventoryModelTests(unittest.TestCase):
         self.assertEqual(1, summary["bundle_component_rule_count"])
         self.assertEqual(9.0, float(summary["bundle_component_adjustment_30d_units"]))
         self.assertGreaterEqual(summary["historical_restock_relevant_products"], 3)
+
+    def test_roy_demand_outputs_top_products_and_loss_products(self) -> None:
+        exporter = RoyInventoryModelExporter(inventory_snapshot=pd.DataFrame())
+        item_df = pd.DataFrame(
+            [
+                item_row("R-1", "P-WIN", "Wachman Profit Product", "2026-05-01", 2, 300, cm2_profit=120, cm3_profit=90),
+                item_row("R-2", "P-LOSS", "Loss Product", "2026-05-02", 2, 120, cm2_profit=-15, cm3_profit=-25),
+                item_row("R-3", "P-REV", "Revenue Product", "2026-05-03", 1, 500, cm2_profit=40, cm3_profit=30),
+            ]
+        )
+
+        result = exporter.analyze_roy_product_demand_analytics(
+            df=pd.DataFrame(),
+            orders_df=pd.DataFrame(),
+            item_df=item_df,
+        )
+
+        self.assertEqual("P-REV", result["product_revenue_rows"].iloc[0]["sku"])
+        self.assertEqual("P-WIN", result["product_profit_rows"].iloc[0]["sku"])
+        self.assertEqual(["P-LOSS"], result["loss_product_rows"]["sku"].tolist())
+        self.assertLess(float(result["loss_product_rows"].iloc[0]["profit_without_fixed"]), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from live_dashboard_server import build_roy_operations_dashboard_html
 from roy_operations_dashboard import (
     build_executive_kpi_snapshot,
+    build_commercial_snapshot,
+    build_inventory_snapshot,
     build_roy_orders_snapshot,
     resolve_roy_operations_settings,
 )
@@ -153,6 +155,163 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("Osobné odbery", html)
         self.assertIn("visibleInventoryAlertLimit = 100", html)
         self.assertIn("visibleInventoryLimit = 100", html)
+        self.assertIn("Top zna", html)
+        self.assertIn("Produkty v strate", html)
+        self.assertIn("data-save-inbound", html)
+
+    def test_inbound_order_units_suppress_covered_stock_alert_until_restock(self) -> None:
+        payload = {
+            "dashboard": {
+                "roy_product_demand": {
+                    "summary": {
+                        "alert_delivery_count": 1,
+                        "stock_risk_30d_count": 1,
+                    },
+                    "alert_rows": [
+                        {
+                            "sku": "LOW-1",
+                            "product": "Low stock product",
+                            "available_quantity": 0,
+                            "available_quantity_raw": 0,
+                            "alert_30d_units": 3,
+                            "lead_time_working_days": 5,
+                            "suggested_reorder_units": 8,
+                            "stock_risk_level": "Out of stock",
+                            "reorder_action_label": "Order now",
+                            "alert_30d_revenue": 90,
+                            "alert_30d_profit_estimate": 30,
+                        }
+                    ],
+                    "stock_risk_rows": [
+                        {
+                            "sku": "LOW-1",
+                            "product": "Low stock product",
+                            "available_quantity": 0,
+                            "available_quantity_raw": 0,
+                            "alert_30d_units": 3,
+                            "lead_time_working_days": 5,
+                            "suggested_reorder_units": 8,
+                            "stock_risk_level": "Out of stock",
+                            "reorder_action_label": "Order now",
+                        }
+                    ],
+                    "restock_priority_rows": [
+                        {
+                            "sku": "LOW-1",
+                            "product": "Low stock product",
+                            "available_quantity": 0,
+                            "available_quantity_raw": 0,
+                            "alert_30d_units": 3,
+                            "lead_time_working_days": 5,
+                            "suggested_reorder_units": 8,
+                            "stock_risk_level": "Out of stock",
+                            "reorder_action_label": "Order now",
+                            "restock_priority_score": 90,
+                        }
+                    ],
+                    "inventory_rows": [
+                        {
+                            "sku": "LOW-1",
+                            "product": "Low stock product",
+                            "available_quantity": 0,
+                            "available_quantity_raw": 0,
+                            "alert_30d_units": 3,
+                            "lead_time_working_days": 5,
+                            "suggested_reorder_units": 8,
+                            "stock_risk_level": "Out of stock",
+                            "reorder_action_label": "Order now",
+                        }
+                    ],
+                }
+            }
+        }
+        state = {
+            "version": 1,
+            "loss_acknowledgements": {},
+            "inbound_orders": {
+                "LOW-1": {
+                    "sku": "LOW-1",
+                    "product": "Low stock product",
+                    "ordered_units": 20,
+                    "expected_arrival_date": "2026-06-05",
+                    "baseline_available_quantity": 0,
+                    "created_at": "2026-05-27T10:00:00Z",
+                    "updated_at": "2026-05-27T10:00:00Z",
+                }
+            },
+            "auto_cleared_inbound_orders": [],
+        }
+
+        inventory, state_changed = build_inventory_snapshot(
+            payload,
+            state=state,
+            project_settings={"inventory_model": {"critical_days_of_cover": 14, "warning_days_of_cover": 30, "watch_days_of_cover": 45, "reorder_cover_days": 30}},
+        )
+
+        self.assertFalse(state_changed)
+        self.assertEqual([], inventory["alert_rows"])
+        self.assertEqual([], inventory["restock_priority_rows"])
+        self.assertEqual(1, inventory["summary"]["inbound_order_count"])
+        self.assertEqual(20, inventory["inbound_order_rows"][0]["ordered_units"])
+        self.assertEqual("Inbound ordered", inventory["inventory_rows"][0]["reorder_action_label"])
+
+    def test_inbound_order_marker_auto_clears_after_stock_increase(self) -> None:
+        payload = {
+            "dashboard": {
+                "roy_product_demand": {
+                    "summary": {},
+                    "inventory_rows": [{"sku": "LOW-1", "product": "Low stock product", "available_quantity": 5}],
+                }
+            }
+        }
+        state = {
+            "version": 1,
+            "loss_acknowledgements": {},
+            "inbound_orders": {
+                "LOW-1": {
+                    "sku": "LOW-1",
+                    "product": "Low stock product",
+                    "ordered_units": 5,
+                    "expected_arrival_date": "2026-06-05",
+                    "baseline_available_quantity": 0,
+                }
+            },
+            "auto_cleared_inbound_orders": [],
+        }
+
+        inventory, state_changed = build_inventory_snapshot(
+            payload,
+            state=state,
+            project_settings={"inventory_model": {}},
+        )
+
+        self.assertTrue(state_changed)
+        self.assertEqual({}, state["inbound_orders"])
+        self.assertEqual([], inventory["inbound_order_rows"])
+        self.assertEqual(1, len(state["auto_cleared_inbound_orders"]))
+
+    def test_commercial_snapshot_filters_acknowledged_loss_products(self) -> None:
+        payload = {
+            "dashboard": {
+                "roy_product_demand": {
+                    "brand_revenue_rows": [{"brand_key": "a"}, {"brand_key": "b"}, {"brand_key": "c"}, {"brand_key": "d"}],
+                    "brand_profit_rows": [{"brand_key": "p1"}, {"brand_key": "p2"}, {"brand_key": "p3"}, {"brand_key": "p4"}],
+                    "product_revenue_rows": [{"sku": f"R-{index}"} for index in range(12)],
+                    "product_profit_rows": [{"sku": f"P-{index}"} for index in range(12)],
+                    "loss_product_rows": [{"sku": "LOSS-1"}, {"sku": "LOSS-2"}],
+                }
+            }
+        }
+
+        snapshot = build_commercial_snapshot(
+            payload,
+            {"loss_acknowledgements": {"LOSS-1": {"sku": "LOSS-1"}}},
+        )
+
+        self.assertEqual(3, len(snapshot["brand_revenue_rows"]))
+        self.assertEqual(10, len(snapshot["product_revenue_rows"]))
+        self.assertEqual(["LOSS-2"], [row["sku"] for row in snapshot["loss_product_rows"]])
+        self.assertEqual(1, snapshot["acknowledged_loss_product_count"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## What changed

- Adds ROY operations dashboard sections for top 3 brands by revenue/profit and top 10 products by revenue/profit.
- Adds loss-product warnings with a persisted acknowledgement checkbox.
- Adds low-stock inbound workflow: ordered units + expected arrival date are persisted and counted into live stock-risk calculations.
- Automatically clears inbound markers after BiznisWeb stock increases for the SKU.
- Extends the App Runner runtime S3 policy to allow persisted operations state under the live dashboard artifact prefix.

## Validation

- `python -m py_compile export_orders.py dashboard_modern.py roy_operations_dashboard.py live_dashboard_server.py daily_report_runner.py`
- `python scripts\reporting_qa_smoke.py`
- `python -m unittest tests.test_invoice_generation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
- `git diff --check`

## Deploy note

After merge, rebuild ECR and run the ROY App Runner deploy workflow so the live dashboard image and S3-backed operations state policy are both updated.
