### PR TITLE
[codex] Register unpaid cancellation deploy workflow

### DIFF
--- a/.github/workflows/deploy-unpaid-order-cancellation.yml
+++ b/.github/workflows/deploy-unpaid-order-cancellation.yml
@@ -7,6 +7,14 @@ on:
         description: Reporting project slug
         required: true
         default: roy
+  push:
+    branches:
+      - main
+    paths:
+      - unpaid_order_cancellation.py
+      - unpaid_order_cancellation_runner.py
+      - projects/roy/settings.json
+      - .github/workflows/deploy-unpaid-order-cancellation.yml
 
 env:
   AWS_REGION: eu-central-1
@@ -33,7 +41,7 @@ jobs:
       - name: Deploy scheduler and run host smoke
         shell: bash
         env:
-          PROJECT: ${{ inputs.project }}
+          PROJECT: ${{ inputs.project || 'roy' }}
         run: |
           set -euo pipefail
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -231,6 +231,8 @@ Bootstrap entrypoints:
   - payment refs `6`, `17`, `18`, `11`, `20`
   - daily schedule metadata `roy-unpaid-order-cancellation`, `cron(10 2 * * ? *) Europe/Bratislava`
 - Added GitHub Actions workflow `.github/workflows/deploy-unpaid-order-cancellation.yml` to register the ECS task definition, create/update the EventBridge Scheduler job, and verify a host dry-run marker at `http://127.0.0.1:8000/marker.json`.
+- Follow-up workflow registration note:
+  - the deploy workflow also has a `push` trigger scoped to `main` and only the unpaid-cancellation files so GitHub registers it and future automation-code changes refresh the scheduler through the same host-smoke path
 - Verified locally:
   - `python -m py_compile unpaid_order_cancellation.py unpaid_order_cancellation_runner.py`
   - `python -m unittest tests.test_unpaid_order_cancellation`


### PR DESCRIPTION
## What changed
- Added a scoped `push` trigger to the unpaid order cancellation deploy workflow so GitHub indexes it and future changes to this automation refresh the scheduler through the same host-smoke path.
- Documented the workflow registration detail in PROJECT_STATE.md.

## Validation
- actionlint .github/workflows/deploy-unpaid-order-cancellation.yml
- git diff --check
