### PR TITLE
Make ROY new order sound louder

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3404,3 +3404,18 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - live PDF pages for orders `2677002708` and `2677002747` contain large `VEĽKOOBCHODNÁ OBJEDNÁVKA`
 - Next exact step:
   - watch the next real warehouse download from the ROY dashboard and only adjust spacing if operators report long notes crowding the product rows
+
+### 2026-05-27 (ROY louder new-order sound alert)
+- Branch: `codex/roy-louder-new-order-sound`
+- Change:
+  - ROY operations dashboard new-order alert sound changed from a soft sine beep to a louder two-tone generated Web Audio alarm
+  - the sound test played when enabling the toggle is louder, so the operator can confirm browser audio is armed
+  - added the `loud-two-tone-v2` marker to the rendered dashboard HTML for deployment verification
+- Local verification:
+  - `python -m py_compile live_dashboard_server.py roy_operations_dashboard.py`
+  - `python -m unittest tests.test_roy_operations_dashboard tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_production_board`
+  - rendered ROY operations dashboard inline script extracted from `build_roy_operations_dashboard_html("roy")` and checked with `node --check`
+  - `python scripts\security_ci.py`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, rebuild ECR image, deploy ROY App Runner dashboard with `skip_artifact_refresh=true`, then verify live `/production/roy` contains `loud-two-tone-v2`

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -1236,6 +1236,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     let orderSoundInitialized = false;
     let seenFulfillableOrderKeys = new Set();
     const orderSoundStorageKey = `roy:${project}:new-order-sound`;
+    const ORDER_ALERT_SOUND_VERSION = 'loud-two-tone-v2';
 
     const metricDefsFallback = [
       { key:'revenue', label_en:'Revenue (net)' },
@@ -1290,7 +1291,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         if (ctx.state === 'suspended') await ctx.resume();
         orderSoundArmed = ctx.state === 'running';
         updateSoundButton();
-        if (orderSoundArmed && playTest) playNewOrderSound(1, 0.35);
+        if (orderSoundArmed && playTest) playNewOrderSound(1, 0.75);
         return orderSoundArmed;
       } catch (error) {
         orderSoundArmed = false;
@@ -1298,29 +1299,37 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         return false;
       }
     }
-    function playTone(ctx, frequency, start, duration, gainValue) {
+    function playTone(ctx, frequency, start, duration, gainValue, type='square') {
       const oscillator = ctx.createOscillator();
       const gain = ctx.createGain();
-      oscillator.type = 'sine';
+      const peakGain = Math.max(0.0001, Math.min(Number(gainValue || 0.0001), 0.35));
+      oscillator.type = type;
       oscillator.frequency.setValueAtTime(frequency, start);
+      oscillator.frequency.exponentialRampToValueAtTime(frequency * 0.985, start + duration);
       gain.gain.setValueAtTime(0.0001, start);
-      gain.gain.exponentialRampToValueAtTime(gainValue, start + 0.015);
+      gain.gain.exponentialRampToValueAtTime(peakGain, start + 0.015);
+      gain.gain.setValueAtTime(peakGain, start + (duration * 0.58));
       gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
       oscillator.connect(gain);
       gain.connect(ctx.destination);
       oscillator.start(start);
       oscillator.stop(start + duration + 0.02);
     }
-    function playNewOrderSound(count=1, volume=0.7) {
+    function playOrderAlertBurst(ctx, start, volume) {
+      playTone(ctx, 740, start, 0.24, 0.24 * volume, 'square');
+      playTone(ctx, 1480, start + 0.025, 0.16, 0.10 * volume, 'triangle');
+      playTone(ctx, 988, start + 0.22, 0.22, 0.22 * volume, 'square');
+      playTone(ctx, 1976, start + 0.245, 0.14, 0.08 * volume, 'triangle');
+    }
+    function playNewOrderSound(count=1, volume=1) {
       if (!orderSoundEnabled || !orderSoundArmed) return;
       const ctx = audioContext();
       if (!ctx || ctx.state !== 'running') return;
       const now = ctx.currentTime + 0.02;
-      const repeats = Math.min(Math.max(Number(count || 1), 1), 3);
+      const repeats = Math.min(Math.max(Number(count || 1), 1), 4);
+      const alertVolume = Math.min(Math.max(Number(volume || 1), 0.25), 1.25);
       for (let i = 0; i < repeats; i += 1) {
-        const offset = now + (i * 0.18);
-        playTone(ctx, 880, offset, 0.12, 0.12 * volume);
-        playTone(ctx, 1175, offset + 0.08, 0.14, 0.10 * volume);
+        playOrderAlertBurst(ctx, now + (i * 0.48), alertVolume);
       }
     }
     function fulfillableOrderKeys(data) {

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -274,6 +274,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("data-save-inbound", html)
         self.assertIn("soundToggleBtn", html)
         self.assertIn("playNewOrderSound", html)
+        self.assertIn("loud-two-tone-v2", html)
+        self.assertIn("playOrderAlertBurst", html)
         self.assertIn("notifyAboutNewFulfillableOrders", html)
         self.assertIn("Vysklad. PDF", html)
         self.assertIn("/api/operations/roy/picking-lists.pdf", html)


### PR DESCRIPTION
## Summary
- replace the soft sine beep with a louder generated two-tone Web Audio alert
- make the arm/test sound louder when the sound toggle is enabled
- add a rendered HTML marker for production verification

## Tests
- python -m py_compile live_dashboard_server.py roy_operations_dashboard.py
- python -m unittest tests.test_roy_operations_dashboard tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_production_board
- node --check on extracted ROY operations inline script
- python scripts\\security_ci.py
- git diff --check