### PR TITLE
Restore ROY operations inventory payload

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -492,12 +492,15 @@ jobs:
           dashboard = payload.get("dashboard") or {}
           kpis = dashboard.get("kpis") or {}
           series = dashboard.get("series") or {}
-          inventory = dashboard.get("roy_product_demand") or {}
+          commercial = dashboard.get("roy_product_demand") or {}
+          inventory = dashboard.get("roy_operations_inventory") or commercial
           assert kpis.get("windows"), "KPI windows missing in generated payload"
           assert series.get("dates"), "KPI source series dates missing in generated payload"
-          assert inventory.get("summary"), "Inventory summary missing in generated payload"
+          if project == "roy":
+              assert inventory.get("summary"), "Operations inventory summary missing in generated payload"
+              assert inventory.get("inventory_rows"), "Operations inventory rows missing in generated payload"
           invalid_loss_rows = []
-          for row in inventory.get("loss_product_rows") or []:
+          for row in commercial.get("loss_product_rows") or []:
               if not isinstance(row, dict):
                   invalid_loss_rows.append(row)
                   continue
@@ -520,6 +523,7 @@ jobs:
               "payload_path": str(payload_path),
               "kpi_series_days": len(series.get("dates") or []),
               "inventory_alerts": (inventory.get("summary") or {}).get("alert_delivery_count"),
+              "inventory_rows": len(inventory.get("inventory_rows") or []),
           }
           (marker_dir / "marker.json").write_text(json.dumps(marker, ensure_ascii=False), encoding="utf-8")
           PY
@@ -677,12 +681,14 @@ jobs:
           dashboard = payload.get("dashboard") or {}
           kpis = dashboard.get("kpis") or {}
           series = dashboard.get("series") or {}
-          inventory = dashboard.get("roy_product_demand") or {}
+          commercial = dashboard.get("roy_product_demand") or {}
+          inventory = dashboard.get("roy_operations_inventory") or commercial
           assert kpis.get("windows"), "S3 KPI windows missing"
           assert series.get("dates"), "S3 KPI source series dates missing"
-          assert inventory.get("summary"), "S3 inventory summary missing"
+          assert inventory.get("summary"), "S3 operations inventory summary missing"
+          assert inventory.get("inventory_rows"), "S3 operations inventory rows missing"
           invalid_loss_rows = []
-          for row in inventory.get("loss_product_rows") or []:
+          for row in commercial.get("loss_product_rows") or []:
               if not isinstance(row, dict):
                   invalid_loss_rows.append(row)
                   continue
@@ -700,7 +706,8 @@ jobs:
           print(
               "ROY_LIVE_ARTIFACTS_OK:"
               f"kpi_series_days={len(series.get('dates') or [])}:"
-              f"inventory_alerts={(inventory.get('summary') or {}).get('alert_delivery_count')}"
+              f"inventory_alerts={(inventory.get('summary') or {}).get('alert_delivery_count')}:"
+              f"inventory_rows={len(inventory.get('inventory_rows') or [])}"
           )
           PY
           fi
@@ -1014,6 +1021,7 @@ jobs:
           assert api["executive_kpis"].get("windows"), "Executive KPI windows missing"
           assert len(api["executive_kpis"].get("months") or []) > 0, "Calendar KPI months missing"
           assert api["inventory"].get("summary"), "Inventory summary missing"
+          assert api["inventory"].get("inventory_rows"), "Inventory rows missing"
           assert "/api/operations/roy/picking-lists.pdf" in html, "Picking-list PDF link missing"
           assert pdf.startswith(b"%PDF-"), "Picking-list download is not a PDF"
           assert len(pdf) > 1000, "Picking-list PDF is unexpectedly small"
@@ -1042,6 +1050,7 @@ jobs:
               f"fulfillable_orders={api['orders']['summary'].get('fulfillable_orders')}:"
               f"personal_pickups={api['orders']['summary'].get('personal_pickups')}:"
               f"inventory_alerts={api['inventory']['summary'].get('alert_delivery_count')}:"
+              f"inventory_rows={len(api['inventory'].get('inventory_rows') or [])}:"
               f"kpi_months={len(api['executive_kpis'].get('months') or [])}:"
               f"gross_loss_products={len((api.get('performance') or {}).get('loss_product_rows') or [])}:"
               f"picking_pdf_bytes={os.path.getsize('/tmp/roy-picking-lists.pdf')}"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,14 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY live operations dashboard inventory regression is being fixed on branch `codex/restore-roy-inventory-alerts` on `2026-06-02`:
