### PR TITLE
[codex] Add ROY country performance dashboard

### DIFF
--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -790,6 +790,10 @@ def generate_modern_dashboard(
             "country",
             "orders",
             "revenue",
+            "gross_profit",
+            "fb_ads_spend",
+            "google_ads_spend",
+            "paid_ads_spend",
             "contribution_profit_without_fixed",
             "contribution_profit_without_fixed_guarded",
             "contribution_profit_with_fixed",
@@ -1555,6 +1559,27 @@ def generate_modern_dashboard(
         ],
         limit=80,
     )
+    roy_country_rows = _frame_rows(
+        (roy_product_demand or {}).get("country_rows"),
+        [
+            "country",
+            "country_label",
+            "orders",
+            "products",
+            "units",
+            "revenue",
+            "gross_profit",
+            "profit_without_fixed",
+            "profit_with_fixed",
+            "spend",
+            "paid_ads_spend",
+            "gross_margin_pct",
+            "net_margin_pct",
+            "spend_share_pct",
+            "top_products",
+        ],
+        limit=12,
+    )
 
     heatmap_rows = _frame_rows(day_hour_heatmap, ["day_name", "hour", "orders"], limit=None)
     b2b_rows = _frame_rows(
@@ -2067,6 +2092,7 @@ def generate_modern_dashboard(
             "product_revenue_rows": roy_product_revenue_rows,
             "product_profit_rows": roy_product_profit_rows,
             "loss_product_rows": roy_loss_product_rows,
+            "country_rows": roy_country_rows,
         },
         "daily_margin_rows": daily_margin_rows,
         "payday_window_rows": payday_window_rows,

--- a/export_orders.py
+++ b/export_orders.py
@@ -2302,6 +2302,40 @@ class BizniWebExporter:
         geo_source = geo_source.drop_duplicates(subset=["order_num"]).copy()
         return orders_df.merge(geo_source, on="order_num", how="left")
 
+    def _normalize_country_key_label(self, value: Any) -> Tuple[str, str]:
+        raw = str(value or "").strip()
+        normalized = self._normalize_match_text(raw)
+        alias_map = {
+            "sk": "sk",
+            "svk": "sk",
+            "slovakia": "sk",
+            "slovensko": "sk",
+            "slovenska republika": "sk",
+            "cz": "cz",
+            "cze": "cz",
+            "cesko": "cz",
+            "ceska republika": "cz",
+            "czechia": "cz",
+            "czech republic": "cz",
+            "hu": "hu",
+            "hun": "hu",
+            "hungary": "hu",
+            "madarsko": "hu",
+            "magyarorszag": "hu",
+            "unknown": "unknown",
+            "nan": "unknown",
+            "none": "unknown",
+            "": "unknown",
+        }
+        key = alias_map.get(normalized)
+        if key is None:
+            key = re.sub(r"[^a-z0-9]+", "-", normalized).strip("-") or "unknown"
+        label_map = {"sk": "SK", "cz": "CZ", "hu": "HU", "unknown": "Unknown"}
+        label = label_map.get(key)
+        if label is None:
+            label = raw.upper() if raw and len(raw) <= 3 else (raw or "Unknown")
+        return key, label
+
     def _match_named_group(self, label: Any, groups: List[Dict[str, Any]]) -> Tuple[Optional[str], Optional[str]]:
         for group in groups or []:
             if self._matches_patterns(str(label or ""), group.get("patterns") or []):
@@ -8253,6 +8287,7 @@ class BizniWebExporter:
 
         geo['fb_ads_spend'] = geo['country'].map(fb_spend_by_country).fillna(0)
         geo['paid_ads_spend'] = geo['fb_ads_spend'] + geo['google_ads_spend']
+        geo['gross_profit'] = geo['revenue'] - geo['product_cost']
         geo['contribution_cost_without_fixed'] = geo['product_cost'] + geo['packaging_cost'] + geo['shipping_net_cost'] + geo['paid_ads_spend']
         geo['contribution_profit_without_fixed'] = geo['revenue'] - geo['contribution_cost_without_fixed']
         geo['contribution_margin_without_fixed_pct'] = geo.apply(
@@ -8318,7 +8353,7 @@ class BizniWebExporter:
         # Round financial values for display.
         for col in [
             'revenue', 'product_cost', 'packaging_cost', 'shipping_subsidy_cost', 'fixed_cost',
-            'fb_ads_spend', 'google_ads_spend', 'paid_ads_spend',
+            'fb_ads_spend', 'google_ads_spend', 'paid_ads_spend', 'gross_profit',
             'contribution_cost_without_fixed', 'contribution_profit_without_fixed', 'contribution_profit_without_fixed_guarded',
             'contribution_cost_with_fixed', 'contribution_profit_with_fixed', 'contribution_profit_with_fixed_guarded',
             'contribution_cost', 'contribution_profit', 'contribution_profit_guarded'
@@ -8582,6 +8617,7 @@ class BizniWebExporter:
                 "product_revenue_rows": pd.DataFrame(),
                 "product_profit_rows": pd.DataFrame(),
                 "loss_product_rows": pd.DataFrame(),
+                "country_rows": pd.DataFrame(),
             }
 
         print("\nAnalyzing Roy product demand analytics...")
@@ -8610,6 +8646,7 @@ class BizniWebExporter:
                 "product_revenue_rows": pd.DataFrame(),
                 "product_profit_rows": pd.DataFrame(),
                 "loss_product_rows": pd.DataFrame(),
+                "country_rows": pd.DataFrame(),
             }
 
         demand_df = item_df.copy()
@@ -8636,6 +8673,7 @@ class BizniWebExporter:
                 "product_revenue_rows": pd.DataFrame(),
                 "product_profit_rows": pd.DataFrame(),
                 "loss_product_rows": pd.DataFrame(),
+                "country_rows": pd.DataFrame(),
             }
 
         numeric_columns = ["item_quantity", "item_total_without_tax", "cm2_profit", "cm3_profit"]
