### PR TITLE
[codex] Guard ROY loss products by gross profit

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -457,6 +457,22 @@ jobs:
           assert kpis.get("windows"), "KPI windows missing in generated payload"
           assert series.get("dates"), "KPI source series dates missing in generated payload"
           assert inventory.get("summary"), "Inventory summary missing in generated payload"
+          invalid_loss_rows = []
+          for row in inventory.get("loss_product_rows") or []:
+              if not isinstance(row, dict):
+                  invalid_loss_rows.append(row)
+                  continue
+              raw_gross = row.get("gross_profit")
+              if raw_gross is None:
+                  raw_gross = row.get("cm1_profit")
+              try:
+                  gross_profit = float(raw_gross)
+              except (TypeError, ValueError):
+                  invalid_loss_rows.append(row)
+                  continue
+              if gross_profit >= 0:
+                  invalid_loss_rows.append(row)
+          assert not invalid_loss_rows, "Loss products must be based on negative gross profit only"
           marker_dir = Path("/tmp/live-dashboard-marker")
           marker_dir.mkdir(parents=True, exist_ok=True)
           marker = {
@@ -625,6 +641,22 @@ jobs:
           assert kpis.get("windows"), "S3 KPI windows missing"
           assert series.get("dates"), "S3 KPI source series dates missing"
           assert inventory.get("summary"), "S3 inventory summary missing"
+          invalid_loss_rows = []
+          for row in inventory.get("loss_product_rows") or []:
+              if not isinstance(row, dict):
+                  invalid_loss_rows.append(row)
+                  continue
+              raw_gross = row.get("gross_profit")
+              if raw_gross is None:
+                  raw_gross = row.get("cm1_profit")
+              try:
+                  gross_profit = float(raw_gross)
+              except (TypeError, ValueError):
+                  invalid_loss_rows.append(row)
+                  continue
+              if gross_profit >= 0:
+                  invalid_loss_rows.append(row)
+          assert not invalid_loss_rows, "S3 loss products must be based on negative gross profit only"
           print(
               "ROY_LIVE_ARTIFACTS_OK:"
               f"kpi_series_days={len(series.get('dates') or [])}:"
@@ -912,6 +944,7 @@ jobs:
             curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/operations/roy/live?refresh=1" -o /tmp/production-board-api.json
             python - <<'PY'
           import json
+          html = open("/tmp/production-board.html", encoding="utf-8").read()
           api = json.load(open("/tmp/production-board-api.json", encoding="utf-8"))
           assert api["project"] == "roy"
           assert api["marker"] == "roy-operations-dashboard"
@@ -921,12 +954,31 @@ jobs:
           assert api["executive_kpis"].get("windows"), "Executive KPI windows missing"
           assert len(api["executive_kpis"].get("months") or []) > 0, "Calendar KPI months missing"
           assert api["inventory"].get("summary"), "Inventory summary missing"
+          assert "Hrubý zisk/strata" in html, "Gross-loss table header missing"
+          assert "Zisk s fixom" not in html, "Loss products must not show post-fixed profit"
+          invalid_loss_rows = []
+          for row in (api.get("performance") or {}).get("loss_product_rows") or []:
+              if not isinstance(row, dict):
+                  invalid_loss_rows.append(row)
+                  continue
+              raw_gross = row.get("gross_profit")
+              if raw_gross is None:
+                  raw_gross = row.get("cm1_profit")
+              try:
+                  gross_profit = float(raw_gross)
+              except (TypeError, ValueError):
+                  invalid_loss_rows.append(row)
+                  continue
+              if gross_profit >= 0:
+                  invalid_loss_rows.append(row)
+          assert not invalid_loss_rows, "Live loss products must be based on negative gross profit only"
           print(
               "APP_RUNNER_ROY_OPERATIONS_OK:"
               f"fulfillable_orders={api['orders']['summary'].get('fulfillable_orders')}:"
               f"personal_pickups={api['orders']['summary'].get('personal_pickups')}:"
               f"inventory_alerts={api['inventory']['summary'].get('alert_delivery_count')}:"
-              f"kpi_months={len(api['executive_kpis'].get('months') or [])}"
+              f"kpi_months={len(api['executive_kpis'].get('months') or [])}:"
+              f"gross_loss_products={len((api.get('performance') or {}).get('loss_product_rows') or [])}"
           )
           PY
           else

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2875,3 +2875,18 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - `Zvonček na medvede, plašič medveďov` is present in inventory with `available_quantity=368`, so it is healthy and not an urgent alert
 - Next exact step:
   - monitor the next scheduled ROY report once and confirm the alert counts stay consistent with the live dashboard
+
+### 2026-05-27 (ROY loss products gross-profit runtime guard)
+- Branch: `codex/roy-loss-products-runtime-gross-guard`
+- Change:
+  - ROY operations dashboard now shows `Produkty v strate` only when the product row has negative gross profit (`gross_profit` or `cm1_profit`)
+  - rows that are negative only after fixed costs are ignored by the live operations snapshot, including stale payload rows without gross-profit data
+  - ROY App Runner deploy smoke now validates generated payload, S3 latest artifact, live HTML, and live API for gross-profit-only loss products
+- Local verification:
+  - `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_dashboard_modern`
+  - `python -m py_compile roy_operations_dashboard.py live_dashboard_server.py dashboard_modern.py export_orders.py`
+  - `python scripts\reporting_qa_smoke.py`
+  - workflow YAML parse check for `.github/workflows/deploy-live-dashboard-apprunner.yml`
+  - `git diff --check`
+- Next exact step:
+  - run local tests, open/merge PR, wait for ECR build, deploy ROY App Runner, and verify `/production/roy` live API

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -355,6 +355,17 @@ def _to_float(value: Any) -> float:
         return 0.0
 
 
+def _optional_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _pct_change(current: Optional[float], previous: Optional[float]) -> Optional[float]:
     if current is None or previous in (None, 0):
         return None
@@ -801,7 +812,19 @@ def build_commercial_snapshot(report_payload: Dict[str, Any], state: Optional[Di
 
     loss_rows = []
     hidden_loss_count = 0
-    for row in list(roy_demand.get("loss_product_rows") or []):
+    for raw_row in list(roy_demand.get("loss_product_rows") or []):
+        if not isinstance(raw_row, dict):
+            continue
+        row = dict(raw_row)
+        gross_profit = _optional_float(row.get("gross_profit"))
+        if gross_profit is None:
+            gross_profit = _optional_float(row.get("cm1_profit"))
+        if gross_profit is None or gross_profit >= 0:
+            continue
+        row["gross_profit"] = gross_profit
+        if _optional_float(row.get("gross_margin_pct")) is None:
+            revenue = _to_float(row.get("revenue"))
+            row["gross_margin_pct"] = round((gross_profit / revenue * 100.0) if revenue > 0 else 0.0, 1)
         sku = str(row.get("sku") or "").strip()
         if sku and sku in acknowledged:
             hidden_loss_count += 1

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -305,7 +305,10 @@ class RoyOperationsDashboardTests(unittest.TestCase):
                     "product_revenue_rows": [{"sku": f"R-{index}"} for index in range(12)],
                     "product_profit_rows": [{"sku": f"P-{index}"} for index in range(12)],
                     "country_rows": [{"country": "sk"}, {"country": "cz"}],
-                    "loss_product_rows": [{"sku": "LOSS-1"}, {"sku": "LOSS-2"}],
+                    "loss_product_rows": [
+                        {"sku": "LOSS-1", "gross_profit": -7, "revenue": 50},
+                        {"sku": "LOSS-2", "gross_profit": -5, "revenue": 40},
+                    ],
                 },
                 "geo_rows": [{"country": "sk", "paid_ads_spend": 25, "contribution_profit_with_fixed": 75}],
             }
@@ -323,6 +326,26 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(75, snapshot["country_rows"][0]["profit_with_fixed"])
         self.assertEqual(["LOSS-2"], [row["sku"] for row in snapshot["loss_product_rows"]])
         self.assertEqual(1, snapshot["acknowledged_loss_product_count"])
+
+    def test_commercial_snapshot_uses_only_gross_loss_products(self) -> None:
+        payload = {
+            "dashboard": {
+                "roy_product_demand": {
+                    "loss_product_rows": [
+                        {"sku": "GROSS-LOSS", "gross_profit": -3, "profit_with_fixed": 10, "revenue": 30},
+                        {"sku": "CM1-LOSS", "cm1_profit": -2, "profit_with_fixed": -12, "revenue": 20},
+                        {"sku": "FIXED-ONLY-LOSS", "profit_with_fixed": -25, "revenue": 100},
+                        {"sku": "GROSS-PROFIT", "gross_profit": 5, "profit_with_fixed": -10, "revenue": 20},
+                    ],
+                },
+            },
+        }
+
+        snapshot = build_commercial_snapshot(payload, {})
+
+        self.assertEqual(["GROSS-LOSS", "CM1-LOSS"], [row["sku"] for row in snapshot["loss_product_rows"]])
+        self.assertEqual(-3, snapshot["loss_product_rows"][0]["gross_profit"])
+        self.assertEqual(-10.0, snapshot["loss_product_rows"][0]["gross_margin_pct"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- Guards ROY operations `loss_product_rows` so live `Produkty v strate` only includes rows with negative `gross_profit` or `cm1_profit`.
- Ignores stale/post-fixed-only loss rows that do not carry gross profit data.
- Extends ROY App Runner deploy smoke checks across generated payload, S3 latest artifact, live HTML, and live API.

## Why
The live dashboard could still surface a product as a loss when the row came from older/post-fixed economics. The user requested loss products to be calculated only from gross profit/loss.

## Verification
- `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_dashboard_modern`
- `python -m py_compile roy_operations_dashboard.py live_dashboard_server.py dashboard_modern.py export_orders.py`
- `python scripts\reporting_qa_smoke.py`
- workflow YAML parse check
- `git diff --check`