+  - root cause: `dashboard_payload_latest.json` is the full/all-time sidecar, and the all-time `roy_product_demand` payload can have `inventory_rows=0` / `alert_rows=0`; the live operations dashboard was using that payload for the stock tables
+  - code now embeds a separate `dashboard.roy_operations_inventory` block into the main sidecar from the preferred rolling period report (`monthly`, then `weekly`, then `daily`) when that period has inventory rows
+  - ROY operations inventory rendering now prefers `roy_operations_inventory` and falls back to `roy_product_demand`
+  - workflow smoke now fails if ROY production operations inventory has no `inventory_rows`
+  - verified locally: `python -m unittest tests.test_reporting_calculation_fixes tests.test_unpaid_order_cancellation tests.test_roy_inventory_model tests.test_roy_operations_dashboard tests.test_dashboard_modern`; simulated live inventory payload returned `inventory_rows=160` and `alert_rows=9`
+  - Next exact step: push the branch, open/merge PR, rebuild ECR/App Runner, refresh ROY artifacts, and verify host marker plus live UI/API smoke
+
 - ROY/VEVO realized revenue filtering was corrected on `2026-06-02` so shipped prepaid orders are not lost after the current BizniWeb status changes from `Platba online - zaplatené` to `Odoslaná`:
   - COD still counts only when payment is COD and status is `Čaká na vybavenie` or `Odoslaná`
   - prepaid/card/bank-transfer orders still count immediately in status `Platba online - zaplatené`

--- a/export_orders.py
+++ b/export_orders.py
@@ -951,6 +951,113 @@ class BizniWebExporter:
             embedded_reports[key] = base64.b64encode(report_html.encode("utf-8")).decode("ascii")
         return embedded_reports
 
+    @staticmethod
+    def _dashboard_inventory_has_rows(inventory_payload: Any) -> bool:
+        if not isinstance(inventory_payload, dict):
+            return False
+        for key in ("inventory_rows", "stock_risk_rows", "alert_rows", "restock_priority_rows"):
+            rows = inventory_payload.get(key)
+            if isinstance(rows, list) and rows:
+                return True
+        summary = inventory_payload.get("summary") if isinstance(inventory_payload.get("summary"), dict) else {}
+        for key in ("inventory_products_total", "inventory_products_with_stock", "stock_risk_45d_count"):
+            try:
+                if float(summary.get(key) or 0) > 0:
+                    return True
+            except (TypeError, ValueError):
+                continue
+        return False
+
+    @staticmethod
+    def _safe_spec_date(value: Any) -> Optional[str]:
+        if isinstance(value, (datetime, pd.Timestamp)):
+            return value.strftime("%Y-%m-%d")
+        text = str(value or "").strip()
+        return text or None
+
+    def _enrich_roy_operations_inventory_payload(
+        self,
+        dashboard_payload: Dict[str, Any],
+        period_switcher: Optional[Dict[str, Any]],
+    ) -> None:
+        if self.project_name != "roy" or not isinstance(dashboard_payload, dict):
+            return
+
+        candidates: List[Dict[str, Any]] = []
+        base_inventory = dashboard_payload.get("roy_product_demand")
+        if isinstance(base_inventory, dict):
+            candidates.append(
+                {
+                    "key": str((period_switcher or {}).get("current_key") or "full"),
+                    "label": "current",
+                    "payload": base_inventory,
+                    "date_from": None,
+                    "date_to": None,
+                    "path": None,
+                }
+            )
+
+        switcher = period_switcher or {}
+        embedded_specs = switcher.get("_embedded_specs") if isinstance(switcher.get("_embedded_specs"), list) else []
+        for spec in embedded_specs:
+            key = str(spec.get("key") or "").strip().lower()
+            report_path_raw = spec.get("report_path")
+            if not key or not report_path_raw:
+                continue
+            report_path = Path(str(report_path_raw))
+            if not report_path.exists():
+                continue
+            try:
+                embedded_payload = extract_embedded_dashboard_payload(report_path.read_text(encoding="utf-8-sig"))
+            except Exception as exc:
+                logger.warning("Could not read embedded %s payload for ROY operations inventory: %s", key, exc)
+                continue
+            inventory_payload = embedded_payload.get("roy_product_demand")
+            if not isinstance(inventory_payload, dict):
+                continue
+            candidates.append(
+                {
+                    "key": key,
+                    "label": key,
+                    "payload": inventory_payload,
+                    "date_from": self._safe_spec_date(spec.get("date_from")),
+                    "date_to": self._safe_spec_date(spec.get("date_to")),
+                    "path": str(report_path),
+                }
+            )
+
+        selected = None
+        preferred_keys = ("monthly", "weekly", "daily")
+        for key in preferred_keys:
+            selected = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if candidate["key"] == key and self._dashboard_inventory_has_rows(candidate["payload"])
+                ),
+                None,
+            )
+            if selected is not None:
+                break
+        if selected is None:
+            selected = next(
+                (candidate for candidate in candidates if self._dashboard_inventory_has_rows(candidate["payload"])),
+                candidates[0] if candidates else None,
+            )
+        if selected is None:
+            return
+
+        operations_inventory = copy.deepcopy(selected["payload"])
+        summary = operations_inventory.setdefault("summary", {})
+        if isinstance(summary, dict):
+            summary["operations_inventory_source_period"] = selected["key"]
+            summary["operations_inventory_source_path"] = selected["path"]
+            if selected["date_from"]:
+                summary["operations_inventory_date_from"] = selected["date_from"]
+            if selected["date_to"]:
+                summary["operations_inventory_date_to"] = selected["date_to"]
+        dashboard_payload["roy_operations_inventory"] = operations_inventory
+
     def _build_period_switcher_bundle(
         self,
         orders: List[Dict[str, Any]],
@@ -1222,6 +1329,7 @@ class BizniWebExporter:
         report_title: str,
     ) -> Tuple[Path, Path]:
         dashboard_payload = extract_embedded_dashboard_payload(html_content)
