### PR TITLE
Pin live dashboard refresh task image

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -239,30 +239,38 @@ jobs:
               --policy-name ReportingLiveDashboardArtifacts \
               --policy-document file://reporting-artifacts-policy.json
 
-            NEEDS_REPORT_TASK_UPDATE="$(python - "${REPORT_S3_BUCKET_VALUE}" "${REPORT_S3_PREFIX_VALUE}" <<'PY'
+            NEEDS_REPORT_TASK_UPDATE="$(python - "${REPORT_S3_BUCKET_VALUE}" "${REPORT_S3_PREFIX_VALUE}" "${IMAGE_IDENTIFIER}" <<'PY'
           import json
           import sys
-          bucket, prefix = sys.argv[1], sys.argv[2]
+          bucket, prefix, image_identifier = sys.argv[1], sys.argv[2], sys.argv[3]
           task_def = json.load(open("task-definition.json", encoding="utf-8"))["taskDefinition"]
+          container = task_def["containerDefinitions"][0]
           env = {
               item.get("name"): item.get("value")
-              for item in task_def["containerDefinitions"][0].get("environment", [])
+              for item in container.get("environment", [])
           }
           secret_names = {
               item.get("name")
-              for item in task_def["containerDefinitions"][0].get("secrets", [])
+              for item in container.get("secrets", [])
           }
           has_conflicting_secret = bool({"REPORT_S3_BUCKET", "REPORT_S3_PREFIX"} & secret_names)
-          print("true" if has_conflicting_secret or env.get("REPORT_S3_BUCKET") != bucket or env.get("REPORT_S3_PREFIX") != prefix else "false")
+          image_mismatch = container.get("image") != image_identifier
+          needs_update = (
+              has_conflicting_secret
+              or env.get("REPORT_S3_BUCKET") != bucket
+              or env.get("REPORT_S3_PREFIX") != prefix
+              or image_mismatch
+          )
+          print("true" if needs_update else "false")
           PY
             )"
             if [[ "${NEEDS_REPORT_TASK_UPDATE}" == "true" ]]; then
-              python - "${REPORT_S3_BUCKET_VALUE}" "${REPORT_S3_PREFIX_VALUE}" <<'PY' > task-definition-s3.json
+              python - "${REPORT_S3_BUCKET_VALUE}" "${REPORT_S3_PREFIX_VALUE}" "${IMAGE_IDENTIFIER}" <<'PY' > task-definition-s3.json
           import copy
           import json
           import sys
 
-          bucket, prefix = sys.argv[1], sys.argv[2]
+          bucket, prefix, image_identifier = sys.argv[1], sys.argv[2], sys.argv[3]
           source = json.load(open("task-definition.json", encoding="utf-8"))["taskDefinition"]
           allowed = {
               "family",
@@ -284,6 +292,7 @@ jobs:
           }
           task = {key: copy.deepcopy(value) for key, value in source.items() if key in allowed and value not in (None, [], {})}
           container = task["containerDefinitions"][0]
+          container["image"] = image_identifier
           env = [item for item in container.get("environment", []) if item.get("name") not in {"REPORT_S3_BUCKET", "REPORT_S3_PREFIX"}]
           env.extend([
               {"name": "REPORT_S3_BUCKET", "value": bucket},
@@ -542,6 +551,7 @@ jobs:
             echo "task-definition=${TASK_DEFINITION_ARN}"
             echo "task-arn=${REFRESH_TASK_ARN}"
             echo "image-path=${IMAGE_URI}"
+            echo "image-identifier=${IMAGE_IDENTIFIER}"
             echo "marker-path=http://127.0.0.1:8000/marker.json"
             echo "latest-artifact-path=s3://${REPORT_S3_BUCKET_VALUE}/${REPORT_S3_PREFIX_VALUE}/latest/dashboard_payload_latest.json"
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -211,9 +211,24 @@ Bootstrap entrypoints:
   - production S3 state write/read was smoke-tested through inbound save + clear on `/api/operations/roy/inbound/__codex_smoke__`
 
 ## 8) Next Exact Step
-- Open/merge the ROY gross-loss-products PR, refresh ECR, deploy ROY App Runner, and verify live `Produkty v strate` uses only gross profit/loss.
+- Open/merge the live dashboard refresh image-pin fix, refresh ECR, deploy ROY App Runner again, and verify live `Produkty v strate` rows contain negative `gross_profit`.
 
 ## 9) Change Log
+
+### 2026-05-27 (Live dashboard refresh task pins current image)
+- Branch: `codex/live-dashboard-refresh-image-pin`
+- Context:
+  - PR `#104` updated ROY loss-product logic and App Runner served the updated HTML, but the live API payload still showed a loss row without `gross_profit`.
+  - The deploy workflow refreshed the S3 report artifact using the existing scheduled ECS task definition and only re-registered it when S3 env values changed, so the refresh task could run an older reporting image than App Runner.
+- Change:
+  - `Deploy Live Dashboard App Runner` now compares the scheduled ECS refresh task image with the current ECR image digest.
+  - When the image differs, the workflow registers a new ROY reporting task definition pinned to the current image digest before running the refresh.
+  - The refresh hard-gate log now prints the refresh task `image-identifier`.
+- Local verification:
+  - parsed `.github/workflows/deploy-live-dashboard-apprunner.yml` with `yaml.safe_load`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, wait for ECR build, rerun guarded ROY App Runner deploy, then verify loss rows have `gross_profit < 0`.
 
 ### 2026-05-27 (ROY loss products use gross profit only)
 - Branch: `codex/roy-loss-products-gross-profit`


### PR DESCRIPTION
## Summary
- make the live dashboard deploy workflow update the ROY artifact refresh ECS task to the current ECR image digest
- log the refresh task image identifier in the hard-gate context
- document why this is needed for live dashboard artifact parity

## Verification
- parsed .github/workflows/deploy-live-dashboard-apprunner.yml with yaml.safe_load
- git diff --check