### PR TITLE
Add large ROY picking-list handling flags

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3346,3 +3346,19 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - `/api/operations/roy/picking-lists.pdf?refresh=1` returned a valid PDF with `34` pages and `275096` bytes; extracted first page contains order `2677002576`, `Poznámka klienta`, customer note text, and address blocks
 - Next exact step:
   - watch one real downloaded picking-list PDF during warehouse use and adjust spacing only if long notes or long addresses crowd the product table
+
+### 2026-05-27 (ROY picking-list large handling flags)
+- Branch: `codex/roy-picking-list-big-flags`
+- Change:
+  - ROY picking-list PDF now prints a large red `OSOBNÝ ODBER - NEBALIŤ` banner when the order is a personal pickup
+  - ROY picking-list PDF now prints a large orange `VEĽKOOBCHODNÁ OBJEDNÁVKA` banner when wholesale pricing is detected
+  - personal pickup detection in the PDF renderer accepts both the snapshot `personal_pickup` flag and shipping title fallback containing `osobný odber`
+- Local verification:
+  - `python -m py_compile roy_picking_lists_pdf.py`
+  - `python -m unittest tests.test_roy_picking_lists_pdf`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python scripts\security_ci.py`
+  - `git diff --check`
+- Next exact step:
+  - merge PR, rebuild ECR image, deploy ROY App Runner dashboard, and verify live `/api/operations/roy/picking-lists.pdf?refresh=1`

--- a/roy_picking_lists_pdf.py
+++ b/roy_picking_lists_pdf.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import io
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Sequence
@@ -115,6 +116,41 @@ def _draw_badge(canvas: Any, label: str, x: float, y: float, fonts: Dict[str, st
     canvas.drawString(x + 4 * mm, y - 3.2 * mm, label)
     canvas.setFillColor(colors.black)
     return badge_width
+
+
+def _fit_font_size(canvas: Any, label: str, font_name: str, max_width: float, start_size: int, min_size: int = 11) -> int:
+    size = start_size
+    while size > min_size and canvas.stringWidth(label, font_name, size) > max_width:
+        size -= 1
+    return size
+
+
+def _draw_attention_banner(
+    canvas: Any,
+    label: str,
+    x: float,
+    y_top: float,
+    width: float,
+    fonts: Dict[str, str],
+    colors: Any,
+    *,
+    fill: str,
+    stroke: str,
+    text_color: str,
+) -> float:
+    from reportlab.lib.units import mm
+
+    height = 14 * mm
+    canvas.setFillColor(colors.HexColor(fill))
+    canvas.setStrokeColor(colors.HexColor(stroke))
+    canvas.setLineWidth(1.3)
+    canvas.roundRect(x, y_top - height, width, height, 2.5 * mm, fill=1, stroke=1)
+    canvas.setFillColor(colors.HexColor(text_color))
+    font_size = _fit_font_size(canvas, label, fonts["bold"], width - 10 * mm, 18, min_size=12)
+    canvas.setFont(fonts["bold"], font_size)
+    canvas.drawCentredString(x + width / 2, y_top - 9 * mm, label)
+    canvas.setFillColor(colors.black)
+    return y_top - height - 4 * mm
 
 
 def _draw_order_barcode(canvas: Any, order_num: Any, x_right: float, y_top: float, fonts: Dict[str, str]) -> None:
@@ -239,6 +275,19 @@ def _wholesale_info(order: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _normalize_flag_text(value: Any) -> str:
+    text = unicodedata.normalize("NFKD", str(value or "").casefold())
+    return "".join(ch for ch in text if not unicodedata.combining(ch)).strip()
+
+
+def _is_personal_pickup_order(order: Dict[str, Any]) -> bool:
+    if bool(order.get("personal_pickup")):
+        return True
+    shipping = order.get("shipping") if isinstance(order.get("shipping"), dict) else {}
+    shipping_title = _normalize_flag_text(shipping.get("title"))
+    return "osobny odber" in shipping_title
+
+
 def _draw_footer(canvas: Any, width: float, page_no: int, fonts: Dict[str, str]) -> None:
     from reportlab.lib.units import mm
 
@@ -293,6 +342,7 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
         new_page()
         y = top_y
         wholesale = _wholesale_info(order)
+        is_personal_pickup = _is_personal_pickup_order(order)
 
         canvas.setFont(fonts["bold"], 18)
         canvas.drawString(margin_x, y, "Vyskladňovací list")
@@ -308,6 +358,33 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
         canvas.setLineWidth(1.1)
         canvas.line(margin_x, y, width - margin_x, y)
         y -= 8 * mm
+
+        if is_personal_pickup:
+            y = _draw_attention_banner(
+                canvas,
+                "OSOBNÝ ODBER - NEBALIŤ",
+                margin_x,
+                y,
+                width - 2 * margin_x,
+                fonts,
+                colors,
+                fill="#fee2e2",
+                stroke="#dc2626",
+                text_color="#991b1b",
+            )
+        if wholesale["is_wholesale"]:
+            y = _draw_attention_banner(
+                canvas,
+                "VEĽKOOBCHODNÁ OBJEDNÁVKA",
+                margin_x,
+                y,
+                width - 2 * margin_x,
+                fonts,
+                colors,
+                fill="#ffedd5",
+                stroke="#f97316",
+                text_color="#9a3412",
+            )
 
         left_x = margin_x
         right_x = width / 2 + 8 * mm

--- a/tests/test_roy_picking_lists_pdf.py
+++ b/tests/test_roy_picking_lists_pdf.py
@@ -75,6 +75,8 @@ class RoyPickingListsPdfTests(unittest.TestCase):
         self.assertIn("Pozn\u00e1mka klienta", text)
         self.assertIn("Objednavku pripravit v piatok doobeda.", text)
         self.assertIn("VE\u013dKOOBCHOD / VO CENY", text)
+        self.assertIn("OSOBN\u00dd ODBER - NEBALI\u0164", text)
+        self.assertIn("VE\u013dKOOBCHODN\u00c1 OBJEDN\u00c1VKA", text)
         self.assertIn("B2B Partner s.r.o.", text)
 
     def test_empty_pdf_is_still_downloadable(self) -> None:


### PR DESCRIPTION
## Summary
- add a large personal-pickup banner to ROY picking-list PDFs
- add a large wholesale-order banner to ROY picking-list PDFs
- cover both labels in the PDF text regression test

## Verification
- python -m py_compile roy_picking_lists_pdf.py
- python -m unittest tests.test_roy_picking_lists_pdf
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- python scripts\\reporting_qa_smoke.py
- python scripts\\security_ci.py
- git diff --check