### PR TITLE
Pin ROY live dashboard auth user

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -12,7 +12,7 @@ on:
         required: true
         default: biznisweb-vevo-production-board
       auth_user:
-        description: Basic Auth username
+        description: Basic Auth username fallback; project settings can override it
         required: true
         default: vevo
       s3_bucket:
@@ -86,6 +86,23 @@ jobs:
           print(settings["report_schedule"]["schedule_name"])
           PY
           )"
+          CONFIGURED_AUTH_USER="$(python - "${PROJECT}" <<'PY'
+          import json
+          import pathlib
+          import sys
+          project = sys.argv[1]
+          settings_path = pathlib.Path("projects") / project / "settings.json"
+          settings = json.loads(settings_path.read_text(encoding="utf-8"))
+          live_dashboard = settings.get("live_dashboard") or {}
+          print(str(live_dashboard.get("auth_user") or "").strip())
+          PY
+          )"
+          if [[ -n "${CONFIGURED_AUTH_USER}" ]]; then
+            if [[ "${AUTH_USER}" != "${CONFIGURED_AUTH_USER}" ]]; then
+              echo "Using configured live dashboard auth user for ${PROJECT}; workflow input auth_user is ignored." >&2
+            fi
+            AUTH_USER="${CONFIGURED_AUTH_USER}"
+          fi
           aws scheduler get-schedule \
             --name "${REPORT_SCHEDULE_NAME}" \
             --region "${AWS_REGION}" > schedule.json

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,12 +61,14 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
-- ROY App Runner Basic Auth username was restored on `2026-06-02` after the inventory deploy accidentally changed the runtime `LIVE_DASHBOARD_AUTH_USER` from the user-facing `roy2` login to `roy`:
-  - symptom: browser Basic Auth prompt accepted/stored `roy2`, but `/api/operations/roy/live` returned a plain auth challenge/error; the frontend then showed `Unexpected token 'A' ... is not valid JSON`
-  - fix: re-ran `Deploy Live Dashboard App Runner` with `auth_user=roy2` and `skip_artifact_refresh=true`, so report/S3 data were not regenerated
-  - App Runner hard-gate run `26816577768`: service `biznisweb-roy-operations-dashboard`, ARN `arn:aws:apprunner:eu-central-1:919341186960:service/biznisweb-roy-operations-dashboard/ff762bb1c93148638741c62e7abb45b2`, path `https://qvfzvh82c3.eu-central-1.awsapprunner.com/production/roy`, image digest `sha256:7ebcb7bab80a22725c4ee46221efe38e68eecd24314936eda0cccbce91afc802`
-  - marker/smoke verified: `LIVE_ARTIFACT_MARKER_OK` in skip-refresh mode and `APP_RUNNER_ROY_OPERATIONS_OK:fulfillable_orders=0:personal_pickups=0:inventory_alerts=19:inventory_rows=160:kpi_months=10:gross_loss_products=1:picking_pdf_bytes=80171`
-  - Next exact step: keep future ROY App Runner deploys on `auth_user=roy2`; do not use `roy` unless the browser-facing username is intentionally changed
+- ROY App Runner Basic Auth username was restored to the correct user-facing login `roy21` on `2026-06-02`:
+  - symptom: browser Basic Auth prompt accepted/stored a wrong username while `/api/operations/roy/live` returned a plain auth challenge/error; the frontend then showed `Unexpected token 'A' ... is not valid JSON`
+  - root cause: `Deploy Live Dashboard App Runner` accepted `auth_user` as a manual workflow input, wrote it directly to runtime `LIVE_DASHBOARD_AUTH_USER`, and then smoke-tested with the same input, so a wrong deploy username could pass verification
+  - runtime fix: re-ran `Deploy Live Dashboard App Runner` with `auth_user=roy21` and `skip_artifact_refresh=true`, so report/S3 data were not regenerated
+  - App Runner hard-gate run `26817149992`: service `biznisweb-roy-operations-dashboard`, ARN `arn:aws:apprunner:eu-central-1:919341186960:service/biznisweb-roy-operations-dashboard/ff762bb1c93148638741c62e7abb45b2`, path `https://qvfzvh82c3.eu-central-1.awsapprunner.com/production/roy`, image digest `sha256:7ebcb7bab80a22725c4ee46221efe38e68eecd24314936eda0cccbce91afc802`
+  - marker/smoke verified: Fargate skip-refresh marker `LIVE_ARTIFACT_MARKER_OK`, App Runner host smoke `APP_RUNNER_ROY_OPERATIONS_OK:fulfillable_orders=0:personal_pickups=0:inventory_alerts=19:inventory_rows=160:kpi_months=10:gross_loss_products=1:picking_pdf_bytes=80171`, and `APP_RUNNER_DEPLOY_OK:biznisweb-roy-operations-dashboard:https://qvfzvh82c3.eu-central-1.awsapprunner.com`
+  - prevention: ROY now has `projects/roy/settings.json` -> `live_dashboard.auth_user=roy21`; the App Runner deploy workflow uses that configured project value and ignores a mismatching manual `auth_user` input
+  - Next exact step: use `roy21` for ROY live dashboard login; password is unchanged; do not change `live_dashboard.auth_user` unless the browser-facing username is intentionally changed
 
 - ROY live operations dashboard inventory regression was fixed and deployed on `2026-06-02`:
   - root cause: `dashboard_payload_latest.json` is the full/all-time sidecar, and the all-time `roy_product_demand` payload can have `inventory_rows=0` / `alert_rows=0`; the live operations dashboard was using that payload for the stock tables

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -13,6 +13,9 @@
   "live_dashboard_artifacts": {
     "s3_prefix": "daily-reports/roy-sk"
   },
+  "live_dashboard": {
+    "auth_user": "roy21"
+  },
   "product_identity": {
     "prefer_import_code": true
   },


### PR DESCRIPTION
## What changed
- pins ROY live dashboard Basic Auth username in `projects/roy/settings.json` as `roy21`
- makes the App Runner deploy workflow prefer the project-configured auth user over manual workflow input
- updates `PROJECT_STATE.md` with the corrected runtime fix and root cause

## Verified
- `python -m json.tool projects/roy/settings.json`
- `python -m unittest tests.test_roy_operations_dashboard tests.test_reporting_calculation_fixes`
- production deploy run `26817149992` passed App Runner smoke with ROY inventory data