### PR TITLE
Count shipped prepaid orders in reporting revenue

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,12 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY/VEVO realized revenue filtering was corrected on `2026-06-02` so shipped prepaid orders are not lost after the current BizniWeb status changes from `Platba online - zaplatené` to `Odoslaná`:
+  - COD still counts only when payment is COD and status is `Čaká na vybavenie` or `Odoslaná`
+  - prepaid/card/bank-transfer orders still count immediately in status `Platba online - zaplatené`
+  - prepaid/card/bank-transfer orders now also count when current status is fulfilled (`Odoslaná`), because BizniWeb exposes only current status and older paid orders otherwise disappeared from rolling windows
+  - order cache schema was bumped to `3` because cached order files contain already-filtered order lists and must be revalidated after this filter change
+  - local no-cache ROY recompute for `2026-05-03..2026-06-01` verified `385` orders and `25 712.62 EUR` net revenue versus the stale production KPI `181` orders / `12 879.48 EUR`
 - Env governance added for multi-PC workflow
 - Pre-commit hook install script exists for Bash and PowerShell
 - CI validates env contract and blocks tracked secret env files

--- a/export_orders.py
+++ b/export_orders.py
@@ -117,7 +117,7 @@ MARGIN_15_BRANDS: List[str] = []  # Optional brands forced to 15% product margin
 MARGIN_15_LABEL_PATTERNS: List[str] = []  # Optional label patterns forced to 15% product margin
 EXCLUDE_ZERO_PRICE_LABEL_PATTERNS: List[str] = []  # Optional label patterns excluded only when line price is 0
 EXCLUDED_ORDER_STATUSES: List[str] = []  # Legacy status-only exclude list retained for compatibility
-ORDER_CACHE_SCHEMA_VERSION = 2
+ORDER_CACHE_SCHEMA_VERSION = 3
 MANUAL_FB_ADS_TOTAL: Optional[float] = None  # Optional fixed total FB spend for selected report range
 MANUAL_GOOGLE_ADS_TOTAL: Optional[float] = None  # Optional fixed total Google spend for selected report range
 PREFER_MANUAL_ADS_TOTALS = False
@@ -224,6 +224,28 @@ DEFAULT_REALIZED_REVENUE_COD_PAYMENT_PATTERNS = [
 DEFAULT_REALIZED_REVENUE_COD_PAYMENT_IDS = [
     '7',
     '10',
+]
+DEFAULT_REALIZED_REVENUE_PREPAID_FULFILLED_STATUSES = [
+    'Odoslana',
+]
+DEFAULT_REALIZED_REVENUE_PREPAID_PAYMENT_PATTERNS = [
+    'bankovym prevodom',
+    'bankovni prevod',
+    'okamzita platba online',
+    'platba online',
+    'kartou',
+    'card',
+    'gopay',
+    'besteron',
+    'stripe',
+    '24 pay',
+]
+DEFAULT_REALIZED_REVENUE_PREPAID_PAYMENT_IDS = [
+    '6',
+    '11',
+    '17',
+    '18',
+    '20',
 ]
 
 
@@ -2243,6 +2265,18 @@ class BizniWebExporter:
             raw.get("cod_payment_ids"),
             DEFAULT_REALIZED_REVENUE_COD_PAYMENT_IDS,
         )
+        prepaid_fulfilled_statuses = self._as_config_list(
+            raw.get("prepaid_fulfilled_statuses"),
+            DEFAULT_REALIZED_REVENUE_PREPAID_FULFILLED_STATUSES,
+        )
+        prepaid_payment_patterns = self._as_config_list(
+            raw.get("prepaid_payment_patterns"),
+            DEFAULT_REALIZED_REVENUE_PREPAID_PAYMENT_PATTERNS,
+        )
+        prepaid_payment_ids = self._as_config_list(
+            raw.get("prepaid_payment_ids"),
+            DEFAULT_REALIZED_REVENUE_PREPAID_PAYMENT_IDS,
+        )
         return {
             "paid_statuses": paid_statuses,
             "paid_statuses_normalized": {self._normalize_match_text(status) for status in paid_statuses},
@@ -2255,6 +2289,19 @@ class BizniWebExporter:
                 if self._normalize_match_text(pattern)
             },
             "cod_payment_ids": {str(value).strip() for value in cod_payment_ids if str(value).strip()},
+            "prepaid_fulfilled_statuses": prepaid_fulfilled_statuses,
+            "prepaid_fulfilled_statuses_normalized": {
+                self._normalize_match_text(status)
+                for status in prepaid_fulfilled_statuses
+                if self._normalize_match_text(status)
+            },
+            "prepaid_payment_patterns": prepaid_payment_patterns,
+            "prepaid_payment_patterns_normalized": {
+                self._normalize_match_text(pattern)
+                for pattern in prepaid_payment_patterns
+                if self._normalize_match_text(pattern)
+            },
+            "prepaid_payment_ids": {str(value).strip() for value in prepaid_payment_ids if str(value).strip()},
         }
 
     def _is_cod_payment(self, order: Dict[str, Any]) -> bool:
@@ -2268,12 +2315,29 @@ class BizniWebExporter:
             for pattern in self.realized_revenue_settings["cod_payment_patterns_normalized"]
         )
 
