### PR TITLE
Print ROY picking lists only once

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -985,7 +985,7 @@ jobs:
             curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/operations/roy/live?refresh=1" -o /tmp/production-board-api.json
             curl -fsS --max-time 180 -D /tmp/roy-picking-lists.headers \
               -u "${AUTH_USER}:${AUTH_PASSWORD}" \
-              "${SERVICE_URL}/api/operations/roy/picking-lists.pdf?refresh=1" \
+              "${SERVICE_URL}/api/operations/roy/picking-lists.pdf?refresh=1&preview=1" \
               -o /tmp/roy-picking-lists.pdf
             python - <<'PY'
           import json

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3497,3 +3497,22 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - live pickup list excludes cancelled unpaid pickup order `2677002554`
 - Next exact step:
   - keep the paid-only pickup rule unless warehouse process explicitly needs a separate unpaid pickup queue
+
+### 2026-05-28 (ROY picking lists print-once state)
+- Branch: `codex/roy-print-picking-once`
+- Change:
+  - ROY picking-list PDF endpoint now filters out orders already recorded in operations state under `printed_picking_orders`
+  - when the normal dashboard PDF link generates a non-empty PDF, included order numbers are recorded with `printed_at`, `batch_id`, status, purchase date, and sum
+  - repeated clicks only include newly fulfillable orders that have not been printed before; previously printed but still unshipped orders are skipped
+  - deploy smoke now calls `/api/operations/roy/picking-lists.pdf?refresh=1&preview=1`, so production verification does not mark real orders as printed
+  - PDF print state load is fail-closed for configured S3 state, to avoid falling back to an empty local state and reprinting already printed orders
+- Local verification:
+  - `python -m py_compile roy_operations_dashboard.py live_dashboard_server.py roy_picking_lists_pdf.py`
+  - `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_production_board`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `python scripts\reporting_qa_smoke.py`
+  - `python scripts\security_ci.py`
+  - workflow YAML parse for `.github/workflows/deploy-live-dashboard-apprunner.yml`
+  - `git diff --check`
+- Next exact step:
+  - open/merge PR, rebuild ECR image, deploy ROY App Runner dashboard, then verify preview PDF is side-effect-free and one real PDF download records the printed order batch

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -18,9 +18,13 @@ from production_board import get_cached_production_board_snapshot, resolve_produ
 from roy_operations_dashboard import (
     acknowledge_loss_product,
     clear_inbound_stock_order,
+    filter_unprinted_picking_orders,
     get_cached_roy_operations_snapshot,
+    load_roy_operations_state,
+    mark_picking_orders_printed,
     mark_personal_pickup_shipped,
     resolve_roy_operations_settings,
+    save_roy_operations_state,
     set_inbound_stock_order,
 )
 from roy_picking_lists_pdf import build_roy_picking_lists_filename, build_roy_picking_lists_pdf
@@ -1925,7 +1929,8 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 )
                 return
             try:
-                operations_settings = resolve_roy_operations_settings(load_project_settings(project))
+                project_settings = load_project_settings(project)
+                operations_settings = resolve_roy_operations_settings(project_settings)
             except Exception as exc:
                 self._send_text(
                     f"Failed to load ROY operations settings: {escape(str(exc))}",
@@ -1941,15 +1946,25 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 )
                 return
             force_refresh = (query.get("refresh", ["1"])[0] or "").strip().lower() not in {"0", "false", "no"}
+            preview_only = (query.get("preview", [""])[0] or "").strip().lower() in {"1", "true", "yes"}
             try:
                 payload = get_cached_roy_operations_snapshot(
                     project,
                     report_payload=read_latest_dashboard_payload(project),
                     force_refresh=force_refresh,
                 )
-                orders = ((payload.get("orders") or {}).get("orders") or [])
+                all_orders = ((payload.get("orders") or {}).get("orders") or [])
+                operations_state = load_roy_operations_state(
+                    project,
+                    project_settings,
+                    require_configured_remote=not preview_only,
+                )
+                orders = list(all_orders) if preview_only else filter_unprinted_picking_orders(all_orders, operations_state)
                 pdf = build_roy_picking_lists_pdf(orders)
                 filename = build_roy_picking_lists_filename(orders)
+                if orders and not preview_only:
+                    mark_picking_orders_printed(operations_state, orders)
+                    save_roy_operations_state(project, operations_state, project_settings)
                 self._send_download(pdf, content_type="application/pdf", filename=filename)
             except Exception as exc:
                 self._send_text(

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -207,6 +207,8 @@ def _empty_operations_state() -> Dict[str, Any]:
         "loss_acknowledgements": {},
         "inbound_orders": {},
         "auto_cleared_inbound_orders": [],
+        "printed_picking_orders": {},
+        "picking_print_batches": [],
     }
 
 
