### PR TITLE
Show only paid ROY personal pickups

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3447,3 +3447,24 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - `/api/operations/roy/live?refresh=1` returned marker `roy-operations-dashboard` and `auto_refresh_seconds=90`
 - Next exact step:
   - have the browser tab sound toggle enabled during warehouse use and confirm the new alert volume is sufficient on the next real fulfillable order
+
+### 2026-05-27 (ROY paid-only personal pickup list)
+- Branch: `codex/roy-paid-only-personal-pickups`
+- Change:
+  - ROY operations dashboard personal-pickup list now includes only paid personal pickup orders that are not already shipped
+  - COD personal pickups can still appear in the fulfillable order table when they match the COD fulfillment rule, but they no longer appear in the dedicated `Osobné odbery` panel
+  - pickup ship checkbox/action is allowed only for paid personal pickup rows, so unpaid/cancelled pickup orders cannot be marked shipped through the dashboard action
+  - scan metadata now counts only paid personal pickups for `personal_pickups_seen_during_scan`
+- Pre-change live observation:
+  - `/api/operations/roy/live?refresh=1` returned `2` personal pickup rows
+  - order `2677002554` was present with status `Nezaplatená - zrušená objednávka`, payment `Bankovým prevodom`, shipping `Osobný odber na sklade`
+  - order `2677002764` was present with status `Platba online - zaplatené`, payment `Okamžitá platba online`, shipping `Osobný odber na sklade`
+- Local verification:
+  - `python -m py_compile roy_operations_dashboard.py live_dashboard_server.py`
+  - `python -m unittest tests.test_roy_operations_dashboard tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_production_board`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python scripts\security_ci.py`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, rebuild ECR image, deploy ROY App Runner dashboard with `skip_artifact_refresh=true`, then verify live personal pickup list excludes `2677002554`

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -621,6 +621,14 @@ def _is_personal_pickup(order: Dict[str, Any], settings: Dict[str, Any]) -> bool
     return any(name and name in shipping_title for name in settings["personal_pickup_shipping_names_normalized"])
 
 
+def _is_paid_personal_pickup(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
+    return (
+        _is_personal_pickup(order, settings)
+        and _is_paid_online(order, settings)
+        and _normalize_text(_status_name(order)) != settings["shipped_status_name_normalized"]
+    )
+
+
 def _normalize_product_identifier(value: Any) -> str:
     return str(value or "").strip().upper()
 
@@ -863,9 +871,13 @@ def _public_order_row(order: Dict[str, Any], settings: Dict[str, Any]) -> Dict[s
     is_pickup = _is_personal_pickup(order, settings)
     status_name = _status_name(order)
     status_norm = _normalize_text(status_name)
-    pickup_action_allowed = (
+    paid_pickup_ready = (
         is_pickup
+        and reason == "paid_online"
         and status_norm != settings["shipped_status_name_normalized"]
+    )
+    pickup_action_allowed = (
+        paid_pickup_ready
         and status_norm in settings["pickup_action_statuses_normalized"]
     )
     return {
@@ -890,6 +902,7 @@ def _public_order_row(order: Dict[str, Any], settings: Dict[str, Any]) -> Dict[s
         "fulfillable": fulfillable,
         "fulfillment_reason": reason,
         "personal_pickup": is_pickup,
+        "paid_personal_pickup": paid_pickup_ready,
         "pickup_action_allowed": pickup_action_allowed,
     }
 
@@ -907,7 +920,7 @@ def build_roy_orders_snapshot(
 
     rows = [_public_order_row(order, settings) for order in orders]
     fulfillable_orders = [row for row in rows if row["fulfillable"]]
-    pickup_orders = [row for row in rows if row["personal_pickup"] and row["status"] != settings["shipped_status_name"]]
+    pickup_orders = [row for row in rows if row["paid_personal_pickup"]]
     paid_orders = [row for row in fulfillable_orders if row["fulfillment_reason"] == "paid_online"]
     cod_orders = [row for row in fulfillable_orders if row["fulfillment_reason"] == "cod_waiting"]
 
@@ -984,7 +997,7 @@ def fetch_open_orders_for_roy_operations(project: str, settings: Dict[str, Any])
         page_count += 1
 
         page_fulfillable = sum(1 for order in page_orders if _is_fulfillable_order(order, settings)[0])
-        page_pickups = sum(1 for order in page_orders if _is_personal_pickup(order, settings))
+        page_pickups = sum(1 for order in page_orders if _is_paid_personal_pickup(order, settings))
         fulfillable_seen += page_fulfillable
         pickup_seen += page_pickups
         if page_fulfillable or page_pickups:

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -103,16 +103,22 @@ class RoyOperationsDashboardTests(unittest.TestCase):
             make_order("R-2", "Čaká na vybavenie", price_element("payment", "Dobierkou", "7"), pickup_shipping),
             make_order("R-3", "Čaká na vybavenie", price_element("payment", "Bankovým prevodom", "6"), packeta_shipping),
             make_order("R-4", "Odoslaná", price_element("payment", "Dobierkou", "7"), pickup_shipping),
+            make_order("R-5", "Platba online - zaplatené", price_element("payment", "Okamžitá platba online", "18"), pickup_shipping),
+            make_order("R-6", "Nezaplatená - zrušená objednávka", price_element("payment", "Okamžitá platba online", "18"), pickup_shipping),
         ]
 
         snapshot = build_roy_orders_snapshot(project="roy", orders=orders, settings=settings)
 
-        self.assertEqual(2, snapshot["summary"]["fulfillable_orders"])
-        self.assertEqual(1, snapshot["summary"]["paid_online_orders"])
+        self.assertEqual(3, snapshot["summary"]["fulfillable_orders"])
+        self.assertEqual(2, snapshot["summary"]["paid_online_orders"])
         self.assertEqual(1, snapshot["summary"]["cod_waiting_orders"])
-        self.assertEqual(["R-1", "R-2"], [row["order_num"] for row in snapshot["orders"]])
-        self.assertEqual(["R-2"], [row["order_num"] for row in snapshot["personal_pickups"]])
+        self.assertEqual(["R-1", "R-2", "R-5"], [row["order_num"] for row in snapshot["orders"]])
+        self.assertEqual(["R-5"], [row["order_num"] for row in snapshot["personal_pickups"]])
+        cod_pickup = next(row for row in snapshot["orders"] if row["order_num"] == "R-2")
+        self.assertFalse(cod_pickup["paid_personal_pickup"])
+        self.assertFalse(cod_pickup["pickup_action_allowed"])
         self.assertTrue(snapshot["personal_pickups"][0]["pickup_action_allowed"])
+        self.assertTrue(snapshot["personal_pickups"][0]["paid_personal_pickup"])
 
     def test_snapshot_exposes_notes_addresses_and_wholesale_signal_for_pdf(self) -> None:
         settings = make_settings()


### PR DESCRIPTION
## Summary
- filter the ROY personal pickup panel to paid pickup orders only
- keep COD pickup orders in the fulfillable table but remove them from the dedicated pickup panel
- block pickup ship action unless the pickup row is paid
- record the pre-change live cancelled pickup example in PROJECT_STATE.md

## Tests
- python -m py_compile roy_operations_dashboard.py live_dashboard_server.py
- python -m unittest tests.test_roy_operations_dashboard tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_production_board
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- python scripts\\reporting_qa_smoke.py
- python scripts\\security_ci.py
- git diff --check