### PR TITLE
Harden order payment metadata fallback

### DIFF
--- a/export_orders.py
+++ b/export_orders.py
@@ -431,6 +431,142 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
 }
 """)
 
+ORDER_QUERY_WITHOUT_PRICE_ELEMENTS = gql("""
+query GetOrdersWithoutPriceElements($filter: OrderFilter, $params: OrderParams) {
+  getOrderList(filter: $filter, params: $params) {
+    data {
+      id
+      order_num
+      external_ref
+      pur_date
+      var_symb
+      last_change
+      oss
+      oss_country
+      status {
+        id
+        name
+        color
+      }
+      customer {
+        ... on Company {
+          company_name
+          company_id
+          vat_id
+          vat_id2
+          name
+          surname
+          email
+        }
+        ... on Person {
+          name
+          surname
+          email
+        }
+        ... on UnauthenticatedEmail {
+          name
+          surname
+          email
+        }
+      }
+      invoice_address {
+        street
+        descriptive_number
+        orientation_number
+        city
+        zip
+        country
+      }
+      items {
+        item_label
+        ean
+        import_code
+        warehouse_number
+        quantity
+        tax_rate
+        weight {
+          value
+          unit
+        }
+        recycle_fee {
+          value
+          formatted
+          is_net_price
+          currency {
+            symbol
+            code
+          }
+        }
+        price {
+          value
+          formatted
+          is_net_price
+          currency {
+            symbol
+            code
+          }
+        }
+        sum {
+          value
+          formatted
+          is_net_price
+          currency {
+            symbol
+            code
+          }
+        }
+        sum_with_tax {
+          value
+          formatted
+          is_net_price
+          currency {
+            symbol
+            code
+          }
+        }
+      }
+      sum {
+        value
+        formatted
+        is_net_price
+        currency {
+          symbol
+          code
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      nextCursor
+      previousCursor
+      pageIndex
+      totalPages
+    }
+  }
+}
+""")
+
+ORDER_PAYMENT_QUERY = gql("""
+query GetOrderPaymentMetadata($order_num: String!) {
+  getOrder(order_num: $order_num) {
+    order_num
+    price_elements {
+      type
+      title
+      value
+      reference_id
+      price {
+        value
+        raw_value
+        formatted
+        is_net_price
+      }
+    }
+  }
+}
+""")
+
 PRODUCT_INVENTORY_QUERY = gql("""
 query GetProductInventory($lang_code: CountryCodeAlpha2!, $params: ProductParams) {
   getProductList(lang_code: $lang_code, params: $params) {
@@ -2074,6 +2210,21 @@ class BizniWebExporter:
             "price": first.get("price") or None,
         }
 
+    @staticmethod
+    def _has_loaded_price_elements(order: Dict[str, Any]) -> bool:
+        return isinstance((order or {}).get("price_elements"), list)
+
+    @staticmethod
+    def _status_name(order: Dict[str, Any]) -> str:
+        return str(((order or {}).get("status") or {}).get("name") or "").strip()
+
+    def _status_norm(self, order: Dict[str, Any]) -> str:
+        return self._normalize_match_text(self._status_name(order))
+
+    @staticmethod
+    def _is_price_elements_error(error: Exception) -> bool:
+        return "price_elements" in str(error or "")
+
     def _resolve_realized_revenue_settings(self) -> Dict[str, Any]:
         raw = self.project_settings.get("realized_revenue") or {}
         paid_statuses = self._as_config_list(
@@ -2118,14 +2269,15 @@ class BizniWebExporter:
         )
 
     def _realized_revenue_decision(self, order: Dict[str, Any]) -> Tuple[bool, str]:
-        status_name = str(((order or {}).get("status") or {}).get("name") or "").strip()
-        status_norm = self._normalize_match_text(status_name)
+        status_norm = self._status_norm(order)
         settings = self.realized_revenue_settings
 
         if status_norm in settings["paid_statuses_normalized"]:
             return True, "paid_status"
 
         if status_norm in settings["cod_statuses_normalized"]:
+            if not self._has_loaded_price_elements(order):
+                return False, "cod_status_missing_payment_metadata"
             if self._is_cod_payment(order):
                 return True, "cod_status_and_payment"
             return False, "cod_status_without_cod_payment"
@@ -2133,6 +2285,81 @@ class BizniWebExporter:
         if not status_norm:
             return False, "missing_status"
         return False, "non_realized_status"
+
+    def _needs_payment_metadata_for_realized_revenue(self, order: Dict[str, Any]) -> bool:
+        if self._has_loaded_price_elements(order):
+            return False
+        status_norm = self._status_norm(order)
+        return status_norm in self.realized_revenue_settings["cod_statuses_normalized"]
+
+    def _fetch_order_payment_metadata(self, order: Dict[str, Any]) -> bool:
+        order_num = str((order or {}).get("order_num") or "").strip()
+        if not order_num:
+            return False
+
+        try:
+            result = self.client.execute(
+                ORDER_PAYMENT_QUERY,
+                variable_values={"order_num": order_num},
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Could not fetch payment metadata for order {order_num}: {str(exc)[:200]}"
+            )
+            return False
+
+        fetched_order = (result or {}).get("getOrder") or {}
+        price_elements = fetched_order.get("price_elements")
+        if isinstance(price_elements, list):
+            order["price_elements"] = price_elements
+            return True
+
+        logger.warning(f"Payment metadata missing in getOrder response for order {order_num}")
+        return False
+
+    def _enrich_payment_metadata_for_realized_revenue(self, orders: List[Dict[str, Any]]) -> None:
+        candidates = [
+            order
+            for order in orders
+            if self._needs_payment_metadata_for_realized_revenue(order)
+        ]
+        if not candidates:
+            return
+
+        success_count = 0
+        for order in candidates:
+            if self._fetch_order_payment_metadata(order):
+                success_count += 1
+
+        failed_count = len(candidates) - success_count
+        logger.info(
+            "Payment metadata enrichment for realized revenue: "
+            f"attempted={len(candidates)}, succeeded={success_count}, failed={failed_count}"
+        )
+
+    def _execute_order_page_with_price_elements_fallback(
+        self,
+        variables: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        try:
+            return self.client.execute(ORDER_QUERY, variable_values=variables)
+        except Exception as exc:
+            if not self._is_price_elements_error(exc):
+                raise
+
+            params = dict((variables or {}).get("params") or {})
+            logger.warning(
+                "Order page failed while fetching price_elements; "
+                "retrying page without price_elements "
+                f"(sort={params.get('sort')}, cursor_present={bool(params.get('cursor'))})"
+            )
+            result = self.client.execute(
+                ORDER_QUERY_WITHOUT_PRICE_ELEMENTS,
+                variable_values=variables,
+            )
+            orders = ((result or {}).get("getOrderList") or {}).get("data") or []
+            self._enrich_payment_metadata_for_realized_revenue(orders)
+            return result
 
     @staticmethod
     def _compose_expense_key(*parts: Any) -> str:
@@ -3280,7 +3507,7 @@ class BizniWebExporter:
             
             while retry_count < max_retries and not success:
                 try:
-                    result = self.client.execute(ORDER_QUERY, variable_values=variables)
+                    result = self._execute_order_page_with_price_elements_fallback(variables)
                     orders_data = result.get('getOrderList', {})
                     orders = orders_data.get('data', [])
                     all_orders.extend(orders)
@@ -3533,7 +3760,7 @@ class BizniWebExporter:
 
             while retry_count < max_retries and not success:
                 try:
-                    result = self.client.execute(ORDER_QUERY, variable_values=variables)
+                    result = self._execute_order_page_with_price_elements_fallback(variables)
                     orders_data = result.get('getOrderList', {})
                     orders = orders_data.get('data', [])
                     all_orders.extend(orders)
@@ -3952,7 +4179,7 @@ class BizniWebExporter:
 
             while retry_count < max_retries and not success:
                 try:
-                    result = self.client.execute(ORDER_QUERY, variable_values=variables)
+                    result = self._execute_order_page_with_price_elements_fallback(variables)
                     orders_data = result.get('getOrderList', {})
                     orders = orders_data.get('data', [])
                     all_orders.extend(orders)

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -288,6 +288,72 @@ class ReportingCalculationFixTests(unittest.TestCase):
             [order["order_num"] for order in filtered],
         )
 
+    def test_cod_status_without_payment_metadata_is_not_counted(self) -> None:
+        exporter = make_exporter()
+
+        missing_metadata = {
+            "order_num": "COD-MISSING",
+            "status": {"name": "Odoslana"},
+        }
+        paid_without_metadata = {
+            "order_num": "PAID-MISSING",
+            "status": {"name": "Platba online - zaplatene"},
+        }
+
+        self.assertEqual(
+            (False, "cod_status_missing_payment_metadata"),
+            exporter._realized_revenue_decision(missing_metadata),
+        )
+        self.assertEqual(
+            (True, "paid_status"),
+            exporter._realized_revenue_decision(paid_without_metadata),
+        )
+
+    def test_price_elements_page_failure_falls_back_and_enriches_cod_orders(self) -> None:
+        exporter = make_exporter()
+
+        class FallbackClient:
+            def __init__(self) -> None:
+                self.calls = []
+
+            def execute(self, query, variable_values=None):
+                self.calls.append((query, variable_values))
+                if len(self.calls) == 1:
+                    raise Exception("{'path': ['getOrderList', 'data', 5, 'price_elements']}")
+                if len(self.calls) == 2:
+                    return {
+                        "getOrderList": {
+                            "data": [
+                                {
+                                    "id": "COD-FALLBACK",
+                                    "order_num": "COD-FALLBACK",
+                                    "pur_date": "2026-06-01 09:00:00",
+                                    "status": {"name": "Odoslana"},
+                                }
+                            ],
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "nextCursor": None,
+                            },
+                        }
+                    }
+                return {
+                    "getOrder": {
+                        "order_num": "COD-FALLBACK",
+                        "price_elements": [price_element("payment", "Dobierkou", "7")],
+                    }
+                }
+
+        exporter.client = FallbackClient()
+
+        orders, next_cursor = exporter.fetch_all_orders_bulk(max_orders=30)
+        filtered = exporter._filter_by_status(orders, track_excluded=False)
+
+        self.assertIsNone(next_cursor)
+        self.assertEqual(["COD-FALLBACK"], [order["order_num"] for order in filtered])
+        self.assertEqual("Dobierkou", exporter._price_element_info(orders[0], "payment")["title"])
+        self.assertEqual(3, len(exporter.client.calls))
+
     def test_flatten_order_exports_payment_audit_fields(self) -> None:
         exporter = make_exporter()
         order = {


### PR DESCRIPTION
## What changed
- Added a fallback order-list GraphQL query without `price_elements` when BizniWeb returns an internal error on that field.
- Enriches missing payment metadata with per-order `getOrder` calls only for COD-status orders that need payment confirmation.
- Keeps paid-status orders counted even when payment metadata is unavailable, and excludes COD-status orders with missing metadata using `cod_status_missing_payment_metadata`.
- Added regression coverage for the fallback and missing-metadata realized revenue decision.

## Why
The realized revenue PR made `price_elements` required for COD payment detection. VEVO production smoke showed BizniWeb can fail on `price_elements` for a specific order/page, which made full-history reporting unreliable. This keeps the fetch alive while preventing overcounting when payment metadata cannot be verified.

## Validation
- `python -m py_compile export_orders.py`
- `python -m unittest tests.test_reporting_calculation_fixes`
- `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity` (64 tests OK)
- `git diff --check`
- Live read-only VEVO probe fetched 600 DESC orders, hit the problematic page, continued, and excluded order `2602007112` as `cod_status_missing_payment_metadata`.