@@ -262,20 +264,35 @@ def _normalize_operations_state(raw: Any) -> Dict[str, Any]:
     if not isinstance(raw, dict):
         return state
     state["version"] = int(raw.get("version") or STATE_VERSION)
-    for section in ("loss_acknowledgements", "inbound_orders"):
+    for section in ("loss_acknowledgements", "inbound_orders", "printed_picking_orders"):
         values = raw.get(section) if isinstance(raw.get(section), dict) else {}
         state[section] = {
             str(key).strip(): value
             for key, value in values.items()
             if str(key).strip() and isinstance(value, dict)
         }
-    cleared = raw.get("auto_cleared_inbound_orders")
-    if isinstance(cleared, list):
-        state["auto_cleared_inbound_orders"] = [row for row in cleared[-50:] if isinstance(row, dict)]
+    for section in ("auto_cleared_inbound_orders", "picking_print_batches"):
+        rows = raw.get(section)
+        if isinstance(rows, list):
+            state[section] = [row for row in rows[-50:] if isinstance(row, dict)]
     return state
 
 
-def load_roy_operations_state(project: str, project_settings: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def _s3_error_code(exc: Exception) -> str:
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error")
+        if isinstance(error, dict):
+            return str(error.get("Code") or "").strip()
+    return ""
+
+
+def load_roy_operations_state(
+    project: str,
+    project_settings: Optional[Dict[str, Any]] = None,
+    *,
+    require_configured_remote: bool = False,
+) -> Dict[str, Any]:
     project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
     project_settings = project_settings or load_project_settings(project)
     location = _state_s3_location(project, project_settings)
@@ -286,7 +303,9 @@ def load_roy_operations_state(project: str, project_settings: Optional[Dict[str,
 
             response = boto3.client("s3", region_name=region).get_object(Bucket=bucket, Key=key)
             return _normalize_operations_state(json.loads(response["Body"].read().decode("utf-8")))
-        except Exception:
+        except Exception as exc:
+            if require_configured_remote and _s3_error_code(exc) not in {"NoSuchKey", "404"}:
+                raise RuntimeError(f"Failed to load configured ROY operations state from s3://{bucket}/{key}: {exc}")
             pass
 
     path = _local_state_path(project)
@@ -327,6 +346,73 @@ def save_roy_operations_state(
     tmp_path.write_bytes(body)
     tmp_path.replace(path)
     return {"storage": "local", "path": str(path)}
+
+
+def _picking_order_key(order: Dict[str, Any]) -> str:
+    return str(order.get("order_num") or order.get("id") or "").strip()
+
+
+def filter_unprinted_picking_orders(
+    orders: Iterable[Dict[str, Any]],
+    state: Optional[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    printed = (state or {}).get("printed_picking_orders")
+    printed_keys = {str(key).strip() for key in printed} if isinstance(printed, dict) else set()
+    result: List[Dict[str, Any]] = []
+    for order in orders:
+        key = _picking_order_key(order)
+        if key and key in printed_keys:
+            continue
+        result.append(order)
+    return result
+
+
+def mark_picking_orders_printed(
+    state: Dict[str, Any],
+    orders: Iterable[Dict[str, Any]],
+    *,
+    printed_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    printed_at = printed_at or _state_now_iso()
+    batch_id = "picking-" + "".join(ch for ch in printed_at if ch.isdigit())[:14]
+    printed = state.setdefault("printed_picking_orders", {})
+    if not isinstance(printed, dict):
+        printed = {}
+        state["printed_picking_orders"] = printed
+
+    marked_order_nums: List[str] = []
+    for order in orders:
+        key = _picking_order_key(order)
+        if not key or key in printed:
+            continue
+        record = {
+            "order_num": key,
+            "printed_at": printed_at,
+            "batch_id": batch_id,
+            "status": str(order.get("status") or "").strip(),
+            "purchase_at": str(order.get("purchase_at") or "").strip(),
+            "sum": str(order.get("sum") or "").strip(),
+        }
+        customer = order.get("customer") if isinstance(order.get("customer"), dict) else {}
+        customer_name = str(customer.get("name") or customer.get("company_name") or "").strip()
+        if customer_name:
+            record["customer"] = customer_name
+        printed[key] = record
+        marked_order_nums.append(key)
+
+    batch = {
+        "batch_id": batch_id,
+        "printed_at": printed_at,
+        "order_count": len(marked_order_nums),
+        "order_nums": marked_order_nums,
+    }
+    batches = state.setdefault("picking_print_batches", [])
+    if not isinstance(batches, list):
+        batches = []
+    if marked_order_nums:
+        batches.append(batch)
+    state["picking_print_batches"] = [row for row in batches[-50:] if isinstance(row, dict)]
+    return batch
 
 
 def _validate_eta_date(value: Any) -> str:
@@ -1545,6 +1631,8 @@ def generate_roy_operations_snapshot(project: str, report_payload: Optional[Dict
             "inbound_order_count": len(operations_state.get("inbound_orders") or {}),
             "acknowledged_loss_product_count": len(operations_state.get("loss_acknowledgements") or {}),
             "auto_cleared_inbound_order_count": len(operations_state.get("auto_cleared_inbound_orders") or []),
+            "printed_picking_order_count": len(operations_state.get("printed_picking_orders") or {}),
+            "last_picking_print_batch": (operations_state.get("picking_print_batches") or [None])[-1],
         },
     }
 

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -8,6 +8,8 @@ from roy_operations_dashboard import (
     build_commercial_snapshot,
     build_inventory_snapshot,
     build_roy_orders_snapshot,
+    filter_unprinted_picking_orders,
+    mark_picking_orders_printed,
     resolve_roy_operations_settings,
 )
 
@@ -174,6 +176,40 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("Sklad B2B", row["delivery_address"]["lines"])
         self.assertTrue(row["wholesale_pricing"]["is_wholesale"])
         self.assertEqual(20.0, row["wholesale_pricing"]["max_discount_pct"])
+
+    def test_picking_pdf_orders_are_marked_printed_once(self) -> None:
+        orders = [
+            {"order_num": "R-1", "status": "Platba online - zaplatené", "purchase_at": "2026-05-28 09:00:00", "sum": "10,00 €"},
+            {"order_num": "R-2", "status": "Čaká na vybavenie", "purchase_at": "2026-05-28 09:05:00", "sum": "20,00 €"},
+        ]
+        state = {"version": 1, "printed_picking_orders": {}}
+
+        first_batch = filter_unprinted_picking_orders(orders, state)
+        first_mark = mark_picking_orders_printed(state, first_batch, printed_at="2026-05-28T10:00:00Z")
+        second_batch = filter_unprinted_picking_orders(orders, state)
+        second_mark = mark_picking_orders_printed(state, second_batch, printed_at="2026-05-28T10:05:00Z")
+
+        self.assertEqual(["R-1", "R-2"], [row["order_num"] for row in first_batch])
+        self.assertEqual(["R-1", "R-2"], first_mark["order_nums"])
+        self.assertEqual([], second_batch)
+        self.assertEqual([], second_mark["order_nums"])
+        self.assertEqual({"R-1", "R-2"}, set(state["printed_picking_orders"]))
+        self.assertEqual("2026-05-28T10:00:00Z", state["printed_picking_orders"]["R-1"]["printed_at"])
+        self.assertEqual(1, len(state["picking_print_batches"]))
+
+    def test_picking_pdf_filter_keeps_new_orders_after_previous_print(self) -> None:
+        orders = [{"order_num": "R-1"}, {"order_num": "R-2"}, {"order_num": "R-3"}]
+        state = {
+            "version": 1,
+            "printed_picking_orders": {
+                "R-1": {"order_num": "R-1", "printed_at": "2026-05-28T10:00:00Z"},
+                "R-2": {"order_num": "R-2", "printed_at": "2026-05-28T10:00:00Z"},
+            },
+        }
+
+        unprinted = filter_unprinted_picking_orders(orders, state)
+
+        self.assertEqual(["R-3"], [row["order_num"] for row in unprinted])
 
     def test_snapshot_expands_bundle_order_items_to_pickable_components(self) -> None:
         project_settings = json.loads((ROOT_DIR / "projects" / "roy" / "settings.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- persist printed ROY picking-list order numbers in operations state
- filter normal picking-list PDF downloads to only unprinted fulfillable orders
- add a side-effect-free preview mode for deploy smoke
- make configured S3 state loading fail closed for real print downloads

## Tests
- python -m py_compile roy_operations_dashboard.py live_dashboard_server.py roy_picking_lists_pdf.py
- python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_production_board
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- python scripts\\reporting_qa_smoke.py
- python scripts\\security_ci.py
- workflow YAML parse for deploy-live-dashboard-apprunner.yml
- git diff --check