### PR TITLE
[codex] Add ROY picking list PDF export

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -19,6 +19,7 @@ on:
       - live_dashboard_server.py
       - production_board.py
       - roy_operations_dashboard.py
+      - roy_picking_lists_pdf.py
       - project_config.py
       - weather_client.py
       - http_client.py
@@ -61,7 +62,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
+          python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 COPY requirements.txt /app/requirements.txt
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
+    apt-get install -y --no-install-recommends curl fonts-dejavu-core && \
     rm -rf /var/lib/apt/lists/* && \
     pip install --no-cache-dir -r /app/requirements.txt && \
     pip install --no-cache-dir boto3

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -216,11 +216,36 @@ Bootstrap entrypoints:
   - production task definition `roy-unpaid-order-cancellation:3` uses ECR digest `sha256:be3e39f3184ef479d899fb97682792a998c72d30bc41cc7dcd8f2670629c8ac3`
   - production one-off execute run `26510343214` updated `11` stale unpaid orders and returned `failed_orders=0`
   - post-execute read-only dry-run on `2026-05-27` scanned `1500` ROY orders through `2026-01-29` and found `eligible_orders=0`
+- ROY operations picking-list PDF export is implemented on task branch:
+  - dashboard header now has one-click `Vysklad. PDF` download
+  - endpoint `/api/operations/roy/picking-lists.pdf?refresh=1` generates one PDF with one picking list page per fulfillable order
+  - PDF uses the same expanded order items as the operations dashboard, so configured bundle components are reflected in picking lists
+  - local server smoke on `2026-05-27` returned `application/pdf`, download filename `roy-vyskladnovacie-listy-30-20260527-1429.pdf`, `%PDF-` header, and `167256` bytes
 
 ## 8) Next Exact Step
-- Monitor the first scheduled ROY unpaid-order cancellation run after `2026-05-28 02:10 Europe/Bratislava` and confirm it exits cleanly with no unexpected eligible backlog.
+- Deploy ROY operations picking-list PDF export to App Runner and verify `/api/operations/roy/picking-lists.pdf?refresh=1` on the production service.
 
 ## 9) Change Log
+
+### 2026-05-27 (ROY operations picking-list PDF export staged)
+- Added one-click PDF picking-list export to the ROY operations dashboard:
+  - new module `roy_picking_lists_pdf.py`
+  - new endpoint `/api/operations/roy/picking-lists.pdf?refresh=1`
+  - new header button `Vysklad. PDF`
+  - dependency `reportlab>=4.2.0`
+  - Docker image now installs `fonts-dejavu-core` for Slovak/Czech diacritics in generated PDFs
+- Verified locally:
+  - `python -m py_compile live_dashboard_server.py roy_picking_lists_pdf.py`
+  - `python -m unittest tests.test_roy_picking_lists_pdf tests.test_roy_operations_dashboard tests.test_live_dashboard_auth`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python scripts\security_ci.py`
+  - `git diff --check`
+- Local endpoint smoke:
+  - `GET http://127.0.0.1:8790/api/operations/roy/picking-lists.pdf?refresh=1`
+  - HTTP `200`, content type `application/pdf`
+  - file header `%PDF-`
+  - generated `30` picking lists into one PDF
 
 ### 2026-05-27 (ROY unpaid-order cancellation automation staged)
 - Added standalone stale unpaid order cancellation code:

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -23,6 +23,7 @@ from roy_operations_dashboard import (
     resolve_roy_operations_settings,
     set_inbound_stock_order,
 )
+from roy_picking_lists_pdf import build_roy_picking_lists_filename, build_roy_picking_lists_pdf
 from reporting_core import load_project_settings
 
 
@@ -1035,6 +1036,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       </div>
       <div class="actions">
         <button id="soundToggleBtn" class="sound" type="button" aria-pressed="false">Zvuk vyp.</button>
+        <a class="button" href="/api/operations/roy/picking-lists.pdf?refresh=1">Vysklad. PDF</a>
         <button id="refreshBtn" class="primary" type="button">Refresh</button>
         <a class="button" href="/">Dashboardy</a>
       </div>
@@ -1784,6 +1786,19 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_download(self, body: bytes, *, content_type: str, filename: str, status: int = 200) -> None:
+        ascii_filename = "".join(ch if ch.isalnum() or ch in ".-_" else "_" for ch in filename) or "download.pdf"
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header(
+            "Content-Disposition",
+            f"attachment; filename=\"{ascii_filename}\"; filename*=UTF-8''{quote(filename)}",
+        )
+        self.end_headers()
+        self.wfile.write(body)
+
     def _send_json(self, payload: Dict[str, object], status: int = 200) -> None:
         self._send_bytes(
             json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8"),
@@ -1873,6 +1888,53 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 )
             except Exception as exc:
                 self._send_json({"error": f"Failed to load ROY operations data: {exc}"}, status=500)
+            return
+
+        if len(parts) == 4 and parts[0] == "api" and parts[1] == "operations" and parts[3] == "picking-lists.pdf":
+            project = parts[2]
+            if project not in projects:
+                self._send_text(f"Unknown project '{escape(project)}'.", content_type="text/plain; charset=utf-8", status=404)
+                return
+            if project != "roy":
+                self._send_text(
+                    f"Operations dashboard is not enabled for '{escape(project)}'.",
+                    content_type="text/plain; charset=utf-8",
+                    status=404,
+                )
+                return
+            try:
+                operations_settings = resolve_roy_operations_settings(load_project_settings(project))
+            except Exception as exc:
+                self._send_text(
+                    f"Failed to load ROY operations settings: {escape(str(exc))}",
+                    content_type="text/plain; charset=utf-8",
+                    status=500,
+                )
+                return
+            if not operations_settings["enabled"]:
+                self._send_text(
+                    f"Operations dashboard is not enabled for '{escape(project)}'.",
+                    content_type="text/plain; charset=utf-8",
+                    status=404,
+                )
+                return
+            force_refresh = (query.get("refresh", ["1"])[0] or "").strip().lower() not in {"0", "false", "no"}
+            try:
+                payload = get_cached_roy_operations_snapshot(
+                    project,
+                    report_payload=read_latest_dashboard_payload(project),
+                    force_refresh=force_refresh,
+                )
+                orders = ((payload.get("orders") or {}).get("orders") or [])
+                pdf = build_roy_picking_lists_pdf(orders)
+                filename = build_roy_picking_lists_filename(orders)
+                self._send_download(pdf, content_type="application/pdf", filename=filename)
+            except Exception as exc:
+                self._send_text(
+                    f"Failed to generate picking lists PDF: {escape(str(exc))}",
+                    content_type="text/plain; charset=utf-8",
+                    status=500,
+                )
             return
 
         if len(parts) == 4 and parts[0] == "api" and parts[1] == "production" and parts[3] == "live":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ gql[all]>=3.5.0
 python-dotenv>=1.0.0
 pandas>=2.0.0
 requests>=2.31.0
+reportlab>=4.2.0
 
 # Google Ads API integration
 google-ads>=24.1.0

--- a/roy_picking_lists_pdf.py
+++ b/roy_picking_lists_pdf.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""PDF picking-list generation for the ROY operations dashboard."""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
+
+
+ROOT_DIR = Path(__file__).resolve().parent
+
+
+def _text(value: Any, fallback: str = "-") -> str:
+    text = str(value or "").strip()
+    return text if text else fallback
+
+
+def _font_candidates() -> Sequence[Path]:
+    return (
+        ROOT_DIR / "assets" / "fonts" / "DejaVuSans.ttf",
+        Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"),
+        Path("/usr/share/fonts/dejavu/DejaVuSans.ttf"),
+        Path("C:/Windows/Fonts/arial.ttf"),
+        Path("C:/Windows/Fonts/DejaVuSans.ttf"),
+    )
+
+
+def _register_fonts() -> Dict[str, str]:
+    try:
+        from reportlab.pdfbase import pdfmetrics
+        from reportlab.pdfbase.ttfonts import TTFont
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise RuntimeError("PDF export requires reportlab. Install dependencies from requirements.txt.") from exc
+
+    for path in _font_candidates():
+        if path.exists():
+            pdfmetrics.registerFont(TTFont("BizniswebSans", str(path)))
+            return {"regular": "BizniswebSans", "bold": "BizniswebSans"}
+    return {"regular": "Helvetica", "bold": "Helvetica-Bold"}
+
+
+def _wrap_text(text: Any, max_width: float, font_name: str, font_size: int) -> List[str]:
+    from reportlab.pdfbase import pdfmetrics
+
+    words = _text(text, "").split()
+    if not words:
+        return [""]
+
+    lines: List[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if pdfmetrics.stringWidth(candidate, font_name, font_size) <= max_width:
+            current = candidate
+            continue
+        if current:
+            lines.append(current)
+        current = word
+    if current:
+        lines.append(current)
+    return lines or [""]
+
+
+def _draw_wrapped(
+    canvas: Any,
+    value: Any,
+    x: float,
+    y: float,
+    max_width: float,
+    font_name: str,
+    font_size: int,
+    *,
+    leading: float = 11,
+    max_lines: int = 3,
+) -> float:
+    lines = _wrap_text(value, max_width, font_name, font_size)
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines[-1] = lines[-1].rstrip(".") + "..."
+    canvas.setFont(font_name, font_size)
+    for line in lines:
+        canvas.drawString(x, y, line)
+        y -= leading
+    return y
+
+
+def _draw_meta_row(
+    canvas: Any,
+    label: str,
+    value: Any,
+    x: float,
+    y: float,
+    label_width: float,
+    fonts: Dict[str, str],
+) -> None:
+    canvas.setFont(fonts["bold"], 8)
+    canvas.drawString(x, y, label)
+    canvas.setFont(fonts["regular"], 9)
+    canvas.drawString(x + label_width, y, _text(value))
+
+
+def _draw_footer(canvas: Any, width: float, page_no: int, fonts: Dict[str, str]) -> None:
+    from reportlab.lib.units import mm
+
+    canvas.setFont(fonts["regular"], 8)
+    canvas.setFillColorRGB(0.35, 0.39, 0.35)
+    canvas.drawString(16 * mm, 10 * mm, f"ROY operations dashboard · strana {page_no}")
+    canvas.drawRightString(width - 16 * mm, 10 * mm, datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"))
+    canvas.setFillColorRGB(0, 0, 0)
+
+
+def _order_items(order: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [item for item in (order.get("items") or []) if isinstance(item, dict)]
+
+
+def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
+    try:
+        from reportlab.lib import colors
+        from reportlab.lib.pagesizes import A4
+        from reportlab.lib.units import mm
+        from reportlab.pdfgen import canvas as pdf_canvas
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise RuntimeError("PDF export requires reportlab. Install dependencies from requirements.txt.") from exc
+
+    fonts = _register_fonts()
+    order_rows = [order for order in orders if isinstance(order, dict)]
+
+    buffer = io.BytesIO()
+    canvas = pdf_canvas.Canvas(buffer, pagesize=A4, pageCompression=0)
+    width, height = A4
+    margin_x = 16 * mm
+    top_y = height - 16 * mm
+    page_no = 0
+
+    def new_page() -> None:
+        nonlocal page_no
+        if page_no:
+            _draw_footer(canvas, width, page_no, fonts)
+            canvas.showPage()
+        page_no += 1
+
+    if not order_rows:
+        new_page()
+        canvas.setFont(fonts["bold"], 18)
+        canvas.drawString(margin_x, top_y, "Vyskladňovacie listy")
+        canvas.setFont(fonts["regular"], 11)
+        canvas.drawString(margin_x, top_y - 18 * mm, "Aktuálne nie sú žiadne objednávky na odoslanie.")
+        _draw_footer(canvas, width, page_no, fonts)
+        canvas.save()
+        return buffer.getvalue()
+
+    for index, order in enumerate(order_rows, start=1):
+        new_page()
+        y = top_y
+
+        canvas.setFont(fonts["bold"], 18)
+        canvas.drawString(margin_x, y, "Vyskladňovací list")
+        canvas.setFont(fonts["regular"], 10)
+        canvas.drawRightString(width - margin_x, y + 1, f"{index}/{len(order_rows)}")
+        y -= 10 * mm
+
+        canvas.setStrokeColor(colors.HexColor("#18211b"))
+        canvas.setLineWidth(1.1)
+        canvas.line(margin_x, y, width - margin_x, y)
+        y -= 8 * mm
+
+        left_x = margin_x
+        right_x = width / 2 + 8 * mm
+        label_width = 26 * mm
+        _draw_meta_row(canvas, "Objednávka", order.get("order_num"), left_x, y, label_width, fonts)
+        _draw_meta_row(canvas, "Suma", order.get("sum"), right_x, y, label_width, fonts)
+        y -= 6 * mm
+        _draw_meta_row(canvas, "Dátum", order.get("purchase_at"), left_x, y, label_width, fonts)
+        _draw_meta_row(canvas, "Status", order.get("status"), right_x, y, label_width, fonts)
+        y -= 6 * mm
+        _draw_meta_row(canvas, "Platba", (order.get("payment") or {}).get("title"), left_x, y, label_width, fonts)
+        _draw_meta_row(canvas, "Doprava", (order.get("shipping") or {}).get("title"), right_x, y, label_width, fonts)
+        y -= 10 * mm
+
+        table_x = margin_x
+        col_qty = 16 * mm
+        col_product = 92 * mm
+        col_code = 30 * mm
+        col_ean = 32 * mm
+        table_width = col_qty + col_product + col_code + col_ean
+
+        def draw_header() -> None:
+            nonlocal y
+            canvas.setFillColor(colors.HexColor("#f3f5f1"))
+            canvas.rect(table_x, y - 5 * mm, table_width, 7 * mm, fill=1, stroke=0)
+            canvas.setFillColor(colors.black)
+            canvas.setFont(fonts["bold"], 8)
+            canvas.drawString(table_x + 2 * mm, y - 2 * mm, "Ks")
+            canvas.drawString(table_x + col_qty + 2 * mm, y - 2 * mm, "Produkt")
+            canvas.drawString(table_x + col_qty + col_product + 2 * mm, y - 2 * mm, "Import kód")
+            canvas.drawString(table_x + col_qty + col_product + col_code + 2 * mm, y - 2 * mm, "EAN")
+            y -= 9 * mm
+
+        draw_header()
+        canvas.setStrokeColor(colors.HexColor("#d9ded5"))
+        for item in _order_items(order):
+            if y < 34 * mm:
+                _draw_footer(canvas, width, page_no, fonts)
+                canvas.showPage()
+                page_no += 1
+                y = top_y
+                canvas.setFont(fonts["bold"], 14)
+                canvas.drawString(margin_x, y, f"Vyskladňovací list · {_text(order.get('order_num'))}")
+                y -= 10 * mm
+                draw_header()
+
+            product_lines = _wrap_text(item.get("label"), col_product - 4 * mm, fonts["regular"], 8)
+            row_height = max(8 * mm, (len(product_lines[:3]) * 4.2 * mm) + 4 * mm)
+            canvas.line(table_x, y + 2 * mm, table_x + table_width, y + 2 * mm)
+            canvas.setFont(fonts["bold"], 9)
+            canvas.drawString(table_x + 2 * mm, y - 2 * mm, _text(item.get("quantity"), "0"))
+            _draw_wrapped(canvas, item.get("label"), table_x + col_qty + 2 * mm, y - 1.5 * mm, col_product - 4 * mm, fonts["regular"], 8, leading=4.2 * mm)
+            canvas.setFont(fonts["regular"], 8)
+            canvas.drawString(table_x + col_qty + col_product + 2 * mm, y - 2 * mm, _text(item.get("import_code")))
+            canvas.drawString(table_x + col_qty + col_product + col_code + 2 * mm, y - 2 * mm, _text(item.get("ean")))
+            y -= row_height
+
+        y = max(y - 8 * mm, 24 * mm)
+        canvas.setFont(fonts["regular"], 9)
+        canvas.drawString(margin_x, y, "Skontroloval: ____________________________")
+        canvas.drawRightString(width - margin_x, y, "Dátum: __________________")
+
+    _draw_footer(canvas, width, page_no, fonts)
+    canvas.save()
+    return buffer.getvalue()
+
+
+def build_roy_picking_lists_filename(orders: Iterable[Dict[str, Any]]) -> str:
+    order_rows = [order for order in orders if isinstance(order, dict)]
+    stamp = datetime.now().strftime("%Y%m%d-%H%M")
+    return f"roy-vyskladnovacie-listy-{len(order_rows)}-{stamp}.pdf"

--- a/scripts/security_ci.py
+++ b/scripts/security_ci.py
@@ -216,6 +216,7 @@ def main() -> int:
             "generate_invoices.py",
             "unpaid_order_cancellation.py",
             "unpaid_order_cancellation_runner.py",
+            "roy_picking_lists_pdf.py",
             "scripts/observability_snapshot.py",
             "scripts/scaffold_client.py",
             "scripts/import_product_expenses_excel.py",

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -218,6 +218,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("soundToggleBtn", html)
         self.assertIn("playNewOrderSound", html)
         self.assertIn("notifyAboutNewFulfillableOrders", html)
+        self.assertIn("Vysklad. PDF", html)
+        self.assertIn("/api/operations/roy/picking-lists.pdf", html)
         self.assertIn("seenFulfillableOrderKeys", html)
         self.assertIn("nová objednávka na odoslanie", html)
         self.assertIn("replace(/[\"\\\\]/g, '\\\\$&')", html)

--- a/tests/test_roy_picking_lists_pdf.py
+++ b/tests/test_roy_picking_lists_pdf.py
@@ -1,0 +1,49 @@
+import unittest
+
+from roy_picking_lists_pdf import build_roy_picking_lists_filename, build_roy_picking_lists_pdf
+
+
+class RoyPickingListsPdfTests(unittest.TestCase):
+    def test_builds_single_pdf_for_fulfillable_orders(self) -> None:
+        orders = [
+            {
+                "order_num": "2677009999",
+                "purchase_at": "2026-05-27 10:00:00",
+                "status": "Platba online - zaplaten\u00e9",
+                "sum": "120,00 EUR",
+                "payment": {"title": "Okam\u017eit\u00e1 platba online"},
+                "shipping": {"title": "Packeta"},
+                "items": [
+                    {
+                        "label": "Fotopasca Wachman Rio 4G",
+                        "quantity": 1,
+                        "import_code": "F_1472",
+                        "ean": "",
+                    },
+                    {
+                        "label": "Univerz\u00e1lne sol\u00e1rne nap\u00e1janie BL8000 pre fotopascu",
+                        "quantity": 1,
+                        "import_code": "F_486",
+                        "ean": "",
+                    },
+                ],
+            }
+        ]
+
+        pdf = build_roy_picking_lists_pdf(orders)
+        filename = build_roy_picking_lists_filename(orders)
+
+        self.assertTrue(pdf.startswith(b"%PDF-"))
+        self.assertGreater(len(pdf), 1500)
+        self.assertTrue(filename.startswith("roy-vyskladnovacie-listy-1-"))
+        self.assertTrue(filename.endswith(".pdf"))
+
+    def test_empty_pdf_is_still_downloadable(self) -> None:
+        pdf = build_roy_picking_lists_pdf([])
+
+        self.assertTrue(pdf.startswith(b"%PDF-"))
+        self.assertGreater(len(pdf), 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- Added one-click `Vysklad. PDF` download in the ROY operations dashboard.
- Added `/api/operations/roy/picking-lists.pdf?refresh=1`, generating one combined PDF from current fulfillable orders.
- Added `reportlab` plus DejaVu fonts in the Docker image so Slovak/Czech diacritics render in PDFs.
- Added PDF generator tests and CI coverage.

## Validation
- python -m py_compile live_dashboard_server.py roy_picking_lists_pdf.py
- python -m unittest tests.test_roy_picking_lists_pdf tests.test_roy_operations_dashboard tests.test_live_dashboard_auth
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- python scripts\reporting_qa_smoke.py
- python scripts\security_ci.py
- git diff --check
- Local server smoke: GET /api/operations/roy/picking-lists.pdf?refresh=1 returned application/pdf, %PDF- header, 167256 bytes, 30 picking lists

## Note
The example PDF path from the prompt was not present on disk, so this implements a clean dashboard-native picking list layout from the same order rows the ROY operations dashboard already uses.
