### PR TITLE
Fix ROY wholesale gross price trigger

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3757,3 +3757,27 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - preview picking-list PDF returned `200`, `130112` bytes, starts with `%PDF-`, and the first wholesale page contains `VEĽKOOBCHOD / VO CENY`, `VEĽKOOBCHODNÁ OBJEDNÁVKA`, and `VO ceny: áno, zľava do 49.1%`
 - Next exact step:
   - if order `2677002772` was printed from an older already-downloaded PDF, use a newly generated PDF for corrected VO banners; future discounted person orders should no longer be flagged as wholesale
+
+### 2026-05-30 (ROY wholesale gross price and coupon guard)
+- Branch: `codex/roy-wholesale-gross-price-trigger`
+- Finding:
+  - BiznisWeb ROY item `price` / `sum` values behave as net values even when `is_net_price=false`, while `product.final_price` behaves as a gross regular price
+  - previous wholesale comparison divided item net prices by VAT again, creating a false `18.7%` discount on full-price person orders
+  - `sum_with_tax / quantity` is the reliable gross item unit price for the live order payload
+  - order `2677002772` satisfies the intended rule: IČO `51983095`, no discount code, HC800 `25.50` vs `29.99` gross, Discovery `59.99` vs `95.90` gross
+- Change:
+  - ROY operations query now fetches item `sum_with_tax`
+  - wholesale detection now treats company signal as present only when `company_id` / IČO exists
+  - wholesale discount comparison now uses gross item unit price vs gross product final price
+  - discount-code price elements (`percent_discount`, coupon/voucher/gift/kód signals) prevent the wholesale flag
+  - wholesale examples now expose `order_unit_gross` and `retail_unit_gross`
+- Local verification:
+  - `python -m json.tool projects\roy\settings.json`
+  - `python -m py_compile roy_operations_dashboard.py roy_picking_lists_pdf.py live_dashboard_server.py`
+  - `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf`
+  - direct current BiznisWeb check with local code returned `fulfillable=6`, `wholesale=2`, wholesale order numbers `2677002789` and `2677002792`; full-price person orders had `max_discount=0.0`, and the discount-code order had `discount_code_used=True`
+  - direct order `2677002772` check returned `wholesale=True`, `discount_code_used=False`, `max_discount_pct=37.4`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
+  - `git diff --check`
+- Next exact step:
+  - commit/push branch, open PR, merge, rebuild ECR, deploy ROY App Runner, then verify live wholesale count and preview PDF banners

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -141,6 +141,12 @@ query GetRoyOperationsOrders($params: OrderParams) {
           formatted
           is_net_price
         }
