### PR TITLE
Filter reporting revenue by payment state

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3815,6 +3815,7 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
 
 ### 2026-06-02 (VEVO/ROY realized revenue payment filter)
 - Branch: `codex/realized-revenue-payment-filter`
+- PR: `#151` (`https://github.com/vzeman/biznisweb/pull/151`)
 - Context:
   - ROY report for `2026-06-01` counted transfer order `2677002831` even though it was not paid yet
   - reporting revenue is item-level net revenue (`item_total_without_tax`), not gross order total with VAT/shipping

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -3812,3 +3812,31 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - preview picking-list PDF returned `200`, `130112` bytes, starts with `%PDF-`, and first page contains `VEĽKOOBCHOD / VO CENY`, `VEĽKOOBCHODNÁ OBJEDNÁVKA`, and `VO ceny: áno, zľava do 37.4%`
 - Next exact step:
   - use newly generated picking-list PDFs for future VO checks; the older already-downloaded PDFs do not recalculate banners
+
+### 2026-06-02 (VEVO/ROY realized revenue payment filter)
+- Branch: `codex/realized-revenue-payment-filter`
+- Context:
+  - ROY report for `2026-06-01` counted transfer order `2677002831` even though it was not paid yet
+  - reporting revenue is item-level net revenue (`item_total_without_tax`), not gross order total with VAT/shipping
+- Change:
+  - realized reporting revenue now includes only:
+    - COD payment with status `Čaká na vybavenie` or `Odoslaná`
+    - status `Platba online - zaplatené` for paid online-card / bank-transfer orders
+  - all other statuses/payments are excluded until the order reaches `Platba online - zaplatené`, at which point the order is counted retroactively on its original purchase date
+  - the same `realized_revenue` config is defined for VEVO and ROY
+  - order query now fetches `price_elements`, and exported CSV rows include payment/shipping audit fields plus realized-revenue decision fields
+  - order cache schema bumped to `2`, so old cached order days without payment metadata are refreshed before reporting
+- Local verification:
+  - `python -m py_compile export_orders.py`
+  - `python -m json.tool projects\vevo\settings.json`
+  - `python -m json.tool projects\roy\settings.json`
+  - `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity` (`62` tests OK)
+  - `git diff --check`
+- Live read-only verification:
+  - ROY `2026-06-01`: current API returned `14` orders; new realized-revenue filter includes `13`
+  - order `2677002831` is excluded with reason `cod_status_without_cod_payment` because status is `Čaká na vybavenie` and payment is `Bankovým prevodom` (`reference_id=6`)
+  - ROY item-net revenue for `2026-06-01` changes from `1401.46` to `791.83` EUR under the new filter
+- Known issues:
+  - production is not deployed yet; corrected historical figures require PR merge, image rebuild, and a full-history reporting refresh for VEVO and ROY
+- Next exact step:
+  - commit/push this branch, open PR, merge to `main`, rebuild the reporting image, run VEVO/ROY full-history reports, then verify on host with localhost marker before UI smoke

--- a/export_orders.py
+++ b/export_orders.py
@@ -116,7 +116,8 @@ ZERO_COST_LABEL_PATTERNS: List[str] = []  # Optional label patterns forced to 0 
 MARGIN_15_BRANDS: List[str] = []  # Optional brands forced to 15% product margin
 MARGIN_15_LABEL_PATTERNS: List[str] = []  # Optional label patterns forced to 15% product margin
 EXCLUDE_ZERO_PRICE_LABEL_PATTERNS: List[str] = []  # Optional label patterns excluded only when line price is 0
-EXCLUDED_ORDER_STATUSES: List[str] = []  # Optional project-specific order statuses excluded from realized revenue
+EXCLUDED_ORDER_STATUSES: List[str] = []  # Legacy status-only exclude list retained for compatibility
+ORDER_CACHE_SCHEMA_VERSION = 2
 MANUAL_FB_ADS_TOTAL: Optional[float] = None  # Optional fixed total FB spend for selected report range
 MANUAL_GOOGLE_ADS_TOTAL: Optional[float] = None  # Optional fixed total Google spend for selected report range
 PREFER_MANUAL_ADS_TOTALS = False