@@ -8726,6 +8764,112 @@ class BizniWebExporter:
             .reset_index(drop=True)
             if not product_display_summary.empty else pd.DataFrame()
         )
+
+        has_cm1_profit = "cm1_profit" in demand_df.columns
+        has_allocated_paid_spend = "allocated_paid_spend" in demand_df.columns
+        for column in ["cm1_profit", "allocated_paid_spend"]:
+            if column not in demand_df.columns:
+                demand_df[column] = 0.0
+        if not has_cm1_profit:
+            if "total_expense" in demand_df.columns:
+                demand_df["cm1_profit"] = demand_df["item_total_without_tax"].fillna(0.0) - pd.to_numeric(
+                    demand_df["total_expense"], errors="coerce"
+                ).fillna(0.0)
+            else:
+                demand_df["cm1_profit"] = pd.to_numeric(demand_df["cm2_profit"], errors="coerce").fillna(0.0)
+        if not has_allocated_paid_spend:
+            demand_df["allocated_paid_spend"] = (
+                pd.to_numeric(demand_df["cm1_profit"], errors="coerce").fillna(0.0)
+                - pd.to_numeric(demand_df["cm2_profit"], errors="coerce").fillna(0.0)
+            ).clip(lower=0.0)
+
+        country_source = pd.DataFrame()
+        if df is not None and not df.empty and orders_df is not None and not orders_df.empty:
+            try:
+                country_source = self._build_order_geo_frame(df, orders_df)[["order_num", "geo_country"]]
+            except Exception:
+                country_source = pd.DataFrame()
+        if country_source.empty and orders_df is not None and not orders_df.empty:
+            if "geo_country" in orders_df.columns:
+                country_source = orders_df[["order_num", "geo_country"]].copy()
+            elif "country" in orders_df.columns:
+                country_source = orders_df[["order_num", "country"]].rename(columns={"country": "geo_country"}).copy()
+        if country_source.empty:
+            if "geo_country" in demand_df.columns:
+                country_source = demand_df[["order_num", "geo_country"]].copy()
+            elif "country" in demand_df.columns:
+                country_source = demand_df[["order_num", "country"]].rename(columns={"country": "geo_country"}).copy()
+        if not country_source.empty:
+            country_source = country_source.drop_duplicates(subset=["order_num"]).copy()
+            demand_df = demand_df.drop(columns=["geo_country"], errors="ignore").merge(
+                country_source,
+                on="order_num",
+                how="left",
+            )
+        if "geo_country" not in demand_df.columns:
+            demand_df["geo_country"] = "Unknown"
+        demand_df["geo_country"] = demand_df["geo_country"].fillna("Unknown")
+        country_pairs = demand_df["geo_country"].apply(self._normalize_country_key_label)
+        demand_df["country"] = country_pairs.apply(lambda pair: pair[0])
+        demand_df["country_label"] = country_pairs.apply(lambda pair: pair[1])
+
+        country_product_summary = (
+            demand_df.groupby(["country", "country_label", "product_sku"], dropna=False)
+            .agg(
+                product=("item_label", "first"),
+                orders=("order_num", "nunique"),
+                units=("item_quantity", "sum"),
+                revenue=("item_total_without_tax", "sum"),
+                gross_profit=("cm1_profit", "sum"),
+                profit_without_fixed=("cm2_profit", "sum"),
+                profit_with_fixed=("cm3_profit", "sum"),
+                spend=("allocated_paid_spend", "sum"),
+            )
+            .reset_index()
+        )
+        country_rows: List[Dict[str, Any]] = []
+        for (country_key, country_label), group in country_product_summary.groupby(["country", "country_label"], dropna=False):
+            top_products = group.sort_values(["revenue", "profit_with_fixed"], ascending=[False, False]).head(5).copy()
+            country_revenue = float(group["revenue"].sum())
+            country_profit_with_fixed = float(group["profit_with_fixed"].sum())
+            country_gross_profit = float(group["gross_profit"].sum())
+            country_spend = float(group["spend"].sum())
+            country_rows.append(
+                {
+                    "country": country_key,
+                    "country_label": country_label,
+                    "orders": int(
+                        demand_df.loc[demand_df["country"].eq(country_key), "order_num"].nunique()
+                    ),
+                    "products": int(group["product_sku"].nunique()),
+                    "units": round(float(group["units"].sum()), 1),
+                    "revenue": round(country_revenue, 2),
+                    "gross_profit": round(country_gross_profit, 2),
+                    "profit_without_fixed": round(float(group["profit_without_fixed"].sum()), 2),
+                    "profit_with_fixed": round(country_profit_with_fixed, 2),
+                    "spend": round(country_spend, 2),
+                    "paid_ads_spend": round(country_spend, 2),
+                    "gross_margin_pct": round((country_gross_profit / country_revenue * 100.0) if country_revenue > 0 else 0.0, 1),
+                    "net_margin_pct": round((country_profit_with_fixed / country_revenue * 100.0) if country_revenue > 0 else 0.0, 1),
+                    "spend_share_pct": round((country_spend / country_revenue * 100.0) if country_revenue > 0 else 0.0, 1),
+                    "top_products": [
+                        {
+                            "sku": str(row.get("product_sku") or ""),
+                            "product": str(row.get("product") or ""),
+                            "orders": int(row.get("orders") or 0),
+                            "units": round(float(row.get("units") or 0.0), 1),
+                            "revenue": round(float(row.get("revenue") or 0.0), 2),
+                            "gross_profit": round(float(row.get("gross_profit") or 0.0), 2),
+                            "profit_with_fixed": round(float(row.get("profit_with_fixed") or 0.0), 2),
+                            "spend": round(float(row.get("spend") or 0.0), 2),
+                        }
+                        for _, row in top_products.iterrows()
+                    ],
+                }
+            )
+        country_rows_df = pd.DataFrame(country_rows).sort_values(
+            ["revenue", "profit_with_fixed"], ascending=[False, False]
+        ).reset_index(drop=True) if country_rows else pd.DataFrame()
 
         weekly = (
             demand_df.groupby(["product_sku", "week_start"])
@@ -10231,6 +10375,7 @@ class BizniWebExporter:
             "product_revenue_rows": product_revenue_rows_df,
             "product_profit_rows": product_profit_rows_df,
             "loss_product_rows": loss_product_rows_df,
+            "country_rows": country_rows_df,
         }
         print(
             f"Roy product demand analytics complete: growing={len(growing_rows_df)}, "
@@ -10238,7 +10383,7 @@ class BizniWebExporter:
             f"inventory_rows={len(inventory_rows_df)}, alert_rows={len(alert_rows_df)}, "
             f"restock_rows={len(restock_priority_rows_df)}, "
             f"forecast_backtests={len(forecast_accuracy_rows_df)}, brands={len(brand_summary)}, "
-            f"loss_products={len(loss_product_rows_df)}"
+            f"loss_products={len(loss_product_rows_df)}, countries={len(country_rows_df)}"
         )
         return result
 

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -998,6 +998,9 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     .stock-action input { min-height:34px; border:1px solid var(--line); border-radius:6px; padding:0 8px; font-weight:700; width:100%; }
     .stock-action button { min-height:34px; padding:0 9px; }
     .inbound-note { margin-top:5px; color:var(--green); font-size:12px; font-weight:800; }
