### PR TITLE
Format ROY picking list product rows

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3640,3 +3640,17 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - BizniWeb GraphQL was intermittently returning non-JSON responses during verification; live dashboard now returns the last valid cached payload on those refresh errors
 - Next exact step:
   - monitor whether BizniWeb GraphQL instability continues; if yes, consider reducing live stock lookup scope further or adding a short background refresh queue instead of request-time lookups
+
+### 2026-05-30 (ROY picking-list product row formatting)
+- Branch: `codex/roy-picking-list-product-format`
+- Change:
+  - ROY picking-list PDF product rows now show a larger bold quantity value, a new `Cena/ks` column, and EAN as a barcode with small EAN text below it
+  - ROY operations order snapshots now carry BizniWeb item unit price into dashboard/PDF data
+  - PDF font registration now uses a real bold font when available, so quantity emphasis renders as actual bold text
+- Local verification:
+  - `python -m py_compile roy_picking_lists_pdf.py roy_operations_dashboard.py live_dashboard_server.py`
+  - `python -m unittest tests.test_roy_picking_lists_pdf tests.test_roy_operations_dashboard`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `git diff --check`
+- Next exact step:
+  - commit/push branch, open PR, merge to `main`, rebuild/deploy ROY App Runner dashboard, then verify live preview picking-list PDF returns a valid PDF

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -781,6 +781,8 @@ def _expand_order_item_components(item: Dict[str, Any], settings: Dict[str, Any]
                     "ean": str(component.get("item_ean") or "").strip(),
                     "import_code": str(component.get("item_import_code") or "").strip(),
                     "warehouse_number": str(component.get("item_warehouse_number") or "").strip(),
+                    "unit_price": None,
+                    "unit_price_formatted": "",
                     "bundle_component": True,
                     "bundle_parent_label": item.get("label", ""),
                     "bundle_expansion_rule": str(rule.get("key") or "").strip(),
@@ -803,6 +805,14 @@ def _merge_order_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             merged[key] = dict(item)
             continue
         merged[key]["quantity"] = round(_to_float(merged[key].get("quantity")) + _to_float(item.get("quantity")), 2)
+        existing_price = str(merged[key].get("unit_price_formatted") or "").strip()
+        incoming_price = str(item.get("unit_price_formatted") or "").strip()
+        if not existing_price and incoming_price:
+            merged[key]["unit_price_formatted"] = incoming_price
+            merged[key]["unit_price"] = item.get("unit_price")
+        elif existing_price and incoming_price and existing_price != incoming_price:
+            merged[key]["unit_price_formatted"] = ""
+            merged[key]["unit_price"] = None
         if item.get("bundle_component"):
             merged[key]["bundle_component"] = True
             parent_labels = {
@@ -817,18 +827,33 @@ def _merge_order_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return list(merged.values())
 
 
+def _order_item_unit_price_info(item: Dict[str, Any]) -> Dict[str, Any]:
+    price = item.get("price") if isinstance(item.get("price"), dict) else {}
+    formatted = str(price.get("formatted") or "").strip()
+    value = _optional_float(price.get("raw_value"))
+    if value is None:
+        value = _optional_float(price.get("value"))
+    return {
+        "unit_price": value,
+        "unit_price_formatted": formatted,
+    }
+
+
 def _order_items(order: Dict[str, Any], settings: Dict[str, Any]) -> List[Dict[str, Any]]:
     items: List[Dict[str, Any]] = []
     for item in order.get("items") or []:
         quantity = _to_float(item.get("quantity"))
         if quantity <= 0:
             continue
+        price_info = _order_item_unit_price_info(item)
         base_item = {
             "label": str(item.get("item_label") or "").strip(),
             "quantity": quantity,
             "ean": str(item.get("ean") or "").strip(),
             "import_code": str(item.get("import_code") or "").strip(),
             "warehouse_number": str(item.get("warehouse_number") or "").strip(),
+            "unit_price": price_info["unit_price"],
+            "unit_price_formatted": price_info["unit_price_formatted"],
         }
         items.extend(_expand_order_item_components(base_item, settings))
     return _merge_order_items(items)

--- a/roy_picking_lists_pdf.py
+++ b/roy_picking_lists_pdf.py
@@ -18,6 +18,38 @@ def _text(value: Any, fallback: str = "-") -> str:
     return text if text else fallback
 
 
+def _format_quantity(value: Any) -> str:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return _text(value, "0")
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.2f}".rstrip("0").rstrip(".")
+
+
+def _item_unit_price_text(item: Dict[str, Any]) -> str:
+    for key in ("unit_price_formatted", "unit_price"):
+        value = item.get(key)
+        if isinstance(value, (int, float)):
+            return f"{value:.2f} EUR"
+        text = str(value or "").strip()
+        if text:
+            return text
+
+    price = item.get("price") if isinstance(item.get("price"), dict) else {}
+    formatted = str(price.get("formatted") or "").strip()
+    if formatted:
+        return formatted
+    for key in ("raw_value", "value"):
+        try:
+            value = float(price.get(key))
+        except (TypeError, ValueError):
+            continue
+        return f"{value:.2f} EUR"
+    return ""
+
+
 def _font_candidates() -> Sequence[Path]:
     return (
         ROOT_DIR / "assets" / "fonts" / "DejaVuSans.ttf",
@@ -25,6 +57,17 @@ def _font_candidates() -> Sequence[Path]:
         Path("/usr/share/fonts/dejavu/DejaVuSans.ttf"),
         Path("C:/Windows/Fonts/arial.ttf"),
         Path("C:/Windows/Fonts/DejaVuSans.ttf"),
+    )
+
+
+def _bold_font_candidates(regular_path: Path) -> Sequence[Path]:
+    return (
+        regular_path.with_name("DejaVuSans-Bold.ttf"),
+        regular_path.with_name("arialbd.ttf"),
+        ROOT_DIR / "assets" / "fonts" / "DejaVuSans-Bold.ttf",
+        Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"),
+        Path("/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf"),
+        Path("C:/Windows/Fonts/arialbd.ttf"),
     )
 
 
@@ -38,7 +81,13 @@ def _register_fonts() -> Dict[str, str]:
     for path in _font_candidates():
         if path.exists():
             pdfmetrics.registerFont(TTFont("BizniswebSans", str(path)))
-            return {"regular": "BizniswebSans", "bold": "BizniswebSans"}
+            bold_font = "BizniswebSans"
+            for bold_path in _bold_font_candidates(path):
+                if bold_path.exists():
+                    pdfmetrics.registerFont(TTFont("BizniswebSans-Bold", str(bold_path)))
+                    bold_font = "BizniswebSans-Bold"
+                    break
+            return {"regular": "BizniswebSans", "bold": bold_font}
     return {"regular": "Helvetica", "bold": "Helvetica-Bold"}
 
 
@@ -177,6 +226,36 @@ def _draw_order_barcode(canvas: Any, order_num: Any, x_right: float, y_top: floa
     barcode.drawOn(canvas, x, y)
     canvas.setFont(fonts["bold"], 8)
     canvas.drawCentredString(x + barcode.width / 2, y - 3.4 * mm, order_text)
+
+
+def _draw_item_ean_barcode(
+    canvas: Any,
+    ean: Any,
+    x: float,
+    y_top: float,
+    max_width: float,
+    fonts: Dict[str, str],
+) -> None:
+    from reportlab.graphics.barcode.code128 import Code128
+    from reportlab.lib.units import mm
+
+    ean_text = _text(ean, "")
+    if not ean_text:
+        return
+
+    bar_width = 0.26 * mm
+    barcode = Code128(ean_text, barWidth=bar_width, barHeight=7 * mm, humanReadable=False)
+    if barcode.width > max_width:
+        barcode = Code128(
+            ean_text,
+            barWidth=bar_width * (max_width / barcode.width),
+            barHeight=7 * mm,
+            humanReadable=False,
+        )
+
+    barcode.drawOn(canvas, x, y_top - barcode.height)
+    canvas.setFont(fonts["regular"], 5)
+    canvas.drawCentredString(x + barcode.width / 2, y_top - barcode.height - 2.3 * mm, ean_text)
 
 
 def _draw_labeled_box(
@@ -456,11 +535,12 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
             y -= block_height + 7 * mm
 
         table_x = margin_x
-        col_qty = 16 * mm
-        col_product = 92 * mm
-        col_code = 30 * mm
-        col_ean = 32 * mm
-        table_width = col_qty + col_product + col_code + col_ean
+        col_qty = 15 * mm
+        col_product = 72 * mm
+        col_unit_price = 23 * mm
+        col_code = 24 * mm
+        col_ean = 44 * mm
+        table_width = col_qty + col_product + col_unit_price + col_code + col_ean
 
         def draw_header() -> None:
             nonlocal y
@@ -470,14 +550,17 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
             canvas.setFont(fonts["bold"], 8)
             canvas.drawString(table_x + 2 * mm, y - 2 * mm, "Ks")
             canvas.drawString(table_x + col_qty + 2 * mm, y - 2 * mm, "Produkt")
-            canvas.drawString(table_x + col_qty + col_product + 2 * mm, y - 2 * mm, "Import kód")
-            canvas.drawString(table_x + col_qty + col_product + col_code + 2 * mm, y - 2 * mm, "EAN")
+            canvas.drawString(table_x + col_qty + col_product + 2 * mm, y - 2 * mm, "Cena/ks")
+            canvas.drawString(table_x + col_qty + col_product + col_unit_price + 2 * mm, y - 2 * mm, "Import kód")
+            canvas.drawString(table_x + col_qty + col_product + col_unit_price + col_code + 2 * mm, y - 2 * mm, "EAN")
             y -= 9 * mm
 
         draw_header()
         canvas.setStrokeColor(colors.HexColor("#d9ded5"))
         for item in _order_items(order):
-            if y < 34 * mm:
+            product_lines = _wrap_text(item.get("label"), col_product - 4 * mm, fonts["regular"], 8)
+            row_height = max(14 * mm, (len(product_lines[:3]) * 4.2 * mm) + 5 * mm)
+            if y - row_height < 22 * mm:
                 _draw_footer(canvas, width, page_no, fonts)
                 canvas.showPage()
                 page_no += 1
@@ -488,11 +571,11 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
                 y -= 16 * mm
                 draw_header()
 
-            product_lines = _wrap_text(item.get("label"), col_product - 4 * mm, fonts["regular"], 8)
-            row_height = max(8 * mm, (len(product_lines[:3]) * 4.2 * mm) + 4 * mm)
             canvas.line(table_x, y + 2 * mm, table_x + table_width, y + 2 * mm)
-            canvas.setFont(fonts["bold"], 9)
-            canvas.drawString(table_x + 2 * mm, y - 2 * mm, _text(item.get("quantity"), "0"))
+            qty_text = _format_quantity(item.get("quantity"))
+            qty_font_size = _fit_font_size(canvas, qty_text, fonts["bold"], col_qty - 4 * mm, 18, min_size=11)
+            canvas.setFont(fonts["bold"], qty_font_size)
+            canvas.drawCentredString(table_x + col_qty / 2, y - 6 * mm, qty_text)
             _draw_wrapped(
                 canvas,
                 item.get("label"),
@@ -504,8 +587,16 @@ def build_roy_picking_lists_pdf(orders: Iterable[Dict[str, Any]]) -> bytes:
                 leading=4.2 * mm,
             )
             canvas.setFont(fonts["regular"], 8)
-            canvas.drawString(table_x + col_qty + col_product + 2 * mm, y - 2 * mm, _text(item.get("import_code")))
-            canvas.drawString(table_x + col_qty + col_product + col_code + 2 * mm, y - 2 * mm, _text(item.get("ean")))
+            canvas.drawString(table_x + col_qty + col_product + 2 * mm, y - 2 * mm, _item_unit_price_text(item))
+            canvas.drawString(table_x + col_qty + col_product + col_unit_price + 2 * mm, y - 2 * mm, _text(item.get("import_code")))
+            _draw_item_ean_barcode(
+                canvas,
+                item.get("ean"),
+                table_x + col_qty + col_product + col_unit_price + col_code + 2 * mm,
+                y + 0.5 * mm,
+                col_ean - 4 * mm,
+                fonts,
+            )
             y -= row_height
 
         y = max(y - 8 * mm, 24 * mm)

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -69,6 +69,7 @@ def make_order(
                 "import_code": "WA-HC800",
                 "warehouse_number": "W1",
                 "quantity": 2,
+                "price": {"raw_value": 13.7, "value": 13.7, "formatted": "13,70 EUR", "is_net_price": True},
             }
         ],
     }
@@ -116,6 +117,7 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(2, snapshot["summary"]["paid_online_orders"])
         self.assertEqual(1, snapshot["summary"]["cod_waiting_orders"])
         self.assertEqual(["R-1", "R-2", "R-5"], [row["order_num"] for row in snapshot["orders"]])
+        self.assertEqual("13,70 EUR", snapshot["orders"][0]["items"][0]["unit_price_formatted"])
         self.assertEqual(["R-5"], [row["order_num"] for row in snapshot["personal_pickups"]])
         cod_pickup = next(row for row in snapshot["orders"] if row["order_num"] == "R-2")
         self.assertFalse(cod_pickup["paid_personal_pickup"])

--- a/tests/test_roy_picking_lists_pdf.py
+++ b/tests/test_roy_picking_lists_pdf.py
@@ -64,7 +64,15 @@ class RoyPickingListsPdfTests(unittest.TestCase):
                     "invoice_address": {"lines": ["B2B Partner s.r.o.", "Hlavna 12", "81101 Bratislava Slovensko"]},
                     "delivery_address": {"lines": ["B2B Partner s.r.o.", "Hlavna 12", "81101 Bratislava Slovensko"]},
                     "wholesale_pricing": {"is_wholesale": True, "max_discount_pct": 20.0},
-                    "items": [{"label": "Fotopasca Wachman Solar Pro", "quantity": 1, "import_code": "12474", "ean": "8586024430013"}],
+                    "items": [
+                        {
+                            "label": "Fotopasca Wachman Solar Pro",
+                            "quantity": 1,
+                            "import_code": "12474",
+                            "ean": "8586024430013",
+                            "unit_price_formatted": "39,90 EUR",
+                        }
+                    ],
                 }
             ]
         )
@@ -77,6 +85,9 @@ class RoyPickingListsPdfTests(unittest.TestCase):
         self.assertIn("VE\u013dKOOBCHOD / VO CENY", text)
         self.assertIn("OSOBN\u00dd ODBER - NEBALI\u0164", text)
         self.assertIn("VE\u013dKOOBCHODN\u00c1 OBJEDN\u00c1VKA", text)
+        self.assertIn("Cena/ks", text)
+        self.assertIn("39,90 EUR", text)
+        self.assertIn("8586024430013", text)
         self.assertIn("B2B Partner s.r.o.", text)
 
     def test_empty_pdf_is_still_downloadable(self) -> None:


### PR DESCRIPTION
## Summary
- add unit price data to ROY operations order items for picking-list PDFs
- render picking-list quantities larger and bold
- render product EANs as barcodes with small EAN text underneath
- register a real bold font when available for PDF output

## Tests
- python -m py_compile roy_picking_lists_pdf.py roy_operations_dashboard.py live_dashboard_server.py
- python -m unittest tests.test_roy_picking_lists_pdf tests.test_roy_operations_dashboard
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- git diff --check