+    def _is_prepaid_payment(self, order: Dict[str, Any]) -> bool:
+        payment = self._price_element_info(order, "payment")
+        reference_id = str(payment.get("reference_id") or "").strip()
+        if reference_id and reference_id in self.realized_revenue_settings["prepaid_payment_ids"]:
+            return True
+        payment_title = self._normalize_match_text(payment.get("title"))
+        return any(
+            pattern and pattern in payment_title
+            for pattern in self.realized_revenue_settings["prepaid_payment_patterns_normalized"]
+        )
+
     def _realized_revenue_decision(self, order: Dict[str, Any]) -> Tuple[bool, str]:
         status_norm = self._status_norm(order)
         settings = self.realized_revenue_settings
 
         if status_norm in settings["paid_statuses_normalized"]:
             return True, "paid_status"
+
+        if status_norm in settings["prepaid_fulfilled_statuses_normalized"]:
+            if not self._has_loaded_price_elements(order):
+                return False, "fulfilled_status_missing_payment_metadata"
+            if self._is_prepaid_payment(order):
+                return True, "prepaid_fulfilled_status"
 
         if status_norm in settings["cod_statuses_normalized"]:
             if not self._has_loaded_price_elements(order):
@@ -2290,7 +2354,10 @@ class BizniWebExporter:
         if self._has_loaded_price_elements(order):
             return False
         status_norm = self._status_norm(order)
-        return status_norm in self.realized_revenue_settings["cod_statuses_normalized"]
+        return (
+            status_norm in self.realized_revenue_settings["cod_statuses_normalized"]
+            or status_norm in self.realized_revenue_settings["prepaid_fulfilled_statuses_normalized"]
+        )
 
     def _fetch_order_payment_metadata(self, order: Dict[str, Any]) -> bool:
         order_num = str((order or {}).get("order_num") or "").strip()

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -97,6 +97,28 @@
     "cod_payment_ids": [
       "7",
       "10"
+    ],
+    "prepaid_fulfilled_statuses": [
+      "Odoslana"
+    ],
+    "prepaid_payment_patterns": [
+      "bankovym prevodom",
+      "bankovni prevod",
+      "okamzita platba online",
+      "platba online",
+      "kartou",
+      "card",
+      "gopay",
+      "besteron",
+      "stripe",
+      "24 pay"
+    ],
+    "prepaid_payment_ids": [
+      "6",
+      "11",
+      "17",
+      "18",
+      "20"
     ]
   },
   "unpaid_order_cancellation": {

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -71,6 +71,28 @@
     "cod_payment_ids": [
       "7",
       "10"
+    ],
+    "prepaid_fulfilled_statuses": [
+      "Odoslana"
+    ],
+    "prepaid_payment_patterns": [
+      "bankovym prevodom",
+      "bankovni prevod",
+      "okamzita platba online",
+      "platba online",
+      "kartou",
+      "card",
+      "gopay",
+      "besteron",
+      "stripe",
+      "24 pay"
+    ],
+    "prepaid_payment_ids": [
+      "6",
+      "11",
+      "17",
+      "18",
+      "20"
     ]
   },
   "excluded_order_statuses": [

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -268,7 +268,7 @@ class ReportingCalculationFixTests(unittest.TestCase):
             write_order_cache(exporter, old_date, today - timedelta(days=90))
             self.assertFalse(exporter.should_use_cache(old_date, today=today))
 
-    def test_realized_revenue_filter_counts_only_paid_or_cod_orders(self) -> None:
+    def test_realized_revenue_filter_counts_paid_cod_and_shipped_prepaid_orders(self) -> None:
         exporter = make_exporter()
         orders = [
             reporting_order("COD-WAIT", "Čaká na vybavenie", "Dobierkou", "7"),
@@ -284,8 +284,17 @@ class ReportingCalculationFixTests(unittest.TestCase):
         filtered = exporter._filter_by_status(orders, track_excluded=False)
 
         self.assertEqual(
-            ["COD-WAIT", "COD-SHIPPED", "PAID-CARD", "PAID-BANK"],
+            ["COD-WAIT", "COD-SHIPPED", "PAID-CARD", "PAID-BANK", "BANK-SHIPPED"],
             [order["order_num"] for order in filtered],
+        )
+
+    def test_shipped_online_card_counts_as_prepaid_fulfilled_revenue(self) -> None:
+        exporter = make_exporter()
+        order = reporting_order("CARD-SHIPPED", "Odoslana", "Okamzita platba online", "18")
+
+        self.assertEqual(
+            (True, "prepaid_fulfilled_status"),
+            exporter._realized_revenue_decision(order),
         )
 
     def test_cod_status_without_payment_metadata_is_not_counted(self) -> None:
@@ -301,7 +310,7 @@ class ReportingCalculationFixTests(unittest.TestCase):
         }
 
         self.assertEqual(
-            (False, "cod_status_missing_payment_metadata"),
+            (False, "fulfilled_status_missing_payment_metadata"),
             exporter._realized_revenue_decision(missing_metadata),
         )
         self.assertEqual(


### PR DESCRIPTION
## Summary
- include shipped prepaid/card/bank-transfer orders in realized revenue after BizniWeb current status changes to `Odoslaná`
- keep unpaid waiting bank/card orders excluded until paid or fulfilled
- bump order cache schema because cached order files contain already-filtered order lists
- configure the rule for both ROY and VEVO

## Verification
- `python -m unittest tests.test_reporting_calculation_fixes tests.test_unpaid_order_cancellation tests.test_roy_operations_dashboard`
- `python -m json.tool projects\roy\settings.json`
- `python -m json.tool projects\vevo\settings.json`
- ROY no-cache recompute `2026-05-03..2026-06-01`: `385` orders / `25 712.62 EUR` net revenue, vs stale dashboard `181` / `12 879.48 EUR`