+    .country-products { display:grid; gap:5px; min-width:340px; }
+    .country-product { display:grid; grid-template-columns:minmax(160px,1fr) auto auto; gap:8px; align-items:center; border-top:1px solid #edf0eb; padding-top:4px; }
+    .country-product:first-child { border-top:0; padding-top:0; }
     .hidden { display:none !important; }
     .error,.ok { margin-bottom:12px; padding:10px 12px; border-radius:8px; border:1px solid rgba(170,47,47,.25); color:var(--red); background:var(--red-bg); }
     .ok { color:var(--green); background:var(--green-bg); border-color:rgba(17,115,75,.25); }
@@ -1138,6 +1141,20 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
               <tbody id="productProfitBody"></tbody>
             </table>
           </div>
+        </div>
+      </article>
+      <article class="panel">
+        <div class="panel-head">
+          <div>
+            <h2>Krajiny</h2>
+            <p id="countryPerformanceMeta">-</p>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>Krajina</th><th>Obj.</th><th>Obrat</th><th>Hrubý zisk</th><th>Spend</th><th>Čistý zisk</th><th>Marža</th><th>Top produkty v krajine</th></tr></thead>
+            <tbody id="countryPerformanceBody"></tbody>
+          </table>
         </div>
       </article>
       <article class="panel">
@@ -1389,6 +1406,32 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     function productProfitRow(row) {
       return `<tr><td>${compactProductCell(row)}</td><td>${fmtMoney(row.profit_with_fixed)}</td><td>${fmtMoney(row.revenue)}</td><td>${fmtQty(row.units)} ks</td></tr>`;
     }
+    function countryTopProducts(row) {
+      const products = row.top_products || [];
+      if (!products.length) return '<span class="muted">Top produkty zatiaľ nie sú dostupné.</span>';
+      return `<div class="country-products">${products.slice(0, 5).map((product) => `
+        <div class="country-product">
+          <div><strong>${safe(product.product || '-')}</strong><div class="muted mono">${safe(product.sku || '')}</div></div>
+          <span>${fmtMoney(product.revenue)}</span>
+          <span class="${Number(product.profit_with_fixed || 0) < 0 ? 'negative' : 'positive'}">${fmtMoney(product.profit_with_fixed)}</span>
+        </div>`).join('')}</div>`;
+    }
+    function countryPerformanceRow(row) {
+      const spend = Number(row.spend ?? row.paid_ads_spend ?? 0);
+      const netProfit = Number(row.profit_with_fixed ?? row.contribution_profit_with_fixed ?? row.contribution_profit ?? 0);
+      const grossProfit = Number(row.gross_profit ?? row.profit_without_fixed ?? row.contribution_profit_without_fixed ?? 0);
+      const margin = row.net_margin_pct ?? row.contribution_margin_with_fixed_pct ?? row.contribution_margin_pct;
+      return `<tr>
+        <td><strong>${safe(row.country_label || row.country || 'Unknown')}</strong><div class="muted mono">${safe(row.country || '')}</div></td>
+        <td>${fmtInt(row.orders)}</td>
+        <td>${fmtMoney(row.revenue)}</td>
+        <td><span class="${grossProfit < 0 ? 'negative' : 'positive'}">${fmtMoney(grossProfit)}</span></td>
+        <td>${fmtMoney(spend)}</td>
+        <td><span class="${netProfit < 0 ? 'negative' : 'positive'}">${fmtMoney(netProfit)}</span></td>
+        <td>${fmtPct(margin)}</td>
+        <td>${countryTopProducts(row)}</td>
+      </tr>`;
+    }
     function lossProductRow(row) {
       return `<tr>
         <td>${compactProductCell(row)}</td>
@@ -1405,6 +1448,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       const brandProfit = perf.brand_profit_rows || [];
       const productRevenue = perf.product_revenue_rows || [];
       const productProfit = perf.product_profit_rows || [];
+      const countries = perf.country_rows || [];
       const losses = perf.loss_product_rows || [];
       el('brandPerformanceMeta').textContent = `${fmtInt(brandRevenue.length)} podľa obratu · ${fmtInt(brandProfit.length)} podľa zisku`;
       el('brandRevenueBody').innerHTML = brandRevenue.length ? brandRevenue.map(brandRevenueRow).join('') : '<tr><td colspan="4" class="muted">Značky zatiaľ nie sú dostupné.</td></tr>';
@@ -1412,6 +1456,8 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       el('productPerformanceMeta').textContent = `${fmtInt(productRevenue.length)} podľa obratu · ${fmtInt(productProfit.length)} podľa zisku`;
       el('productRevenueBody').innerHTML = productRevenue.length ? productRevenue.map(productRevenueRow).join('') : '<tr><td colspan="4" class="muted">Produkty zatiaľ nie sú dostupné.</td></tr>';
       el('productProfitBody').innerHTML = productProfit.length ? productProfit.map(productProfitRow).join('') : '<tr><td colspan="4" class="muted">Produkty zatiaľ nie sú dostupné.</td></tr>';
+      el('countryPerformanceMeta').textContent = countries.length ? `${fmtInt(countries.length)} krajín podľa obratu` : 'Krajiny zatiaľ nie sú dostupné';
+      el('countryPerformanceBody').innerHTML = countries.length ? countries.map(countryPerformanceRow).join('') : '<tr><td colspan="8" class="muted">Krajiny zatiaľ nie sú dostupné.</td></tr>';
       const hidden = Number(perf.acknowledged_loss_product_count || 0);
       el('lossProductMeta').textContent = losses.length ? `${fmtInt(losses.length)} nepotvrdených · ${fmtInt(hidden)} potvrdených skrytých` : `${fmtInt(hidden)} potvrdených skrytých`;
       el('lossProductBody').innerHTML = losses.length ? losses.map(lossProductRow).join('') : '<tr><td colspan="6" class="muted">Bez nepotvrdených stratových produktov.</td></tr>';

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -764,6 +764,40 @@ def build_commercial_snapshot(report_payload: Dict[str, Any], state: Optional[Di
     product_profit_rows = list(roy_demand.get("product_profit_rows") or [])
     if not product_profit_rows:
         product_profit_rows = list(dashboard.get("products") or [])
+    country_rows = list(roy_demand.get("country_rows") or [])
+    geo_rows = list(dashboard.get("geo_rows") or [])
+    geo_by_country = {
+        str(row.get("country") or "").strip().lower(): row
+        for row in geo_rows
+        if isinstance(row, dict) and str(row.get("country") or "").strip()
+    }
+    if country_rows and geo_by_country:
+        merged_country_rows: List[Dict[str, Any]] = []
+        for row in country_rows:
+            merged = dict(row)
+            geo = geo_by_country.get(str(row.get("country") or "").strip().lower())
+            if geo:
+                merged["fb_ads_spend"] = geo.get("fb_ads_spend", merged.get("fb_ads_spend"))
+                merged["google_ads_spend"] = geo.get("google_ads_spend", merged.get("google_ads_spend"))
+                merged["paid_ads_spend"] = geo.get("paid_ads_spend", merged.get("paid_ads_spend"))
+                merged["spend"] = geo.get("paid_ads_spend", merged.get("spend"))
+                merged["gross_profit"] = geo.get("gross_profit", merged.get("gross_profit"))
+                merged["profit_without_fixed"] = geo.get(
+                    "contribution_profit_without_fixed",
+                    merged.get("profit_without_fixed"),
+                )
+                merged["profit_with_fixed"] = geo.get(
+                    "contribution_profit_with_fixed",
+                    merged.get("profit_with_fixed"),
+                )
+                merged["net_margin_pct"] = geo.get(
+                    "contribution_margin_with_fixed_pct",
+                    merged.get("net_margin_pct"),
+                )
+            merged_country_rows.append(merged)
+        country_rows = merged_country_rows
+    if not country_rows:
+        country_rows = geo_rows
 
     loss_rows = []
     hidden_loss_count = 0
@@ -779,6 +813,7 @@ def build_commercial_snapshot(report_payload: Dict[str, Any], state: Optional[Di
         "brand_profit_rows": list(roy_demand.get("brand_profit_rows") or [])[:3],
         "product_revenue_rows": product_revenue_rows[:10],
         "product_profit_rows": product_profit_rows[:10],
+        "country_rows": country_rows[:12],
         "loss_product_rows": loss_rows[:80],
         "acknowledged_loss_product_count": hidden_loss_count,
     }

--- a/tests/test_roy_inventory_model.py
+++ b/tests/test_roy_inventory_model.py
@@ -30,6 +30,9 @@ def item_row(
     item_ean: str = "",
     cm2_profit: float | None = None,
     cm3_profit: float | None = None,
+    cm1_profit: float | None = None,
+    allocated_paid_spend: float = 0.0,
+    country: str = "SK",
 ) -> dict:
     return {
         "order_num": order_num,
@@ -40,8 +43,11 @@ def item_row(
         "purchase_datetime": purchase_datetime,
         "item_quantity": quantity,
         "item_total_without_tax": revenue,
+        "cm1_profit": revenue * 0.5 if cm1_profit is None else cm1_profit,
         "cm2_profit": revenue * 0.4 if cm2_profit is None else cm2_profit,
         "cm3_profit": revenue * 0.3 if cm3_profit is None else cm3_profit,
+        "allocated_paid_spend": allocated_paid_spend,
+        "geo_country": country,
     }
 
 
@@ -225,6 +231,72 @@ class RoyInventoryModelTests(unittest.TestCase):
         self.assertEqual("P-WIN", result["product_profit_rows"].iloc[0]["sku"])
         self.assertEqual(["P-LOSS"], result["loss_product_rows"]["sku"].tolist())
         self.assertLess(float(result["loss_product_rows"].iloc[0]["profit_without_fixed"]), 0)
+
+    def test_roy_demand_outputs_country_performance_with_top_products(self) -> None:
+        exporter = RoyInventoryModelExporter(inventory_snapshot=pd.DataFrame())
+        item_df = pd.DataFrame(
+            [
+                item_row(
+                    "R-SK-1",
+                    "P-SK-A",
+                    "SK hero product",
+                    "2026-05-01",
+                    2,
+                    300,
+                    cm1_profit=180,
+                    cm2_profit=150,
+                    cm3_profit=120,
+                    allocated_paid_spend=30,
+                    country="Slovensko",
+                ),
+                item_row(
+                    "R-SK-2",
+                    "P-SK-B",
+                    "SK secondary product",
+                    "2026-05-02",
+                    1,
+                    120,
+                    cm1_profit=70,
+                    cm2_profit=55,
+                    cm3_profit=40,
+                    allocated_paid_spend=15,
+                    country="SK",
+                ),
+                item_row(
+                    "R-CZ-1",
+                    "P-CZ-A",
+                    "CZ hero product",
+                    "2026-05-03",
+                    1,
+                    220,
+                    cm1_profit=130,
+                    cm2_profit=100,
+                    cm3_profit=75,
+                    allocated_paid_spend=30,
+                    country="Czech Republic",
+                ),
+            ]
+        )
+
+        result = exporter.analyze_roy_product_demand_analytics(
+            df=pd.DataFrame(),
+            orders_df=pd.DataFrame(),
+            item_df=item_df,
+        )
+
+        country_rows = result["country_rows"]
+        sk_row = country_rows.loc[country_rows["country"] == "sk"].iloc[0]
+        cz_row = country_rows.loc[country_rows["country"] == "cz"].iloc[0]
+
+        self.assertEqual("SK", sk_row["country_label"])
+        self.assertEqual(2, int(sk_row["orders"]))
+        self.assertEqual(420, float(sk_row["revenue"]))
+        self.assertEqual(250, float(sk_row["gross_profit"]))
+        self.assertEqual(45, float(sk_row["spend"]))
+        self.assertEqual(160, float(sk_row["profit_with_fixed"]))
+        self.assertEqual("P-SK-A", sk_row["top_products"][0]["sku"])
+        self.assertEqual("CZ", cz_row["country_label"])
+        self.assertEqual("P-CZ-A", cz_row["top_products"][0]["sku"])
 
 
 if __name__ == "__main__":

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -156,6 +156,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("visibleInventoryAlertLimit = 100", html)
         self.assertIn("visibleInventoryLimit = 100", html)
         self.assertIn("Top zna", html)
+        self.assertIn("Krajiny", html)
+        self.assertIn("countryPerformanceBody", html)
         self.assertIn("Produkty v strate", html)
         self.assertIn("data-save-inbound", html)
         self.assertIn("replace(/[\"\\\\]/g, '\\\\$&')", html)
@@ -300,8 +302,10 @@ class RoyOperationsDashboardTests(unittest.TestCase):
                     "brand_profit_rows": [{"brand_key": "p1"}, {"brand_key": "p2"}, {"brand_key": "p3"}, {"brand_key": "p4"}],
                     "product_revenue_rows": [{"sku": f"R-{index}"} for index in range(12)],
                     "product_profit_rows": [{"sku": f"P-{index}"} for index in range(12)],
+                    "country_rows": [{"country": "sk"}, {"country": "cz"}],
                     "loss_product_rows": [{"sku": "LOSS-1"}, {"sku": "LOSS-2"}],
-                }
+                },
+                "geo_rows": [{"country": "sk", "paid_ads_spend": 25, "contribution_profit_with_fixed": 75}],
             }
         }
 
@@ -312,6 +316,9 @@ class RoyOperationsDashboardTests(unittest.TestCase):
 
         self.assertEqual(3, len(snapshot["brand_revenue_rows"]))
         self.assertEqual(10, len(snapshot["product_revenue_rows"]))
+        self.assertEqual(["sk", "cz"], [row["country"] for row in snapshot["country_rows"]])
+        self.assertEqual(25, snapshot["country_rows"][0]["spend"])
+        self.assertEqual(75, snapshot["country_rows"][0]["profit_with_fixed"])
         self.assertEqual(["LOSS-2"], [row["sku"] for row in snapshot["loss_product_rows"]])
         self.assertEqual(1, snapshot["acknowledged_loss_product_count"])
 


### PR DESCRIPTION
﻿## What changed

- Added ROY country-level performance rows to the reporting payload.
- Each country now carries revenue, gross profit, paid spend, net profit, margins, and top products in that country.
- ROY operations API exposes country rows in the `performance` snapshot.
- Live ROY dashboard renders a new `Krajiny` table in the overview.
- Country spend/profit rows are enriched from existing geo profitability rows when campaign-level country spend is available.

## Verification

- `python -m py_compile export_orders.py dashboard_modern.py roy_operations_dashboard.py live_dashboard_server.py`
- `python scripts\reporting_qa_smoke.py`
- `python -m unittest tests.test_roy_inventory_model tests.test_roy_operations_dashboard`
- `python -m unittest tests.test_dashboard_modern tests.test_reporting_product_identity tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_inventory_model tests.test_roy_operations_dashboard`
- rendered ROY operations dashboard JS extracted from HTML and checked with `node --check`
- `git diff --check`
