### PR TITLE
[codex] Fix ROY dashboard generated JS escape

### DIFF
--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -1204,7 +1204,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     const fmtRatio = (value) => value === null || value === undefined ? 'N/A' : `${new Intl.NumberFormat('sk-SK', { maximumFractionDigits:2 }).format(Number(value || 0))}x`;
     const text = (value, fallback='-') => value === null || value === undefined || value === '' ? fallback : String(value);
     const safe = (value) => text(value, '').replace(/[&<>"']/g, (ch) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
-    const cssEscape = (value) => window.CSS && CSS.escape ? CSS.escape(String(value)) : String(value).replace(/["\\]/g, '\\$&');
+    const cssEscape = (value) => window.CSS && CSS.escape ? CSS.escape(String(value)) : String(value).replace(/["\\\\]/g, '\\\\$&');
     let latestData = null;
     let refreshTimer = null;
     let kpiScope = 'monthly';

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -158,6 +158,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("Top zna", html)
         self.assertIn("Produkty v strate", html)
         self.assertIn("data-save-inbound", html)
+        self.assertIn("replace(/[\"\\\\]/g, '\\\\$&')", html)
+        self.assertNotIn('replace(/["\\]/g', html)
 
     def test_inbound_order_units_suppress_covered_stock_alert_until_restock(self) -> None:
         payload = {


### PR DESCRIPTION
﻿## What changed

- Fixed the generated ROY operations dashboard JavaScript so the CSS.escape fallback emits a valid regex in the rendered HTML.
- Added a regression assertion against the rendered HTML to catch the invalid escaped regex form.

## Verification

- `python -m py_compile live_dashboard_server.py roy_operations_dashboard.py`
- `python -m unittest tests.test_roy_operations_dashboard`
- `python -m unittest tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard`
- `git diff --check`
