### PR TITLE
Fix ROY country dashboard JSON serialization

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -211,9 +211,28 @@ Bootstrap entrypoints:
   - production S3 state write/read was smoke-tested through inbound save + clear on `/api/operations/roy/inbound/__codex_smoke__`
 
 ## 8) Next Exact Step
-- Monitor the next scheduled ROY report refresh and verify inbound auto-clear on the first real restock event. No open code/deploy blocker for the ROY operations dashboard performance/inbound workflow.
+- Open and merge the ROY country JSON-safe renderer fix, wait for ECR refresh, rerun guarded App Runner deploy for `/production/roy`, then verify the live country table/API payload.
 
 ## 9) Change Log
+
+### 2026-05-27 (ROY country performance renderer fix)
+- Branch: `codex/roy-country-json-safe`
+- Context:
+  - PR `#101` added ROY country performance metrics to the live operations dashboard.
+  - The first guarded deploy refresh run `26491693543` failed during production report generation because `dashboard_modern._json_safe()` called `pd.isna()` on nested `top_products` lists in `country_rows`.
+- Change:
+  - `dashboard_modern._json_safe()` now recursively serializes dictionaries, lists, tuples, sets, and array-like values before scalar missing-value handling.
+  - `pd.NaT` and other missing scalar values remain serialized as JSON `null`.
+  - Added regression coverage for nested country `top_products` rows.
+- Local verification:
+  - `python -m unittest tests.test_dashboard_modern tests.test_roy_inventory_model tests.test_roy_operations_dashboard`
+  - `python -m py_compile dashboard_modern.py export_orders.py roy_operations_dashboard.py live_dashboard_server.py`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python -m unittest tests.test_dashboard_modern tests.test_reporting_product_identity tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_inventory_model tests.test_roy_operations_dashboard`
+  - `git diff --check`
+  - rendered ROY operations dashboard script extracted from `build_roy_operations_dashboard_html("roy")` and checked with `node --check`
+- Next exact step:
+  - open/merge PR, wait for ECR build, rerun guarded ROY App Runner deploy, then verify live `/production/roy` and `/api/operations/roy/live?refresh=1` include `country_rows`.
 
 ### 2026-05-27 (ROY operations performance and inbound workflow)
 - Branch: `codex/roy-dashboard-top-margin-workflow`

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -406,13 +406,22 @@ def _to_frame(value: Any) -> pd.DataFrame:
 
 
 def _json_safe(value: Any) -> Any:
-    if isinstance(value, (datetime, date, pd.Timestamp)):
-        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    if not isinstance(value, (str, bytes, bytearray)) and hasattr(value, "tolist"):
+        try:
+            return _json_safe(value.tolist())
+        except Exception:
+            pass
     try:
         if pd.isna(value):
             return None
-    except TypeError:
+    except (TypeError, ValueError):
         pass
+    if isinstance(value, (datetime, date, pd.Timestamp)):
+        return value.isoformat()
     if hasattr(value, "item"):
         try:
             return value.item()

--- a/tests/test_dashboard_modern.py
+++ b/tests/test_dashboard_modern.py
@@ -1,7 +1,9 @@
 import unittest
 from datetime import datetime
 
-from dashboard_modern import _build_fb_daily_payload
+import pandas as pd
+
+from dashboard_modern import _build_fb_daily_payload, _frame_rows
 
 
 class DashboardModernTests(unittest.TestCase):
@@ -22,6 +24,26 @@ class DashboardModernTests(unittest.TestCase):
         self.assertEqual([10.24, 0.0, 10.09, 0.0], payload["spend"])
         self.assertEqual([80.0, 0.0, 120.0, 0.0], payload["clicks"])
         self.assertEqual([3924.0, 0.0, 5630.0, 0.0], payload["impressions"])
+
+    def test_frame_rows_serializes_nested_country_top_products(self) -> None:
+        rows = _frame_rows(
+            pd.DataFrame(
+                [
+                    {
+                        "country": "sk",
+                        "top_products": [
+                            {"sku": "12474", "revenue": 100.5, "stockout_date": pd.NaT},
+                            {"sku": "sd32", "revenue": 20, "note": None},
+                        ],
+                    }
+                ]
+            ),
+            ["country", "top_products"],
+        )
+
+        self.assertEqual("sk", rows[0]["country"])
+        self.assertEqual("12474", rows[0]["top_products"][0]["sku"])
+        self.assertIsNone(rows[0]["top_products"][0]["stockout_date"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make dashboard JSON serialization handle nested country top-products safely
- keep missing scalar values like pd.NaT as JSON null
- add regression coverage for country top-products rows

## Verification
- python -m unittest tests.test_dashboard_modern tests.test_roy_inventory_model tests.test_roy_operations_dashboard
- python -m py_compile dashboard_modern.py export_orders.py roy_operations_dashboard.py live_dashboard_server.py
- python scripts\\reporting_qa_smoke.py
- python -m unittest tests.test_dashboard_modern tests.test_reporting_product_identity tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_inventory_model tests.test_roy_operations_dashboard
- git diff --check
- node --check extracted ROY operations dashboard script