+        sum_with_tax {
+          value
+          raw_value
+          formatted
+          is_net_price
+        }
         product {
           title
           import_code
@@ -867,17 +873,18 @@ def _customer_info(order: Dict[str, Any]) -> Dict[str, Any]:
     customer = order.get("customer") if isinstance(order.get("customer"), dict) else {}
     customer_type = str(customer.get("__typename") or "").strip()
     company_name = str(customer.get("company_name") or "").strip()
+    company_id = str(customer.get("company_id") or "").strip()
     person_name = _join_name(customer.get("name"), customer.get("surname"))
     display_name = company_name or person_name
     return {
         "type": customer_type,
         "company_name": company_name,
-        "company_id": str(customer.get("company_id") or "").strip(),
+        "company_id": company_id,
         "vat_id": str(customer.get("vat_id") or customer.get("vat_id2") or "").strip(),
         "display_name": display_name,
         "phone": str(customer.get("phone") or "").strip(),
         "email": str(customer.get("email") or "").strip(),
-        "is_company": customer_type == "Company" or bool(company_name),
+        "is_company": bool(company_id),
     }
 
 
@@ -930,6 +937,59 @@ def _price_as_net(price: Any, tax_rate: float) -> Optional[float]:
     return value / (1.0 + (tax_rate / 100.0)) if tax_rate > 0 else value
 
 
+def _price_as_gross(price: Any, tax_rate: float) -> Optional[float]:
+    value = _price_number(price)
+    if value is None:
+        return None
+    if isinstance(price, dict) and bool(price.get("is_net_price")):
+        return value * (1.0 + (tax_rate / 100.0)) if tax_rate > 0 else value
+    return value
+
+
+def _item_unit_gross_price(item: Dict[str, Any]) -> Optional[float]:
+    quantity = _to_float(item.get("quantity"))
+    if quantity <= 0:
+        return None
+    tax_rate = _item_tax_rate(item)
+    gross_total = _price_number(item.get("sum_with_tax"))
+    if gross_total is not None:
+        return gross_total / quantity
+    net_total = _price_number(item.get("sum"))
+    if net_total is not None:
+        return (net_total * (1.0 + (tax_rate / 100.0)) if tax_rate > 0 else net_total) / quantity
+    unit_price = _price_number(item.get("price"))
+    if unit_price is None:
+        return None
+    # BizniWeb ROY item unit prices behave as net values even when is_net_price is false.
+    return unit_price * (1.0 + (tax_rate / 100.0)) if tax_rate > 0 else unit_price
+
+
+def _product_retail_gross_price(item: Dict[str, Any]) -> Optional[float]:
+    product = item.get("product") if isinstance(item.get("product"), dict) else {}
+    return _price_as_gross(product.get("final_price"), _item_tax_rate(item))
+
+
+def _normalize_discount_signal(value: Any) -> str:
+    text = unicodedata.normalize("NFKD", str(value or "").casefold())
+    return "".join(ch for ch in text if not unicodedata.combining(ch)).strip()
+
+
+def _has_discount_code_price_element(order: Dict[str, Any]) -> bool:
+    discount_type_patterns = ("discount", "coupon", "voucher", "gift")
+    discount_text_patterns = ("zlav", "zlava", "kod", "kupon", "coupon", "voucher")
+    for element in order.get("price_elements") or []:
+        if not isinstance(element, dict):
+            continue
+        element_type = _normalize_discount_signal(element.get("type"))
+        title = _normalize_discount_signal(element.get("title"))
+        value = _normalize_discount_signal(element.get("value"))
+        if any(pattern in element_type for pattern in discount_type_patterns):
+            return True
+        if any(pattern in title or pattern in value for pattern in discount_text_patterns):
+            return True
+    return False
+
+
 def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], settings: Dict[str, Any]) -> Dict[str, Any]:
     detection = settings.get("wholesale_detection") if isinstance(settings.get("wholesale_detection"), dict) else {}
     if not detection.get("enabled", True):
@@ -944,13 +1004,13 @@ def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], s
     priced_lines = 0
     discounted_lines = 0
     max_discount_pct = 0.0
+    discount_code_used = _has_discount_code_price_element(order)
     examples: List[Dict[str, Any]] = []
     for item in order.get("items") or []:
         if not isinstance(item, dict):
             continue
-        item_price = _price_as_net(item.get("price"), _item_tax_rate(item))
-        product = item.get("product") if isinstance(item.get("product"), dict) else {}
-        retail_price = _price_as_net(product.get("final_price"), _item_tax_rate(item))
+        item_price = _item_unit_gross_price(item)
+        retail_price = _product_retail_gross_price(item)
         if item_price is None or retail_price is None or item_price <= 0 or retail_price <= 0:
             continue
         priced_lines += 1
@@ -964,20 +1024,22 @@ def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], s
                     {
                         "import_code": str(item.get("import_code") or "").strip(),
                         "label": str(item.get("item_label") or "").strip(),
-                        "order_unit_net": round(item_price, 2),
-                        "retail_unit_net": round(retail_price, 2),
+                        "order_unit_gross": round(item_price, 2),
+                        "retail_unit_gross": round(retail_price, 2),
                         "discount_pct": round(discount_pct, 1),
                     }
                 )
 
     is_company = bool(customer.get("is_company"))
-    is_wholesale = discounted_lines > 0 and (is_company or not require_company)
+    is_wholesale = discounted_lines > 0 and not discount_code_used and (is_company or not require_company)
     reason = ""
     if is_wholesale:
         if is_company:
             reason = f"company customer + {discounted_lines}/{priced_lines} discounted line(s) vs current retail final price"
         else:
             reason = f"{discounted_lines}/{priced_lines} discounted line(s) vs current retail final price"
+    elif discount_code_used:
+        reason = "discount code used"
     elif discounted_lines > 0:
         reason = f"{discounted_lines}/{priced_lines} discounted line(s), but customer is not Company"
     elif is_company:
@@ -990,6 +1052,7 @@ def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], s
         "customer_is_company": is_company,
         "discounted_lines": discounted_lines,
         "priced_lines": priced_lines,
+        "discount_code_used": discount_code_used,
         "max_discount_pct": round(max_discount_pct, 1),
         "threshold_pct": round(threshold_pct, 1),
         "reason": reason,

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -214,6 +214,85 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(20.0, wholesale["max_discount_pct"])
         self.assertEqual("1/1 discounted line(s), but customer is not Company", wholesale["reason"])
 
