### PR TITLE
Relax ROY wholesale discount trigger

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3685,3 +3685,22 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - live API returned marker `roy-operations-dashboard`; current fulfillable order items had unit prices on `9/9` rows
 - Next exact step:
   - visually review one newly downloaded picking-list PDF from the dashboard before using it operationally for all orders
+
+### 2026-05-30 (ROY wholesale trigger diagnosis)
+- Branch: `codex/roy-wholesale-discount-trigger`
+- Finding:
+  - direct BiznisWeb check for order `2677002772` now returns customer `Blackmarket s.r.o.` as `Company`
+  - current ROY wholesale logic evaluates order `2677002772` as wholesale: `2/2` priced lines discounted, max discount `49.1%`
+  - local PDF generated from the current code for order `2677002772` contains `VEĽKOOBCHOD / VO CENY`, `VEĽKOOBCHODNÁ OBJEDNÁVKA`, and `VO ceny: áno, zľava do 49.1%`
+  - root risk: ROY config still required BiznisWeb to classify the customer as `Company`; if the customer was not classified that way at print time, discount-only wholesale orders could miss the flag
+- Change:
+  - ROY wholesale detection no longer requires `Company` customer classification; any order line discounted at least `10%` vs current retail final price triggers the wholesale flag
+  - wholesale detection reason text now distinguishes company and non-company discounted orders
+- Local verification:
+  - `python -m json.tool projects\roy\settings.json`
+  - `python -m py_compile roy_operations_dashboard.py roy_picking_lists_pdf.py live_dashboard_server.py`
+  - `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `git diff --check`
+- Next exact step:
+  - commit/push branch, open PR, merge, rebuild ECR image, deploy ROY App Runner, then verify live preview PDF still returns a valid PDF and live orders expose wholesale flags for discounted lines

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -187,7 +187,7 @@
     "wholesale_detection": {
       "enabled": true,
       "discount_threshold_pct": 10,
-      "require_company_customer": true
+      "require_company_customer": false
     }
   },
   "inventory_model": {

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -35,7 +35,7 @@ DEFAULT_STOP_AFTER_EMPTY_FULFILLABLE_PAGES = 3
 DEFAULT_CACHE_TTL_SECONDS = 60
 DEFAULT_AUTO_REFRESH_SECONDS = 90
 DEFAULT_WHOLESALE_DETECTION_DISCOUNT_THRESHOLD_PCT = 10.0
-DEFAULT_WHOLESALE_DETECTION_REQUIRE_COMPANY = True
+DEFAULT_WHOLESALE_DETECTION_REQUIRE_COMPANY = False
 
 
 ROY_OPERATIONS_ORDER_QUERY = gql(
@@ -974,7 +974,10 @@ def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], s
     is_wholesale = discounted_lines > 0 and (is_company or not require_company)
     reason = ""
     if is_wholesale:
-        reason = f"company customer + {discounted_lines}/{priced_lines} discounted line(s) vs current retail final price"
+        if is_company:
+            reason = f"company customer + {discounted_lines}/{priced_lines} discounted line(s) vs current retail final price"
+        else:
+            reason = f"{discounted_lines}/{priced_lines} discounted line(s) vs current retail final price"
     elif discounted_lines > 0:
         reason = f"{discounted_lines}/{priced_lines} discounted line(s), but customer is not Company"
     elif is_company:

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -85,7 +85,7 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(90, operations["auto_refresh_seconds"])
         self.assertEqual(4, operations["shipped_status_id"])
         self.assertEqual(10, operations["wholesale_detection"]["discount_threshold_pct"])
-        self.assertTrue(operations["wholesale_detection"]["require_company_customer"])
+        self.assertFalse(operations["wholesale_detection"]["require_company_customer"])
         self.assertIn("Čaká na vybavenie", operations["cod_statuses"])
         self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["wachman"])
         self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["roy"])
@@ -179,6 +179,40 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("Sklad B2B", row["delivery_address"]["lines"])
         self.assertTrue(row["wholesale_pricing"]["is_wholesale"])
         self.assertEqual(20.0, row["wholesale_pricing"]["max_discount_pct"])
+
+    def test_discounted_order_is_wholesale_even_without_company_customer(self) -> None:
+        settings = make_settings()
+        settings["wholesale_detection"]["require_company_customer"] = False
+        paid_payment = price_element("payment", "Okamžitá platba online", "18")
+        packeta_shipping = price_element("shipping", "Packeta - výdajné miesto", "9")
+        order = make_order("R-DISCOUNT", settings["paid_statuses"][0], paid_payment, packeta_shipping)
+        order["customer"] = {
+            "__typename": "Person",
+            "name": "Retail",
+            "surname": "Customer",
+        }
+        order["items"][0].update(
+            {
+                "tax_rate": 23,
+                "price": {"raw_value": 80.0, "value": 80.0, "formatted": "80,00 €", "is_net_price": True},
+                "product": {
+                    "final_price": {
+                        "raw_value": 123.0,
+                        "value": 123.0,
+                        "formatted": "123,00 €",
+                        "is_net_price": False,
+                    }
+                },
+            }
+        )
+
+        snapshot = build_roy_orders_snapshot(project="roy", orders=[order], settings=settings)
+        wholesale = snapshot["orders"][0]["wholesale_pricing"]
+
+        self.assertTrue(wholesale["is_wholesale"])
+        self.assertFalse(wholesale["customer_is_company"])
+        self.assertEqual(20.0, wholesale["max_discount_pct"])
+        self.assertEqual("1/1 discounted line(s) vs current retail final price", wholesale["reason"])
 
     def test_picking_pdf_orders_are_marked_printed_once(self) -> None:
         orders = [


### PR DESCRIPTION
## Summary
- make ROY wholesale detection discount-driven instead of requiring BiznisWeb Company customer classification
- keep 10% discount threshold vs current retail final price
- clarify wholesale reason text for non-company discounted orders
- record the 2677002772 diagnosis in PROJECT_STATE.md

## Tests
- python -m json.tool projects\\roy\\settings.json
- python -m py_compile roy_operations_dashboard.py roy_picking_lists_pdf.py live_dashboard_server.py
- python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- git diff --check