+        self._enrich_roy_operations_inventory_payload(dashboard_payload, period_switcher)
         snapshot = {
             "project": self.project_name,
             "report_title": report_title,

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -1477,6 +1477,14 @@ def build_commercial_snapshot(report_payload: Dict[str, Any], state: Optional[Di
     }
 
 
+def _select_roy_operations_inventory_payload(dashboard: Dict[str, Any]) -> Dict[str, Any]:
+    operations_inventory = dashboard.get("roy_operations_inventory")
+    if isinstance(operations_inventory, dict):
+        return operations_inventory
+    roy_inventory = dashboard.get("roy_product_demand")
+    return roy_inventory if isinstance(roy_inventory, dict) else {}
+
+
 def _inventory_row_collections(inventory: Dict[str, Any]) -> Iterable[Tuple[str, List[Dict[str, Any]]]]:
     for key in (
         "alert_rows",
@@ -2148,7 +2156,7 @@ def build_inventory_snapshot(
     live_stock_diagnostics: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Dict[str, Any], bool]:
     dashboard = report_payload.get("dashboard") if isinstance(report_payload.get("dashboard"), dict) else {}
-    roy_inventory = dashboard.get("roy_product_demand") if isinstance(dashboard.get("roy_product_demand"), dict) else {}
+    roy_inventory = _select_roy_operations_inventory_payload(dashboard)
     summary = roy_inventory.get("summary") if isinstance(roy_inventory.get("summary"), dict) else {}
     inventory = {
         "summary": summary or {},

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -1,7 +1,10 @@
 import json
+import shutil
 import unittest
 from pathlib import Path
 
+from dashboard_modern import DASHBOARD_PAYLOAD_SCRIPT_ID
+from export_orders import BizniWebExporter
 from live_dashboard_server import build_roy_operations_dashboard_html
 from roy_operations_dashboard import (
     _select_current_stock_for_target,
@@ -537,6 +540,127 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(1, inventory["summary"]["inbound_order_count"])
         self.assertEqual(20, inventory["inbound_order_rows"][0]["ordered_units"])
         self.assertEqual("Inbound ordered", inventory["inventory_rows"][0]["reorder_action_label"])
+
+    def test_inventory_snapshot_prefers_operations_inventory_payload(self) -> None:
+        payload = {
+            "dashboard": {
+                "roy_product_demand": {
+                    "summary": {
+                        "alert_delivery_count": 0,
+                        "inventory_products_total": 0,
+                    },
+                    "alert_rows": [],
+                    "inventory_rows": [],
+                },
+                "roy_operations_inventory": {
+                    "summary": {
+                        "alert_delivery_count": 1,
+                        "inventory_products_total": 1,
+                        "operations_inventory_source_period": "monthly",
+                    },
+                    "alert_rows": [
+                        {
+                            "sku": "F_206",
+                            "product": "Micro SD KARTA 32GB s adapterom",
+                            "available_quantity": 21,
+                            "available_quantity_raw": 21,
+                            "alert_30d_units": 26,
+                            "lead_time_working_days": 3,
+                            "suggested_reorder_units": 10,
+                            "stock_risk_level": "Low",
+                            "reorder_action_label": "30d alert",
+                            "alert_30d_revenue": 260,
+                            "alert_30d_profit_estimate": 80,
+                        }
+                    ],
+                    "inventory_rows": [
+                        {
+                            "sku": "F_206",
+                            "product": "Micro SD KARTA 32GB s adapterom",
+                            "available_quantity": 21,
+                            "available_quantity_raw": 21,
+                            "alert_30d_units": 26,
+                            "lead_time_working_days": 3,
+                            "suggested_reorder_units": 10,
+                            "stock_risk_level": "Low",
+                            "reorder_action_label": "30d alert",
+                        }
+                    ],
+                },
+            }
+        }
+
+        inventory, state_changed = build_inventory_snapshot(
+            payload,
+            project_settings={
+                "inventory_model": {
+                    "critical_days_of_cover": 14,
+                    "warning_days_of_cover": 30,
+                    "watch_days_of_cover": 45,
+                    "reorder_cover_days": 30,
+                }
+            },
+        )
+
+        self.assertFalse(state_changed)
+        self.assertEqual(["F_206"], [row["sku"] for row in inventory["inventory_rows"]])
+        self.assertEqual(["F_206"], [row["sku"] for row in inventory["alert_rows"]])
+        self.assertEqual("monthly", inventory["summary"]["operations_inventory_source_period"])
+        self.assertEqual(1, inventory["summary"]["alert_delivery_count"])
+
+    def test_export_sidecar_embeds_monthly_operations_inventory_payload(self) -> None:
+        exporter = BizniWebExporter(
+            "https://example.invalid/graphql",
+            "test-token",
+            project_name="roy",
+            artifact_subdir="_unit_operations_inventory",
+            enable_period_bundle=False,
+        )
+        try:
+            monthly_inventory = {
+                "summary": {
+                    "alert_delivery_count": 1,
+                    "inventory_products_total": 1,
+                },
+                "alert_rows": [{"sku": "12468", "stock_risk_level": "Out of stock"}],
+                "inventory_rows": [{"sku": "12468", "available_quantity": 0}],
+            }
+            monthly_report_path = exporter.output_path("monthly_report.html")
+            monthly_report_path.write_text(
+                (
+                    f'<script id="{DASHBOARD_PAYLOAD_SCRIPT_ID}" type="application/json">'
+                    + json.dumps({"roy_product_demand": monthly_inventory})
+                    + "</script>"
+                ),
+                encoding="utf-8",
+            )
+            dashboard_payload = {
+                "roy_product_demand": {
+                    "summary": {
+                        "alert_delivery_count": 0,
+                        "inventory_products_total": 0,
+                    },
+                    "alert_rows": [],
+                    "inventory_rows": [],
+                }
+            }
+
+            exporter._enrich_roy_operations_inventory_payload(
+                dashboard_payload,
+                {
+                    "current_key": "full",
+                    "_embedded_specs": [
+                        {"key": "monthly", "report_path": str(monthly_report_path)},
+                    ],
+                },
+            )
+
+            operations_inventory = dashboard_payload["roy_operations_inventory"]
+            self.assertEqual(["12468"], [row["sku"] for row in operations_inventory["inventory_rows"]])
+            self.assertEqual("monthly", operations_inventory["summary"]["operations_inventory_source_period"])
+            self.assertEqual(1, operations_inventory["summary"]["alert_delivery_count"])
+        finally:
+            shutil.rmtree(exporter.data_dir, ignore_errors=True)
 
     def test_inbound_order_marker_auto_clears_after_stock_increase(self) -> None:
         payload = {


### PR DESCRIPTION
## What changed
- Embed a dedicated `roy_operations_inventory` block in the main dashboard payload from the preferred rolling period report.
- Make the ROY operations dashboard use that operations inventory block for stock tables, with fallback to `roy_product_demand`.
- Tighten production smoke checks so ROY live inventory must include inventory rows.
- Update PROJECT_STATE with root cause and verification.

## Verification
- `python -m unittest tests.test_roy_operations_dashboard tests.test_dashboard_modern`
- `python -m unittest tests.test_reporting_calculation_fixes tests.test_unpaid_order_cancellation tests.test_roy_inventory_model tests.test_roy_operations_dashboard tests.test_dashboard_modern`
- Local simulated operations payload returned `inventory_rows=160` and `alert_rows=9`.