+    def test_full_price_company_order_is_not_wholesale_from_vat_mismatch(self) -> None:
+        settings = make_settings()
+        paid_payment = price_element("payment", "Okamžitá platba online", "18")
+        packeta_shipping = price_element("shipping", "Packeta - výdajné miesto", "9")
+        order = make_order("R-FULL", settings["paid_statuses"][0], paid_payment, packeta_shipping)
+        order["customer"] = {
+            "__typename": "Company",
+            "company_name": "Company Buyer s.r.o.",
+            "company_id": "12345678",
+        }
+        order["items"][0].update(
+            {
+                "tax_rate": 23,
+                "quantity": 1,
+                "price": {"raw_value": 40.642276422764, "value": 40.64, "formatted": "40,64 €", "is_net_price": False},
+                "sum": {"raw_value": 40.642276422764, "value": 40.64, "formatted": "40,64 €", "is_net_price": False},
+                "sum_with_tax": {"raw_value": 49.99, "value": 49.99, "formatted": "49,99 €", "is_net_price": True},
+                "product": {
+                    "final_price": {
+                        "raw_value": 49.99,
+                        "value": 49.99,
+                        "formatted": "49,99 €",
+                        "is_net_price": False,
+                    }
+                },
+            }
+        )
+
+        snapshot = build_roy_orders_snapshot(project="roy", orders=[order], settings=settings)
+        wholesale = snapshot["orders"][0]["wholesale_pricing"]
+
+        self.assertFalse(wholesale["is_wholesale"])
+        self.assertTrue(wholesale["customer_is_company"])
+        self.assertEqual(0.0, wholesale["max_discount_pct"])
+        self.assertEqual("company customer, no wholesale price discount detected", wholesale["reason"])
+
+    def test_discount_code_prevents_wholesale_flag(self) -> None:
+        settings = make_settings()
+        paid_payment = price_element("payment", "Okamžitá platba online", "18")
+        packeta_shipping = price_element("shipping", "Packeta - výdajné miesto", "9")
+        discount = {
+            "type": "percent_discount",
+            "title": "5% kod (5%)",
+            "value": "5",
+            "reference_id": "5",
+            "price": {"value": -5, "formatted": "-5,00 €"},
+        }
+        order = make_order("R-CODE", settings["paid_statuses"][0], paid_payment, packeta_shipping)
+        order["price_elements"].append(discount)
+        order["customer"] = {
+            "__typename": "Company",
+            "company_name": "Code Buyer s.r.o.",
+            "company_id": "12345678",
+        }
+        order["items"][0].update(
+            {
+                "tax_rate": 23,
+                "quantity": 1,
+                "sum_with_tax": {"raw_value": 80.0, "value": 80.0, "formatted": "80,00 €", "is_net_price": True},
+                "product": {
+                    "final_price": {
+                        "raw_value": 100.0,
+                        "value": 100.0,
+                        "formatted": "100,00 €",
+                        "is_net_price": False,
+                    }
+                },
+            }
+        )
+
+        snapshot = build_roy_orders_snapshot(project="roy", orders=[order], settings=settings)
+        wholesale = snapshot["orders"][0]["wholesale_pricing"]
+
+        self.assertFalse(wholesale["is_wholesale"])
+        self.assertTrue(wholesale["customer_is_company"])
+        self.assertTrue(wholesale["discount_code_used"])
+        self.assertEqual(20.0, wholesale["max_discount_pct"])
+        self.assertEqual("discount code used", wholesale["reason"])
+
     def test_picking_pdf_orders_are_marked_printed_once(self) -> None:
         orders = [
             {"order_num": "R-1", "status": "Platba online - zaplatené", "purchase_at": "2026-05-28 09:00:00", "sum": "10,00 €"},


### PR DESCRIPTION
## Summary
- compare ROY wholesale item prices as gross values using sum_with_tax / quantity vs product final price
- treat company signal as present only when IČO/company_id exists
- block wholesale flag when a discount code/coupon/voucher/gift price element is present
- add regressions for VAT mismatch and discount code cases

## Tests
- python -m json.tool projects\\roy\\settings.json
- python -m py_compile roy_operations_dashboard.py roy_picking_lists_pdf.py live_dashboard_server.py
- python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf
- direct current BiznisWeb check with local code: fulfillable=6, wholesale=2, 2677002772 wholesale=True
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
- git diff --check