### PR TITLE
Add ROY picking-list notes and barcode

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3298,3 +3298,23 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - HTML table header is `Hrubý zisk/strata` and no longer contains `Zisk s fixom`
 - Next exact step:
   - monitor the next scheduled ROY report once and confirm the loss-product row count remains gross-profit-only
+
+### 2026-05-27 (ROY picking-list PDF note, barcode, VO signal)
+- Branch: `codex/roy-picking-list-barcode-notes`
+- Change:
+  - ROY operations order query now fetches customer note, internal note, customer contact, invoice/delivery address, item unit prices, product final prices, and tax rate for picking-list PDF output
+  - picking-list PDF now renders an order-number Code128 barcode in the top-right, prints the customer note prominently, prints invoice/delivery address blocks, and marks likely wholesale orders with `VEĽKOOBCHOD / VO CENY`
+  - wholesale order marking is configured for ROY as: company customer plus at least one order item priced at least 10% below the current product final retail net price
+- Local verification:
+  - `python -m py_compile roy_operations_dashboard.py roy_picking_lists_pdf.py live_dashboard_server.py`
+  - `python -m unittest tests.test_roy_picking_lists_pdf tests.test_roy_operations_dashboard`
+  - `python -m json.tool projects\roy\settings.json`
+  - direct BiznisWeb GraphQL smoke for ROY operations query: scanned `30`, fulfillable `10`, note/address/wholesale fields present
+  - full ROY scan smoke: scanned `330`, pages `11`, fulfillable `27`, current wholesale-marked fulfillable orders `0`
+  - generated local sample: `data/roy-picking-list-layout-smoke.pdf`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python scripts\security_ci.py`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, rebuild ECR image, deploy ROY App Runner dashboard, then verify `/api/operations/roy/picking-lists.pdf?refresh=1` on production

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -183,7 +183,12 @@
     "scan_min_pages": 8,
     "stop_after_empty_fulfillable_pages": 3,
     "cache_ttl_seconds": 60,
-    "auto_refresh_seconds": 90
+    "auto_refresh_seconds": 90,
+    "wholesale_detection": {
+      "enabled": true,
+      "discount_threshold_pct": 10,
+      "require_company_customer": true
+    }
   },
   "inventory_model": {
     "enabled": true,

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -34,6 +34,8 @@ DEFAULT_SCAN_MIN_PAGES = 8
 DEFAULT_STOP_AFTER_EMPTY_FULFILLABLE_PAGES = 3
 DEFAULT_CACHE_TTL_SECONDS = 60
 DEFAULT_AUTO_REFRESH_SECONDS = 90
+DEFAULT_WHOLESALE_DETECTION_DISCOUNT_THRESHOLD_PCT = 10.0
+DEFAULT_WHOLESALE_DETECTION_REQUIRE_COMPANY = True
 
 
 ROY_OPERATIONS_ORDER_QUERY = gql(
@@ -45,10 +47,68 @@ query GetRoyOperationsOrders($params: OrderParams) {
       order_num
       pur_date
       last_change
+      note
+      internal_note
+      source
       status {
         id
         name
         color
+      }
+      customer {
+        ... on Company {
+          __typename
+          company_name
+          company_id
+          vat_id
+          vat_id2
+          name
+          surname
+          phone
+          email
+        }
+        ... on Person {
+          __typename
+          name
+          surname
+          phone
+          email
+        }
+        ... on UnauthenticatedEmail {
+          __typename
+          name
+          surname
+          phone
+          email
+        }
+      }
+      invoice_address {
+        company_name
+        name
+        surname
+        street
+        descriptive_number
+        orientation_number
+        city
+        zip
+        state
+        country
+        email
+        phone
+      }
+      delivery_address {
+        company_name
+        name
+        surname
+        street
+        descriptive_number
+        orientation_number
+        city
+        zip
+        state
+        country
+        email
+        phone
       }
       price_elements {
         type
@@ -57,7 +117,9 @@ query GetRoyOperationsOrders($params: OrderParams) {
         reference_id
         price {
           value
+          raw_value
           formatted
+          is_net_price
         }
       }
       items {
@@ -66,6 +128,29 @@ query GetRoyOperationsOrders($params: OrderParams) {
         import_code
         warehouse_number
         quantity
+        tax_rate
+        price {
+          value
+          raw_value
+          formatted
+          is_net_price
+        }
+        sum {
+          value
+          raw_value
+          formatted
+          is_net_price
+        }
+        product {
+          title
+          import_code
+          final_price {
+            value
+            raw_value
+            formatted
+            is_net_price
+          }
+        }
       }
       sum {
         value
@@ -367,6 +452,28 @@ def _as_int(value: Any, default: int, *, minimum: int = 0) -> int:
     return max(minimum, parsed)
 
 
+def _as_float(value: Any, default: float, *, minimum: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, parsed)
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "ano"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "nie"}:
+            return False
+    return bool(value)
+
+
 def _to_float(value: Any) -> float:
     try:
         return float(value or 0.0)
@@ -395,6 +502,7 @@ def resolve_roy_operations_settings(project_settings: Dict[str, Any]) -> Dict[st
     raw = project_settings.get("operations_dashboard") or {}
     component_rules = project_settings.get("product_component_expansion_rules") or []
     component_rules = component_rules if isinstance(component_rules, list) else []
+    wholesale_raw = raw.get("wholesale_detection") if isinstance(raw.get("wholesale_detection"), dict) else {}
     paid_statuses = _as_list(raw.get("paid_statuses"), DEFAULT_PAID_STATUSES)
     cod_statuses = _as_list(raw.get("cod_statuses"), DEFAULT_COD_STATUSES)
     cod_payment_patterns = _as_list(raw.get("cod_payment_patterns"), DEFAULT_COD_PAYMENT_PATTERNS)
@@ -431,6 +539,18 @@ def resolve_roy_operations_settings(project_settings: Dict[str, Any]) -> Dict[st
         "cache_ttl_seconds": _as_int(raw.get("cache_ttl_seconds"), DEFAULT_CACHE_TTL_SECONDS, minimum=1),
         "auto_refresh_seconds": _as_int(raw.get("auto_refresh_seconds"), DEFAULT_AUTO_REFRESH_SECONDS, minimum=30),
         "product_component_expansion_rules": component_rules,
+        "wholesale_detection": {
+            "enabled": _as_bool(wholesale_raw.get("enabled"), True),
+            "discount_threshold_pct": _as_float(
+                wholesale_raw.get("discount_threshold_pct"),
+                DEFAULT_WHOLESALE_DETECTION_DISCOUNT_THRESHOLD_PCT,
+                minimum=0.0,
+            ),
+            "require_company_customer": _as_bool(
+                wholesale_raw.get("require_company_customer"),
+                DEFAULT_WHOLESALE_DETECTION_REQUIRE_COMPANY,
+            ),
+        },
     }
 
 
@@ -599,9 +719,146 @@ def _order_items(order: Dict[str, Any], settings: Dict[str, Any]) -> List[Dict[s
     return _merge_order_items(items)
 
 
+def _join_name(*values: Any) -> str:
+    return " ".join(str(value or "").strip() for value in values if str(value or "").strip()).strip()
+
+
+def _customer_info(order: Dict[str, Any]) -> Dict[str, Any]:
+    customer = order.get("customer") if isinstance(order.get("customer"), dict) else {}
+    customer_type = str(customer.get("__typename") or "").strip()
+    company_name = str(customer.get("company_name") or "").strip()
+    person_name = _join_name(customer.get("name"), customer.get("surname"))
+    display_name = company_name or person_name
+    return {
+        "type": customer_type,
+        "company_name": company_name,
+        "company_id": str(customer.get("company_id") or "").strip(),
+        "vat_id": str(customer.get("vat_id") or customer.get("vat_id2") or "").strip(),
+        "display_name": display_name,
+        "phone": str(customer.get("phone") or "").strip(),
+        "email": str(customer.get("email") or "").strip(),
+        "is_company": customer_type == "Company" or bool(company_name),
+    }
+
+
+def _address_info(address: Any, fallback_customer: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    address = address if isinstance(address, dict) else {}
+    fallback_customer = fallback_customer or {}
+    company_name = str(address.get("company_name") or "").strip()
+    person_name = _join_name(address.get("name"), address.get("surname"))
+    display_name = company_name or person_name or str(fallback_customer.get("display_name") or "").strip()
+    street_number = _join_name(address.get("descriptive_number"), address.get("orientation_number"))
+    street = _join_name(address.get("street"), street_number)
+    city = _join_name(address.get("zip"), address.get("city"))
+    region = _join_name(city, address.get("state"))
+    country = str(address.get("country") or "").strip()
+    phone = str(address.get("phone") or fallback_customer.get("phone") or "").strip()
+    email = str(address.get("email") or fallback_customer.get("email") or "").strip()
+    lines = [line for line in (display_name, street, _join_name(region, country), phone, email) if line]
+    return {
+        "display_name": display_name,
+        "street": street,
+        "city": city,
+        "state": str(address.get("state") or "").strip(),
+        "country": country,
+        "phone": phone,
+        "email": email,
+        "lines": lines,
+    }
+
+
+def _price_number(price: Any) -> Optional[float]:
+    if not isinstance(price, dict):
+        return None
+    for key in ("raw_value", "value"):
+        parsed = _optional_float(price.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _item_tax_rate(item: Dict[str, Any]) -> float:
+    return _to_float(item.get("tax_rate"))
+
+
+def _price_as_net(price: Any, tax_rate: float) -> Optional[float]:
+    value = _price_number(price)
+    if value is None:
+        return None
+    if isinstance(price, dict) and bool(price.get("is_net_price")):
+        return value
+    return value / (1.0 + (tax_rate / 100.0)) if tax_rate > 0 else value
+
+
+def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], settings: Dict[str, Any]) -> Dict[str, Any]:
+    detection = settings.get("wholesale_detection") if isinstance(settings.get("wholesale_detection"), dict) else {}
+    if not detection.get("enabled", True):
+        return {"is_wholesale": False, "reason": "disabled"}
+
+    require_company = bool(detection.get("require_company_customer", DEFAULT_WHOLESALE_DETECTION_REQUIRE_COMPANY))
+    threshold_pct = _to_float(detection.get("discount_threshold_pct"))
+    if threshold_pct <= 0:
+        threshold_pct = DEFAULT_WHOLESALE_DETECTION_DISCOUNT_THRESHOLD_PCT
+    threshold_ratio = max(0.0, 1.0 - (threshold_pct / 100.0))
+
+    priced_lines = 0
+    discounted_lines = 0
+    max_discount_pct = 0.0
+    examples: List[Dict[str, Any]] = []
+    for item in order.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        item_price = _price_as_net(item.get("price"), _item_tax_rate(item))
+        product = item.get("product") if isinstance(item.get("product"), dict) else {}
+        retail_price = _price_as_net(product.get("final_price"), _item_tax_rate(item))
+        if item_price is None or retail_price is None or item_price <= 0 or retail_price <= 0:
+            continue
+        priced_lines += 1
+        ratio = item_price / retail_price
+        if ratio <= threshold_ratio:
+            discounted_lines += 1
+            discount_pct = (1.0 - ratio) * 100.0
+            max_discount_pct = max(max_discount_pct, discount_pct)
+            if len(examples) < 3:
+                examples.append(
+                    {
+                        "import_code": str(item.get("import_code") or "").strip(),
+                        "label": str(item.get("item_label") or "").strip(),
+                        "order_unit_net": round(item_price, 2),
+                        "retail_unit_net": round(retail_price, 2),
+                        "discount_pct": round(discount_pct, 1),
+                    }
+                )
+
+    is_company = bool(customer.get("is_company"))
+    is_wholesale = discounted_lines > 0 and (is_company or not require_company)
+    reason = ""
+    if is_wholesale:
+        reason = f"company customer + {discounted_lines}/{priced_lines} discounted line(s) vs current retail final price"
+    elif discounted_lines > 0:
+        reason = f"{discounted_lines}/{priced_lines} discounted line(s), but customer is not Company"
+    elif is_company:
+        reason = "company customer, no wholesale price discount detected"
+    else:
+        reason = "no wholesale price signal"
+
+    return {
+        "is_wholesale": bool(is_wholesale),
+        "customer_is_company": is_company,
+        "discounted_lines": discounted_lines,
+        "priced_lines": priced_lines,
+        "max_discount_pct": round(max_discount_pct, 1),
+        "threshold_pct": round(threshold_pct, 1),
+        "reason": reason,
+        "examples": examples,
+    }
+
+
 def _public_order_row(order: Dict[str, Any], settings: Dict[str, Any]) -> Dict[str, Any]:
     payment = _price_element_info(order, "payment")
     shipping = _price_element_info(order, "shipping")
+    customer = _customer_info(order)
+    wholesale_pricing = _detect_wholesale_pricing(order, customer, settings)
     fulfillable, reason = _is_fulfillable_order(order, settings)
     is_pickup = _is_personal_pickup(order, settings)
     status_name = _status_name(order)
@@ -616,6 +873,13 @@ def _public_order_row(order: Dict[str, Any], settings: Dict[str, Any]) -> Dict[s
         "order_num": order.get("order_num"),
         "purchase_at": order.get("pur_date"),
         "last_change": order.get("last_change"),
+        "source": str(order.get("source") or "").strip(),
+        "customer": customer,
+        "invoice_address": _address_info(order.get("invoice_address"), customer),
+        "delivery_address": _address_info(order.get("delivery_address"), customer),
+        "customer_note": str(order.get("note") or "").strip(),
+        "internal_note": str(order.get("internal_note") or "").strip(),
+        "wholesale_pricing": wholesale_pricing,
         "status": status_name,
         "status_id": _status_id(order),
         "sum": (order.get("sum") or {}).get("formatted"),

--- a/roy_picking_lists_pdf.py
+++ b/roy_picking_lists_pdf.py
@@ -101,6 +101,144 @@ def _draw_meta_row(
     canvas.drawString(x + label_width, y, _text(value))
 
 
+def _draw_badge(canvas: Any, label: str, x: float, y: float, fonts: Dict[str, str], colors: Any) -> float:
+    from reportlab.lib.units import mm
+    from reportlab.pdfbase import pdfmetrics
+
+    text_width = pdfmetrics.stringWidth(label, fonts["bold"], 8)
+    badge_width = text_width + 8 * mm
+    badge_height = 7 * mm
+    canvas.setFillColor(colors.HexColor("#f97316"))
+    canvas.roundRect(x, y - badge_height + 1.5 * mm, badge_width, badge_height, 2 * mm, fill=1, stroke=0)
+    canvas.setFillColor(colors.white)
+    canvas.setFont(fonts["bold"], 8)
+    canvas.drawString(x + 4 * mm, y - 3.2 * mm, label)
+    canvas.setFillColor(colors.black)
+    return badge_width
+
+
+def _draw_order_barcode(canvas: Any, order_num: Any, x_right: float, y_top: float, fonts: Dict[str, str]) -> None:
+    from reportlab.graphics.barcode.code128 import Code128
+    from reportlab.lib.units import mm
+
+    order_text = _text(order_num, "")
+    if not order_text:
+        return
+
+    max_width = 58 * mm
+    bar_width = 0.32 * mm
+    barcode = Code128(order_text, barWidth=bar_width, barHeight=12 * mm, humanReadable=False)
+    if barcode.width > max_width:
+        barcode = Code128(
+            order_text,
+            barWidth=bar_width * (max_width / barcode.width),
+            barHeight=12 * mm,
+            humanReadable=False,
+        )
+
+    x = x_right - barcode.width
+    y = y_top - barcode.height
+    barcode.drawOn(canvas, x, y)
+    canvas.setFont(fonts["bold"], 8)
+    canvas.drawCentredString(x + barcode.width / 2, y - 3.4 * mm, order_text)
+
+
+def _draw_labeled_box(
+    canvas: Any,
+    title: str,
+    value: Any,
+    x: float,
+    y_top: float,
+    width: float,
+    fonts: Dict[str, str],
+    colors: Any,
+    *,
+    fill: str = "#fff7ed",
+    stroke: str = "#fed7aa",
+    max_lines: int = 4,
+) -> float:
+    from reportlab.lib.units import mm
+
+    text = _text(value, "Bez poznámky")
+    lines = _wrap_text(text, width - 8 * mm, fonts["regular"], 9)
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines[-1] = lines[-1].rstrip(".") + "..."
+    height = 10 * mm + max(1, len(lines)) * 4.5 * mm
+    bottom = y_top - height
+
+    canvas.setFillColor(colors.HexColor(fill))
+    canvas.setStrokeColor(colors.HexColor(stroke))
+    canvas.roundRect(x, bottom, width, height, 2.5 * mm, fill=1, stroke=1)
+    canvas.setFillColor(colors.HexColor("#7c2d12"))
+    canvas.setFont(fonts["bold"], 8)
+    canvas.drawString(x + 4 * mm, y_top - 5 * mm, title)
+    canvas.setFillColor(colors.black)
+    canvas.setFont(fonts["regular"], 9)
+    text_y = y_top - 10 * mm
+    for line in lines:
+        canvas.drawString(x + 4 * mm, text_y, line)
+        text_y -= 4.5 * mm
+    return bottom - 4 * mm
+
+
+def _address_lines(address: Any) -> List[str]:
+    if not isinstance(address, dict):
+        return []
+    lines = address.get("lines")
+    if isinstance(lines, list):
+        return [str(line).strip() for line in lines if str(line or "").strip()]
+
+    fallback_lines = [
+        address.get("display_name"),
+        address.get("street"),
+        " ".join(str(part or "").strip() for part in (address.get("city"), address.get("country")) if str(part or "").strip()),
+        address.get("phone"),
+        address.get("email"),
+    ]
+    return [str(line).strip() for line in fallback_lines if str(line or "").strip()]
+
+
+def _draw_address_block(
+    canvas: Any,
+    title: str,
+    lines: List[str],
+    x: float,
+    y_top: float,
+    width: float,
+    height: float,
+    fonts: Dict[str, str],
+    colors: Any,
+) -> None:
+    from reportlab.lib.units import mm
+
+    canvas.setFillColor(colors.HexColor("#f8fafc"))
+    canvas.setStrokeColor(colors.HexColor("#d8e0d4"))
+    canvas.roundRect(x, y_top - height, width, height, 2 * mm, fill=1, stroke=1)
+    canvas.setFillColor(colors.HexColor("#334155"))
+    canvas.setFont(fonts["bold"], 8)
+    canvas.drawString(x + 3 * mm, y_top - 4.5 * mm, title)
+    canvas.setFillColor(colors.black)
+    y = y_top - 9 * mm
+    for line in (lines or ["-"])[:5]:
+        y = _draw_wrapped(canvas, line, x + 3 * mm, y, width - 6 * mm, fonts["regular"], 8, leading=3.8 * mm, max_lines=1)
+
+
+def _address_block_height(lines: List[str]) -> float:
+    from reportlab.lib.units import mm
+
+    return 10 * mm + max(2, min(len(lines), 5)) * 3.8 * mm
+
+
+def _wholesale_info(order: Dict[str, Any]) -> Dict[str, Any]:
+    info = order.get("wholesale_pricing") if isinstance(order.get("wholesale_pricing"), dict) else {}
+    return {
+        "is_wholesale": bool(info.get("is_wholesale")),
+        "max_discount_pct": info.get("max_discount_pct"),
+        "reason": str(info.get("reason") or "").strip(),
+    }
+
+
 def _draw_footer(canvas: Any, width: float, page_no: int, fonts: Dict[str, str]) -> None:
     from reportlab.lib.units import mm
 
@@ -154,12 +292,17 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
     for index, order in enumerate(order_rows, start=1):
         new_page()
         y = top_y
+        wholesale = _wholesale_info(order)
 
         canvas.setFont(fonts["bold"], 18)
         canvas.drawString(margin_x, y, "Vyskladňovací list")
-        canvas.setFont(fonts["regular"], 10)
-        canvas.drawRightString(width - margin_x, y + 1, f"{index}/{len(order_rows)}")
-        y -= 10 * mm
+        title_width = canvas.stringWidth("Vyskladňovací list", fonts["bold"], 18)
+        if wholesale["is_wholesale"]:
+            _draw_badge(canvas, "VEĽKOOBCHOD / VO CENY", margin_x + title_width + 8 * mm, y + 1 * mm, fonts, colors)
+        _draw_order_barcode(canvas, order.get("order_num"), width - margin_x, y + 4 * mm, fonts)
+        canvas.setFont(fonts["regular"], 8)
+        canvas.drawRightString(width - margin_x, y - 16 * mm, f"strana objednávok {index}/{len(order_rows)}")
+        y -= 20 * mm
 
         canvas.setStrokeColor(colors.HexColor("#18211b"))
         canvas.setLineWidth(1.1)
@@ -168,7 +311,9 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
 
         left_x = margin_x
         right_x = width / 2 + 8 * mm
-        label_width = 26 * mm
+        label_width = 27 * mm
+        customer = order.get("customer") if isinstance(order.get("customer"), dict) else {}
+        customer_name = customer.get("display_name") or customer.get("company_name")
         _draw_meta_row(canvas, "Objednávka", order.get("order_num"), left_x, y, label_width, fonts)
         _draw_meta_row(canvas, "Suma", order.get("sum"), right_x, y, label_width, fonts)
         y -= 6 * mm
@@ -177,7 +322,61 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
         y -= 6 * mm
         _draw_meta_row(canvas, "Platba", (order.get("payment") or {}).get("title"), left_x, y, label_width, fonts)
         _draw_meta_row(canvas, "Doprava", (order.get("shipping") or {}).get("title"), right_x, y, label_width, fonts)
+        y -= 6 * mm
+        _draw_meta_row(canvas, "Zákazník", customer_name, left_x, y, label_width, fonts)
+        if wholesale["is_wholesale"]:
+            wholesale_label = "áno"
+            if wholesale.get("max_discount_pct"):
+                wholesale_label = f"áno, zľava do {wholesale['max_discount_pct']}%"
+            _draw_meta_row(canvas, "VO ceny", wholesale_label, right_x, y, label_width, fonts)
+        else:
+            _draw_meta_row(canvas, "VO ceny", "nie", right_x, y, label_width, fonts)
         y -= 10 * mm
+
+        y = _draw_labeled_box(
+            canvas,
+            "Poznámka klienta",
+            order.get("customer_note") or "Bez poznámky",
+            margin_x,
+            y,
+            width - 2 * margin_x,
+            fonts,
+            colors,
+        )
+        if order.get("internal_note"):
+            y = _draw_labeled_box(
+                canvas,
+                "Interná poznámka",
+                order.get("internal_note"),
+                margin_x,
+                y,
+                width - 2 * margin_x,
+                fonts,
+                colors,
+                fill="#f8fafc",
+                stroke="#cbd5e1",
+                max_lines=3,
+            )
+
+        invoice_lines = _address_lines(order.get("invoice_address"))
+        delivery_lines = _address_lines(order.get("delivery_address")) or invoice_lines
+        if invoice_lines or delivery_lines:
+            gap = 6 * mm
+            block_width = (width - 2 * margin_x - gap) / 2
+            block_height = max(_address_block_height(invoice_lines), _address_block_height(delivery_lines))
+            _draw_address_block(canvas, "Fakturačná adresa", invoice_lines, margin_x, y, block_width, block_height, fonts, colors)
+            _draw_address_block(
+                canvas,
+                "Doručovacia adresa",
+                delivery_lines,
+                margin_x + block_width + gap,
+                y,
+                block_width,
+                block_height,
+                fonts,
+                colors,
+            )
+            y -= block_height + 7 * mm
 
         table_x = margin_x
         col_qty = 16 * mm
@@ -208,7 +407,8 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
                 y = top_y
                 canvas.setFont(fonts["bold"], 14)
                 canvas.drawString(margin_x, y, f"Vyskladňovací list · {_text(order.get('order_num'))}")
-                y -= 10 * mm
+                _draw_order_barcode(canvas, order.get("order_num"), width - margin_x, y + 3 * mm, fonts)
+                y -= 16 * mm
                 draw_header()
 
             product_lines = _wrap_text(item.get("label"), col_product - 4 * mm, fonts["regular"], 8)
@@ -216,7 +416,16 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
             canvas.line(table_x, y + 2 * mm, table_x + table_width, y + 2 * mm)
             canvas.setFont(fonts["bold"], 9)
             canvas.drawString(table_x + 2 * mm, y - 2 * mm, _text(item.get("quantity"), "0"))
-            _draw_wrapped(canvas, item.get("label"), table_x + col_qty + 2 * mm, y - 1.5 * mm, col_product - 4 * mm, fonts["regular"], 8, leading=4.2 * mm)
+            _draw_wrapped(
+                canvas,
+                item.get("label"),
+                table_x + col_qty + 2 * mm,
+                y - 1.5 * mm,
+                col_product - 4 * mm,
+                fonts["regular"],
+                8,
+                leading=4.2 * mm,
+            )
             canvas.setFont(fonts["regular"], 8)
             canvas.drawString(table_x + col_qty + col_product + 2 * mm, y - 2 * mm, _text(item.get("import_code")))
             canvas.drawString(table_x + col_qty + col_product + col_code + 2 * mm, y - 2 * mm, _text(item.get("ean")))

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -80,6 +80,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertTrue(operations["enabled"])
         self.assertEqual(90, operations["auto_refresh_seconds"])
         self.assertEqual(4, operations["shipped_status_id"])
+        self.assertEqual(10, operations["wholesale_detection"]["discount_threshold_pct"])
+        self.assertTrue(operations["wholesale_detection"]["require_company_customer"])
         self.assertIn("Čaká na vybavenie", operations["cod_statuses"])
         self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["wachman"])
         self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["roy"])
@@ -111,6 +113,61 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(["R-1", "R-2"], [row["order_num"] for row in snapshot["orders"]])
         self.assertEqual(["R-2"], [row["order_num"] for row in snapshot["personal_pickups"]])
         self.assertTrue(snapshot["personal_pickups"][0]["pickup_action_allowed"])
+
+    def test_snapshot_exposes_notes_addresses_and_wholesale_signal_for_pdf(self) -> None:
+        settings = make_settings()
+        paid_payment = price_element("payment", "Okamžitá platba online", "18")
+        packeta_shipping = price_element("shipping", "Packeta - výdajné miesto", "9")
+        order = make_order("R-VO", settings["paid_statuses"][0], paid_payment, packeta_shipping)
+        order["note"] = "Prosime pribalit darcek."
+        order["customer"] = {
+            "__typename": "Company",
+            "company_name": "B2B Partner s.r.o.",
+            "company_id": "12345678",
+            "vat_id": "SK1234567890",
+            "phone": "+421900000000",
+            "email": "b2b@example.com",
+        }
+        order["invoice_address"] = {
+            "company_name": "B2B Partner s.r.o.",
+            "street": "Hlavna",
+            "descriptive_number": "12",
+            "city": "Bratislava",
+            "zip": "81101",
+            "country": "Slovensko",
+        }
+        order["delivery_address"] = {
+            "company_name": "Sklad B2B",
+            "street": "Skladova",
+            "descriptive_number": "5",
+            "city": "Trnava",
+            "zip": "91701",
+            "country": "Slovensko",
+        }
+        order["items"][0].update(
+            {
+                "tax_rate": 23,
+                "price": {"raw_value": 80.0, "value": 80.0, "formatted": "80,00 €", "is_net_price": True},
+                "product": {
+                    "final_price": {
+                        "raw_value": 123.0,
+                        "value": 123.0,
+                        "formatted": "123,00 €",
+                        "is_net_price": False,
+                    }
+                },
+            }
+        )
+
+        snapshot = build_roy_orders_snapshot(project="roy", orders=[order], settings=settings)
+        row = snapshot["orders"][0]
+
+        self.assertEqual("Prosime pribalit darcek.", row["customer_note"])
+        self.assertEqual("B2B Partner s.r.o.", row["customer"]["display_name"])
+        self.assertIn("B2B Partner s.r.o.", row["invoice_address"]["lines"])
+        self.assertIn("Sklad B2B", row["delivery_address"]["lines"])
+        self.assertTrue(row["wholesale_pricing"]["is_wholesale"])
+        self.assertEqual(20.0, row["wholesale_pricing"]["max_discount_pct"])
 
     def test_snapshot_expands_bundle_order_items_to_pickable_components(self) -> None:
         project_settings = json.loads((ROOT_DIR / "projects" / "roy" / "settings.json").read_text(encoding="utf-8"))

--- a/tests/test_roy_picking_lists_pdf.py
+++ b/tests/test_roy_picking_lists_pdf.py
@@ -1,4 +1,5 @@
 import unittest
+from io import BytesIO
 
 from roy_picking_lists_pdf import build_roy_picking_lists_filename, build_roy_picking_lists_pdf
 
@@ -13,6 +14,11 @@ class RoyPickingListsPdfTests(unittest.TestCase):
                 "sum": "120,00 EUR",
                 "payment": {"title": "Okam\u017eit\u00e1 platba online"},
                 "shipping": {"title": "Packeta"},
+                "customer": {"display_name": "B2B Partner s.r.o."},
+                "customer_note": "Objednavku pripravit k osobnemu odberu.",
+                "invoice_address": {"lines": ["B2B Partner s.r.o.", "Hlavna 12", "81101 Bratislava Slovensko"]},
+                "delivery_address": {"lines": ["Sklad B2B", "Skladova 5", "91701 Trnava Slovensko"]},
+                "wholesale_pricing": {"is_wholesale": True, "max_discount_pct": 20.0},
                 "items": [
                     {
                         "label": "Fotopasca Wachman Rio 4G",
@@ -37,6 +43,39 @@ class RoyPickingListsPdfTests(unittest.TestCase):
         self.assertGreater(len(pdf), 1500)
         self.assertTrue(filename.startswith("roy-vyskladnovacie-listy-1-"))
         self.assertTrue(filename.endswith(".pdf"))
+
+    def test_pdf_text_contains_customer_note_wholesale_badge_and_order_number(self) -> None:
+        try:
+            from pypdf import PdfReader
+        except ImportError:
+            self.skipTest("pypdf is only used for local PDF text verification")
+
+        pdf = build_roy_picking_lists_pdf(
+            [
+                {
+                    "order_num": "2677009999",
+                    "purchase_at": "2026-05-27 10:00:00",
+                    "status": "Platba online - zaplaten\u00e9",
+                    "sum": "120,00 EUR",
+                    "payment": {"title": "Okam\u017eit\u00e1 platba online"},
+                    "shipping": {"title": "Osobn\u00fd odber na sklade"},
+                    "customer": {"display_name": "B2B Partner s.r.o."},
+                    "customer_note": "Objednavku pripravit v piatok doobeda.",
+                    "invoice_address": {"lines": ["B2B Partner s.r.o.", "Hlavna 12", "81101 Bratislava Slovensko"]},
+                    "delivery_address": {"lines": ["B2B Partner s.r.o.", "Hlavna 12", "81101 Bratislava Slovensko"]},
+                    "wholesale_pricing": {"is_wholesale": True, "max_discount_pct": 20.0},
+                    "items": [{"label": "Fotopasca Wachman Solar Pro", "quantity": 1, "import_code": "12474", "ean": "8586024430013"}],
+                }
+            ]
+        )
+
+        text = PdfReader(BytesIO(pdf)).pages[0].extract_text() or ""
+
+        self.assertIn("2677009999", text)
+        self.assertIn("Pozn\u00e1mka klienta", text)
+        self.assertIn("Objednavku pripravit v piatok doobeda.", text)
+        self.assertIn("VE\u013dKOOBCHOD / VO CENY", text)
+        self.assertIn("B2B Partner s.r.o.", text)
 
     def test_empty_pdf_is_still_downloadable(self) -> None:
         pdf = build_roy_picking_lists_pdf([])


### PR DESCRIPTION
## Summary
- fetch ROY order notes, customer/address fields, and item pricing data for picking-list PDFs
- render customer note, invoice/delivery address blocks, wholesale badge, and Code128 order barcode in ROY picking-list PDFs
- add ROY wholesale detection config and regression coverage

## Verification
- python -m py_compile roy_operations_dashboard.py roy_picking_lists_pdf.py live_dashboard_server.py
- python -m unittest tests.test_roy_picking_lists_pdf tests.test_roy_operations_dashboard
- python -m json.tool projects\\roy\\settings.json
- direct BiznisWeb GraphQL smoke for ROY operations query
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- python scripts\\reporting_qa_smoke.py
- python scripts\\security_ci.py
- git diff --check