@@ -205,6 +206,24 @@ DEFAULT_EXCLUDED_ORDER_STATUSES = [
 FAILED_PAYMENT_STATUSES = [
     'Platba online - platnosť vypršala',
     'Platba online - platba zamietnutá',
+]
+DEFAULT_REALIZED_REVENUE_PAID_STATUSES = [
+    'Platba online - zaplatené',
+]
+DEFAULT_REALIZED_REVENUE_COD_STATUSES = [
+    'Čaká na vybavenie',
+    'Odoslaná',
+]
+DEFAULT_REALIZED_REVENUE_COD_PAYMENT_PATTERNS = [
+    'dobierka',
+    'dobierkou',
+    'dobírka',
+    'dobírkou',
+    'cash on delivery',
+]
+DEFAULT_REALIZED_REVENUE_COD_PAYMENT_IDS = [
+    '7',
+    '10',
 ]
 
 
@@ -300,6 +319,18 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
         id
         name
         color
+      }
+      price_elements {
+        type
+        title
+        value
+        reference_id
+        price {
+          value
+          raw_value
+          formatted
+          is_net_price
+        }
       }
       customer {
         ... on Company {
@@ -475,6 +506,7 @@ class BizniWebExporter:
         self.enable_period_bundle = enable_period_bundle
         self.project_settings = load_project_settings(project_name)
         self.reporting_defaults = resolve_reporting_defaults(project_name, self.project_settings)
+        self.realized_revenue_settings = self._resolve_realized_revenue_settings()
         self.project_root_dir = Path("data") / project_name
         self.data_dir = self.project_root_dir / normalized_subdir if normalized_subdir else self.project_root_dir
         self.data_dir.mkdir(parents=True, exist_ok=True)
@@ -2013,6 +2045,96 @@ class BizniWebExporter:
         return re.sub(r'\s+', ' ', text).strip()
 
     @staticmethod
+    def _as_config_list(value: Any, default: List[str]) -> List[str]:
+        if value is None:
+            return list(default)
+        if isinstance(value, str):
+            return [value] if value.strip() else []
+        return [str(item).strip() for item in value if str(item or "").strip()]
+
+    @staticmethod
+    def _price_elements(order: Dict[str, Any], element_type: str) -> List[Dict[str, Any]]:
+        wanted = BizniWebExporter._normalize_match_text(element_type)
+        return [
+            element
+            for element in order.get("price_elements") or []
+            if BizniWebExporter._normalize_match_text((element or {}).get("type")) == wanted
+        ]
+
+    @staticmethod
+    def _price_element_info(order: Dict[str, Any], element_type: str) -> Dict[str, Any]:
+        elements = BizniWebExporter._price_elements(order, element_type)
+        if not elements:
+            return {"title": "", "reference_id": "", "value": "", "price": None}
+        first = elements[0] or {}
+        return {
+            "title": str(first.get("title") or "").strip(),
+            "reference_id": str(first.get("reference_id") or "").strip(),
+            "value": str(first.get("value") or "").strip(),
+            "price": first.get("price") or None,
+        }
+
+    def _resolve_realized_revenue_settings(self) -> Dict[str, Any]:
+        raw = self.project_settings.get("realized_revenue") or {}
+        paid_statuses = self._as_config_list(
+            raw.get("paid_statuses"),
+            DEFAULT_REALIZED_REVENUE_PAID_STATUSES,
+        )
+        cod_statuses = self._as_config_list(
+            raw.get("cod_statuses"),
+            DEFAULT_REALIZED_REVENUE_COD_STATUSES,
+        )
+        cod_payment_patterns = self._as_config_list(
+            raw.get("cod_payment_patterns"),
+            DEFAULT_REALIZED_REVENUE_COD_PAYMENT_PATTERNS,
+        )
+        cod_payment_ids = self._as_config_list(
+            raw.get("cod_payment_ids"),
+            DEFAULT_REALIZED_REVENUE_COD_PAYMENT_IDS,
+        )
+        return {
+            "paid_statuses": paid_statuses,
+            "paid_statuses_normalized": {self._normalize_match_text(status) for status in paid_statuses},
+            "cod_statuses": cod_statuses,
+            "cod_statuses_normalized": {self._normalize_match_text(status) for status in cod_statuses},
+            "cod_payment_patterns": cod_payment_patterns,
+            "cod_payment_patterns_normalized": {
+                self._normalize_match_text(pattern)
+                for pattern in cod_payment_patterns
+                if self._normalize_match_text(pattern)
+            },
+            "cod_payment_ids": {str(value).strip() for value in cod_payment_ids if str(value).strip()},
+        }
+
+    def _is_cod_payment(self, order: Dict[str, Any]) -> bool:
+        payment = self._price_element_info(order, "payment")
+        reference_id = str(payment.get("reference_id") or "").strip()
+        if reference_id and reference_id in self.realized_revenue_settings["cod_payment_ids"]:
+            return True
+        payment_title = self._normalize_match_text(payment.get("title"))
+        return any(
+            pattern and pattern in payment_title
+            for pattern in self.realized_revenue_settings["cod_payment_patterns_normalized"]
+        )
+
+    def _realized_revenue_decision(self, order: Dict[str, Any]) -> Tuple[bool, str]:
+        status_name = str(((order or {}).get("status") or {}).get("name") or "").strip()
+        status_norm = self._normalize_match_text(status_name)
+        settings = self.realized_revenue_settings
+
+        if status_norm in settings["paid_statuses_normalized"]:
+            return True, "paid_status"
+
+        if status_norm in settings["cod_statuses_normalized"]:
+            if self._is_cod_payment(order):
+                return True, "cod_status_and_payment"
+            return False, "cod_status_without_cod_payment"
+
+        if not status_norm:
+            return False, "missing_status"
+        return False, "non_realized_status"
+
+    @staticmethod
     def _compose_expense_key(*parts: Any) -> str:
         normalized_parts = [str(part or "").strip() for part in parts]
         if not normalized_parts or any(not part for part in normalized_parts):
@@ -3225,26 +3347,7 @@ class BizniWebExporter:
 
         logger.info(f"Filtered to {len(date_filtered_orders)} orders within date range for month")
 
-        # Filter out orders with excluded statuses
-        excluded_statuses = get_excluded_order_statuses()
-
-        filtered_orders = []
-        excluded_counts = {}
-
-        for order in date_filtered_orders:
-            status = order.get('status', {}) or {}
-            status_name = status.get('name', '')
-
-            if status_name not in excluded_statuses:
-                filtered_orders.append(order)
-            else:
-                excluded_counts[status_name] = excluded_counts.get(status_name, 0) + 1
-
-        # Report excluded orders
-        if excluded_counts:
-            print("\nFiltered out orders:")
-            for status, count in excluded_counts.items():
-                print(f"  - {status}: {count} orders")
+        filtered_orders = self._filter_by_status(date_filtered_orders)
 
         logger.info(f"Final count after status filtering for month: {len(filtered_orders)} orders")
 
@@ -3322,6 +3425,13 @@ class BizniWebExporter:
         try:
             with open(cache_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
+                schema_version = int(data.get('schema_version') or 0)
+                if schema_version < ORDER_CACHE_SCHEMA_VERSION:
+                    print(
+                        f"  Cache schema outdated for {date.strftime('%Y-%m-%d')} "
+                        f"(found {schema_version}, need {ORDER_CACHE_SCHEMA_VERSION}); refreshing"
+                    )
+                    return None
                 print(f"  Loaded {len(data.get('orders', []))} orders from cache for {date.strftime('%Y-%m-%d')}")
                 return data.get('orders', [])
         except Exception as e:
@@ -3349,6 +3459,7 @@ class BizniWebExporter:
                         day_orders.append(order)
             
             cache_data = {
+                'schema_version': ORDER_CACHE_SCHEMA_VERSION,
                 'date': date_str,
                 'cached_at': datetime.now().isoformat(),
                 'order_count': len(day_orders),
@@ -3700,30 +3811,41 @@ class BizniWebExporter:
         return final_validated_orders
 
     def _filter_by_status(self, orders: List[Dict[str, Any]], track_excluded: bool = True) -> List[Dict[str, Any]]:
-        """Filter out orders with excluded statuses.
+        """Keep only orders that should count as realized reporting revenue.
+
+        Current realized revenue definition:
+        - COD payment + status "Čaká na vybavenie" or "Odoslaná"
+        - Paid online / bank-transfer status "Platba online - zaplatené"
 
         Args:
             orders: List of orders to filter
             track_excluded: If True, store excluded orders for later segmentation analysis
         """
-        excluded_statuses = get_excluded_order_statuses()
-
         # Statuses for failed payment segmentation (subset of excluded)
         failed_payment_statuses = FAILED_PAYMENT_STATUSES
 
         filtered_orders = []
+        excluded_counts: Dict[str, int] = {}
         for order in orders:
             status = order.get('status', {}) or {}
             status_name = status.get('name', '')
+            include_order, reason = self._realized_revenue_decision(order)
 
-            if status_name not in excluded_statuses:
+            if include_order:
                 filtered_orders.append(order)
             else:
+                excluded_counts[reason] = excluded_counts.get(reason, 0) + 1
                 if track_excluded:
                     self.excluded_status_orders.append(order)
                 if track_excluded and status_name in failed_payment_statuses:
                     # Track failed payment orders for segmentation
                     self.excluded_orders.append(order)
+
+        if excluded_counts:
+            logger.info(
+                "Realized revenue filter excluded orders: "
+                + ", ".join(f"{reason}={count}" for reason, count in sorted(excluded_counts.items()))
+            )
 
         return filtered_orders
     
@@ -3733,6 +3855,7 @@ class BizniWebExporter:
         
         try:
             cache_data = {
+                'schema_version': ORDER_CACHE_SCHEMA_VERSION,
                 'date': date.strftime('%Y-%m-%d'),
                 'cached_at': datetime.now().isoformat(),
                 'order_count': len(orders),
@@ -3896,26 +4019,7 @@ class BizniWebExporter:
 
         logger.info(f"Filtered to {len(date_filtered_orders)} orders within date range")
 
-        # Filter out orders with excluded statuses
-        excluded_statuses = get_excluded_order_statuses()
-
-        filtered_orders = []
-        excluded_counts = {}
-
-        for order in date_filtered_orders:
-            status = order.get('status', {}) or {}
-            status_name = status.get('name', '')
-
-            if status_name not in excluded_statuses:
-                filtered_orders.append(order)
-            else:
-                excluded_counts[status_name] = excluded_counts.get(status_name, 0) + 1
-
-        # Report excluded orders
-        if excluded_counts:
-            print("\nFiltered out orders:")
-            for status, count in excluded_counts.items():
-                print(f"  - {status}: {count} orders")
+        filtered_orders = self._filter_by_status(date_filtered_orders)
 
         logger.info(f"Final count after status filtering: {len(filtered_orders)} orders")
 
@@ -3931,6 +4035,9 @@ class BizniWebExporter:
         delivery_addr = order.get('delivery_address', {}) or {}
         status = order.get('status', {}) or {}
         order_sum = order.get('sum', {}) or {}
+        payment = self._price_element_info(order, "payment")
+        shipping = self._price_element_info(order, "shipping")
+        realized_revenue, realized_revenue_reason = self._realized_revenue_decision(order)
         
         # Get order currency
         order_currency = order_sum.get('currency', {}).get('code') if order_sum.get('currency') else 'EUR'
@@ -3958,7 +4065,13 @@ class BizniWebExporter:
             # Status
             'status_id': status.get('id'),
             'status_name': status.get('name'),
-            
+            'realized_revenue': realized_revenue,
+            'realized_revenue_reason': realized_revenue_reason,
+            'payment_title': payment.get('title'),
+            'payment_reference_id': payment.get('reference_id'),
+            'shipping_title': shipping.get('title'),
+            'shipping_reference_id': shipping.get('reference_id'),
+
             # Customer
             'customer_name': customer_name,
             'customer_company_id': customer.get('company_id'),
@@ -4434,6 +4547,8 @@ class BizniWebExporter:
         # Reorder columns for better readability
         column_order = [
             'order_num', 'order_id', 'external_ref', 'purchase_date', 'status_name',
+            'realized_revenue', 'realized_revenue_reason',
+            'payment_title', 'payment_reference_id', 'shipping_title', 'shipping_reference_id',
             'total_items_in_order', 'item_number',
             'product_sku', 'item_label', 'item_ean', 'item_quantity', 
             'item_currency', 'item_unit_price_original', 'item_unit_price',

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -79,6 +79,26 @@
     "timezone": "Europe/Bratislava",
     "task_family": "roy-invoice-daily"
   },
+  "realized_revenue": {
+    "paid_statuses": [
+      "Platba online - zaplatené"
+    ],
+    "cod_statuses": [
+      "Čaká na vybavenie",
+      "Odoslaná"
+    ],
+    "cod_payment_patterns": [
+      "dobierka",
+      "dobierkou",
+      "dobírka",
+      "dobírkou",
+      "cash on delivery"
+    ],
+    "cod_payment_ids": [
+      "7",
+      "10"
+    ]
+  },
   "unpaid_order_cancellation": {
     "enabled": true,
     "age_days": 14,

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -53,6 +53,26 @@
     "timezone": "Europe/Bratislava",
     "task_family": "vevo-invoice-daily"
   },
+  "realized_revenue": {
+    "paid_statuses": [
+      "Platba online - zaplatené"
+    ],
+    "cod_statuses": [
+      "Čaká na vybavenie",
+      "Odoslaná"
+    ],
+    "cod_payment_patterns": [
+      "dobierka",
+      "dobierkou",
+      "dobírka",
+      "dobírkou",
+      "cash on delivery"
+    ],
+    "cod_payment_ids": [
+      "7",
+      "10"
+    ]
+  },
   "excluded_order_statuses": [
     "madfrog stara odoslana"
   ],

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -35,6 +35,26 @@ def write_order_cache(exporter: BizniWebExporter, order_date: datetime, cached_a
     return cache_file
 
 
+def price_element(element_type: str, title: str, reference_id: str) -> dict:
+    return {
+        "type": element_type,
+        "title": title,
+        "reference_id": reference_id,
+        "value": "",
+        "price": {"value": 0, "formatted": "0 €", "is_net_price": False},
+    }
+
+
+def reporting_order(order_num: str, status_name: str, payment_title: str, payment_ref: str) -> dict:
+    return {
+        "id": order_num,
+        "order_num": order_num,
+        "pur_date": "2026-06-01 10:00:00",
+        "status": {"name": status_name},
+        "price_elements": [price_element("payment", payment_title, payment_ref)],
+    }
+
+
 class ReportingCalculationFixTests(unittest.TestCase):
     def test_unknown_currency_is_not_treated_as_eur(self) -> None:
         exporter = make_exporter()
@@ -247,6 +267,71 @@ class ReportingCalculationFixTests(unittest.TestCase):
 
             write_order_cache(exporter, old_date, today - timedelta(days=90))
             self.assertFalse(exporter.should_use_cache(old_date, today=today))
+
+    def test_realized_revenue_filter_counts_only_paid_or_cod_orders(self) -> None:
+        exporter = make_exporter()
+        orders = [
+            reporting_order("COD-WAIT", "Čaká na vybavenie", "Dobierkou", "7"),
+            reporting_order("COD-SHIPPED", "Odoslaná", "Dobírka", "10"),
+            reporting_order("PAID-CARD", "Platba online - zaplatené", "Okamžitá platba online", "18"),
+            reporting_order("PAID-BANK", "Platba online - zaplatené", "Bankovým prevodom", "6"),
+            reporting_order("BANK-WAIT", "Čaká na vybavenie", "Bankovým prevodom", "6"),
+            reporting_order("CARD-WAIT", "Čaká na vybavenie", "Okamžitá platba online", "18"),
+            reporting_order("BANK-SHIPPED", "Odoslaná", "Bankovým prevodom", "6"),
+            reporting_order("CANCELLED", "Nezaplatená - zrušená objednávka", "Bankovým prevodom", "6"),
+        ]
+
+        filtered = exporter._filter_by_status(orders, track_excluded=False)
+
+        self.assertEqual(
+            ["COD-WAIT", "COD-SHIPPED", "PAID-CARD", "PAID-BANK"],
+            [order["order_num"] for order in filtered],
+        )
+
+    def test_flatten_order_exports_payment_audit_fields(self) -> None:
+        exporter = make_exporter()
+        order = {
+            "id": "PAID-BANK",
+            "order_num": "PAID-BANK",
+            "pur_date": "2026-06-01 10:00:00",
+            "status": {"name": "Platba online - zaplatené"},
+            "price_elements": [price_element("payment", "Bankovým prevodom", "6")],
+            "sum": {"value": 123.0, "currency": {"code": "EUR"}},
+            "customer": {"email": "a@example.com"},
+            "items": [
+                {
+                    "item_label": "Unknown unit-test product",
+                    "ean": "",
+                    "quantity": 1,
+                    "tax_rate": 23,
+                    "price": {"value": 100.0, "currency": {"code": "EUR"}},
+                    "sum": {"value": 100.0, "currency": {"code": "EUR"}},
+                    "sum_with_tax": {"value": 123.0, "currency": {"code": "EUR"}},
+                }
+            ],
+        }
+
+        rows = exporter.flatten_order(order)
+
+        self.assertEqual("Bankovým prevodom", rows[0]["payment_title"])
+        self.assertEqual("6", rows[0]["payment_reference_id"])
+        self.assertTrue(rows[0]["realized_revenue"])
+        self.assertEqual("paid_status", rows[0]["realized_revenue_reason"])
+
+    def test_old_order_cache_without_current_schema_is_revalidated(self) -> None:
+        exporter = make_exporter()
+        today = datetime(2026, 5, 20)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            exporter.cache_dir = Path(tmp_dir)
+            order_date = today - timedelta(days=30)
+            write_order_cache(
+                exporter,
+                order_date,
+                today,
+                [reporting_order("LEGACY", "Odoslaná", "Dobierkou", "7")],
+            )
+
+            self.assertIsNone(exporter.load_from_cache(order_date))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Count realized reporting revenue only for COD orders in `?ak? na vybavenie` / `Odoslan?` and paid online/bank-transfer orders in `Platba online - zaplaten?`.
- Apply the same `realized_revenue` config to VEVO and ROY.
- Fetch payment `price_elements`, export payment/audit fields, and bump order-cache schema so old cached days refresh with payment metadata.

## Verification
- `python -m py_compile export_orders.py`
- `python -m json.tool projects\vevo\settings.json`
- `python -m json.tool projects\roy\settings.json`
- `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity` (`62` tests OK)
- `git diff --check`

## Live read-only sanity
- ROY `2026-06-01`: API returned `14` orders; new filter includes `13`.
- Order `2677002831` is excluded because it is `?ak? na vybavenie` with payment `Bankov?m prevodom` (`reference_id=6`).
- Item-net reporting revenue changes from `1401.46` to `791.83` EUR for that day under the new filter.

## Next after merge
- Rebuild reporting image, run VEVO/ROY full-history reports, then verify host localhost marker before UI smoke.
