### PR TITLE
[codex] Retry App Runner public smoke curls

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -976,14 +976,26 @@ jobs:
           echo "production-board-path=${SERVICE_URL}/production/${PROJECT}"
           echo "latest-artifacts-s3=s3://${REPORT_S3_BUCKET_VALUE}/${REPORT_S3_PREFIX_VALUE}/latest/"
 
-          curl -fsS "${SERVICE_URL}/health" > /tmp/health.json
-          curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/production/${PROJECT}" -o /tmp/production-board.html
+          curl_with_retry() {
+            local attempt
+            for attempt in 1 2 3 4; do
+              if curl "$@"; then
+                return 0
+              fi
+              echo "curl attempt ${attempt} failed; retrying after $((attempt * 10))s..." >&2
+              sleep $((attempt * 10))
+            done
+            curl "$@"
+          }
+
+          curl_with_retry -fsS "${SERVICE_URL}/health" > /tmp/health.json
+          curl_with_retry -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/production/${PROJECT}" -o /tmp/production-board.html
           if [[ "${PROJECT}" == "roy" ]]; then
             grep -q "roy-operations-dashboard" /tmp/production-board.html
             grep -q "Executive KPI deck" /tmp/production-board.html
             grep -q "Vysklad. PDF" /tmp/production-board.html
-            curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/operations/roy/live?refresh=1" -o /tmp/production-board-api.json
-            curl -fsS --max-time 180 -D /tmp/roy-picking-lists.headers \
+            curl_with_retry -fsS --max-time 240 -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/operations/roy/live?refresh=1" -o /tmp/production-board-api.json
+            curl_with_retry -fsS --max-time 240 -D /tmp/roy-picking-lists.headers \
               -u "${AUTH_USER}:${AUTH_PASSWORD}" \
               "${SERVICE_URL}/api/operations/roy/picking-lists.pdf?refresh=1&preview=1" \
               -o /tmp/roy-picking-lists.pdf
@@ -1039,7 +1051,7 @@ jobs:
             grep -q "vevo-production-board" /tmp/production-board.html
             grep -q "productsCards" /tmp/production-board.html
             grep -q "@media (max-width:680px)" /tmp/production-board.html
-            curl -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/production/vevo/live?refresh=1" -o /tmp/production-board-api.json
+            curl_with_retry -fsS -u "${AUTH_USER}:${AUTH_PASSWORD}" "${SERVICE_URL}/api/production/vevo/live?refresh=1" -o /tmp/production-board-api.json
             python - <<'PY'
           import json
           api = json.load(open("/tmp/production-board-api.json", encoding="utf-8"))

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3597,3 +3597,16 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - `python -m unittest tests.test_roy_operations_dashboard tests.test_live_dashboard_auth tests.test_live_dashboard_mobile`
 - Next exact step:
   - run local py_compile/unit tests, commit/push/PR/merge, rebuild ECR, rerun ROY App Runner deploy, verify public live API stock alerts
+
+### 2026-05-28 (App Runner deploy public smoke curl retry)
+- Branch: `codex/deploy-smoke-curl-retry`
+- Context:
+  - PR `#140` was merged and ECR build run `26573358606` pushed digest `sha256:7260ca4d47cad0953208e556a1914ea91dfd90a0bb698b5848f4b690350eb7e7`
+  - deploy run `26573465453` updated App Runner and passed host marker checks, but public smoke still failed on one transient HTTP `500`
+  - direct manual verification after the run showed the same endpoints recover on retry: `/api/operations/roy/live?refresh=1` returned `200` and preview picking-list PDF returned `200`
+- Change:
+  - deploy workflow public smoke now wraps health, dashboard HTML, live API, and preview PDF curls with retry/backoff and raises ROY live/PDF max-time to `240s`
+- Local verification:
+  - workflow YAML parse for `.github/workflows/deploy-live-dashboard-apprunner.yml`
+- Next exact step:
+  - parse workflow YAML, commit/push/PR/merge workflow retry, rerun ROY App Runner deploy and verify live alert rows


### PR DESCRIPTION
## What changed
- Wraps App Runner public smoke `curl` calls in retry/backoff.
- Raises ROY live API and preview PDF smoke timeout to 240s.
- Documents the transient public smoke behavior in `PROJECT_STATE.md`.

## Why
The ROY App Runner update succeeds and direct endpoint verification recovers, but the deploy workflow has one-shot public smoke curls against endpoints that depend on BizniWeb GraphQL. During the current BizniWeb instability this can fail the deploy job even when the service is already updated and healthy.

## Validation
- Parsed `.github/workflows/deploy-live-dashboard-apprunner.yml` with `yaml.safe_load`.