### PR TITLE
Add ROY pickup ready checkbox

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,13 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY personal pickup ready checkbox is implemented locally on `2026-06-02`:
+  - change: ROY live dashboard personal pickup cards now have a separate `Pripravené k odberu` checkbox before the existing customer pickup/`Odoslaná` action
+  - backend: new `POST /api/operations/roy/pickup/<order_num>/ready` action validates the order as a paid ROY personal pickup, then changes BiznisWeb status to `Pripravené k odberu` (`status_id=23`)
+  - ship action: the existing `POST /api/operations/roy/pickup/<order_num>/ship` remains, but is now enabled only when the pickup is already in `Pripravené k odberu`; it changes the status to `Odoslaná` (`status_id=4`)
+  - verified locally: `python -m json.tool projects/roy/settings.json`; `python -m unittest tests.test_roy_operations_dashboard tests.test_reporting_calculation_fixes tests.test_unpaid_order_cancellation`
+  - Next exact step: open/merge PR, rebuild ECR image, deploy ROY App Runner with `skip_artifact_refresh=true`, then verify the live dashboard smoke still returns ROY inventory and pickup data
+
 - ROY App Runner Basic Auth username was restored to the correct user-facing login `roy21` on `2026-06-02`:
   - symptom: browser Basic Auth prompt accepted/stored a wrong username while `/api/operations/roy/live` returned a plain auth challenge/error; the frontend then showed `Unexpected token 'A' ... is not valid JSON`
   - root cause: `Deploy Live Dashboard App Runner` accepted `auth_user` as a manual workflow input, wrote it directly to runtime `LIVE_DASHBOARD_AUTH_USER`, and then smoke-tested with the same input, so a wrong deploy username could pass verification

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -22,6 +22,7 @@ from roy_operations_dashboard import (
     get_cached_roy_operations_snapshot,
     load_roy_operations_state,
     mark_picking_orders_printed,
+    mark_personal_pickup_ready,
     mark_personal_pickup_shipped,
     resolve_roy_operations_settings,
     save_roy_operations_state,
@@ -999,7 +1000,9 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     .pickup { border:1px solid var(--line); border-radius:8px; padding:10px; background:#fff; }
     .pickup-top { display:flex; justify-content:space-between; gap:10px; align-items:flex-start; }
     .pickup-title { font-weight:850; font-size:16px; }
+    .pickup-actions { display:grid; gap:5px; margin-top:9px; }
     .checkline { display:flex; gap:8px; align-items:center; margin-top:9px; font-weight:800; }
+    .pickup-actions .checkline { margin-top:0; }
     .checkline input { width:19px; height:19px; }
     .stock-action { display:grid; grid-template-columns:82px 138px auto; gap:6px; align-items:center; min-width:290px; }
     .stock-action input { min-height:34px; border:1px solid var(--line); border-radius:6px; padding:0 8px; font-weight:700; width:100%; }
@@ -1480,9 +1483,11 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
     function renderAlerts(data) {
       const orders = (data.orders || {}).summary || {};
       const inv = (data.inventory || {}).summary || {};
+      const readyPickupActions = fmtInt(orders.pickup_ready_actions_available);
+      const shipPickupActions = fmtInt(orders.pickup_ship_actions_available);
       el('alertGrid').innerHTML = [
         metric('Na vybavenie', fmtInt(orders.fulfillable_orders), `${fmtInt(orders.paid_online_orders)} online + ${fmtInt(orders.cod_waiting_orders)} dobierka`),
-        metric('Osobné odbery', fmtInt(orders.personal_pickups), `${fmtInt(orders.pickup_actions_available)} akcií dostupných`),
+        metric('Osobné odbery', fmtInt(orders.personal_pickups), `${readyPickupActions} pripraviť + ${shipPickupActions} odovzdať`),
         metric('Kritický sklad', fmtInt(inv.stock_risk_critical_count), `${fmtInt(inv.stock_risk_30d_count)} položiek v 30d riziku`),
         metric('Objednať teraz', fmtInt(inv.alert_reorder_now_count), `${fmtInt(inv.alert_prepare_po_count)} pripraviť PO`),
         metric('Objednané na ceste', fmtQty(inv.inbound_ordered_units), `${fmtInt(inv.inbound_order_count)} položiek · ETA ${text(inv.inbound_next_arrival_date)}`),
@@ -1525,8 +1530,12 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
           </div>
           <div class="muted" style="margin-top:6px;">${safe((order.payment || {}).title)}</div>
           <div style="margin-top:8px;">${orderItemsHtml(order)}</div>
-          <label class="checkline"><input type="checkbox" data-ship-pickup="${safe(order.order_num)}" ${order.pickup_action_allowed ? '' : 'disabled'}> Označiť ako odoslaná</label>
+          <div class="pickup-actions">
+            <label class="checkline"><input type="checkbox" data-ready-pickup="${safe(order.order_num)}" ${order.pickup_ready ? 'checked disabled' : (order.pickup_ready_action_allowed ? '' : 'disabled')}> Pripravené k odberu</label>
+            <label class="checkline"><input type="checkbox" data-ship-pickup="${safe(order.order_num)}" ${order.pickup_ship_action_allowed ? '' : 'disabled'}> Prevzaté zákazníkom - Odoslaná</label>
+          </div>
         </article>`).join('') : '<p class="muted">Žiadne osobné odbery.</p>';
+      el('pickupList').querySelectorAll('[data-ready-pickup]').forEach((input) => input.addEventListener('change', () => markPickupReady(input)));
       el('pickupList').querySelectorAll('[data-ship-pickup]').forEach((input) => input.addEventListener('change', () => markPickupShipped(input)));
     }
     function rowGrossProfit(row) {
@@ -1713,6 +1722,25 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         const data = await response.json();
         if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
         showMessage(`Objednávka ${orderNum} je zmenená na Odoslaná.`, true);
+        await loadDashboard(true);
+      } catch (error) {
+        input.checked = false;
+        input.disabled = false;
+        showMessage(error instanceof Error ? error.message : String(error));
+      }
+    }
+    async function markPickupReady(input) {
+      const orderNum = input.dataset.readyPickup;
+      if (!window.confirm(`Zmeniť objednávku ${orderNum} v eshope na Pripravené k odberu?`)) {
+        input.checked = false;
+        return;
+      }
+      input.disabled = true;
+      try {
+        const response = await fetch(`/api/operations/${encodeURIComponent(project)}/pickup/${encodeURIComponent(orderNum)}/ready`, { method:'POST', cache:'no-store' });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        showMessage(`Objednávka ${orderNum} je zmenená na Pripravené k odberu.`, true);
         await loadDashboard(true);
       } catch (error) {
         input.checked = false;
@@ -2094,7 +2122,7 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
             and parts[0] == "api"
             and parts[1] == "operations"
             and parts[3] == "pickup"
-            and parts[5] == "ship"
+            and parts[5] in {"ready", "ship"}
         ):
             project = parts[2]
             order_num = unquote(parts[4])
@@ -2102,7 +2130,10 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 self._send_json({"error": f"Unknown project '{project}'."}, status=404)
                 return
             try:
-                self._send_json(mark_personal_pickup_shipped(project, order_num))
+                if parts[5] == "ready":
+                    self._send_json(mark_personal_pickup_ready(project, order_num))
+                else:
+                    self._send_json(mark_personal_pickup_shipped(project, order_num))
             except Exception as exc:
                 self._send_json({"error": str(exc)}, status=400)
             return

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -217,9 +217,12 @@
     "personal_pickup_shipping_ids": [
       "11"
     ],
-    "pickup_action_statuses": [
-      "Čaká na vybavenie",
-      "Platba online - zaplatené",
+    "pickup_ready_status_name": "Pripravené k odberu",
+    "pickup_ready_status_id": 23,
+    "pickup_ready_action_statuses": [
+      "Platba online - zaplatené"
+    ],
+    "pickup_ship_action_statuses": [
       "Pripravené k odberu"
     ],
     "shipped_status_name": "Odoslaná",

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -26,7 +26,10 @@ DEFAULT_COD_STATUSES = ("Čaká na vybavenie",)
 DEFAULT_COD_PAYMENT_PATTERNS = ("dobierk", "dobirk")
 DEFAULT_PICKUP_SHIPPING_NAMES = ("Osobný odber na sklade",)
 DEFAULT_PICKUP_SHIPPING_IDS = ("11",)
-DEFAULT_PICKUP_ACTION_STATUSES = ("Čaká na vybavenie", "Platba online - zaplatené", "Pripravené k odberu")
+DEFAULT_PICKUP_READY_STATUS_NAME = "Pripravené k odberu"
+DEFAULT_PICKUP_READY_STATUS_ID = 0
+DEFAULT_PICKUP_READY_ACTION_STATUSES = DEFAULT_PAID_STATUSES
+DEFAULT_PICKUP_SHIP_ACTION_STATUSES = (DEFAULT_PICKUP_READY_STATUS_NAME,)
 DEFAULT_SHIPPED_STATUS_NAME = "Odoslaná"
 DEFAULT_SHIPPED_STATUS_ID = 4
 DEFAULT_SCAN_MAX_PAGES = 30
@@ -622,7 +625,16 @@ def resolve_roy_operations_settings(project_settings: Dict[str, Any]) -> Dict[st
     cod_payment_ids = _as_list(raw.get("cod_payment_ids"), ())
     pickup_shipping_names = _as_list(raw.get("personal_pickup_shipping_names"), DEFAULT_PICKUP_SHIPPING_NAMES)
     pickup_shipping_ids = _as_list(raw.get("personal_pickup_shipping_ids"), DEFAULT_PICKUP_SHIPPING_IDS)
-    pickup_action_statuses = _as_list(raw.get("pickup_action_statuses"), DEFAULT_PICKUP_ACTION_STATUSES)
+    pickup_ready_status_name = str(raw.get("pickup_ready_status_name") or DEFAULT_PICKUP_READY_STATUS_NAME).strip()
+    pickup_ready_action_statuses = _as_list(
+        raw.get("pickup_ready_action_statuses"),
+        DEFAULT_PICKUP_READY_ACTION_STATUSES,
+    )
+    pickup_ship_action_statuses = _as_list(
+        raw.get("pickup_ship_action_statuses"),
+        (pickup_ready_status_name,),
+    )
+    pickup_action_statuses = list(dict.fromkeys(pickup_ready_action_statuses + pickup_ship_action_statuses))
     shipped_status_name = str(raw.get("shipped_status_name") or DEFAULT_SHIPPED_STATUS_NAME).strip()
 
     return {
@@ -637,6 +649,17 @@ def resolve_roy_operations_settings(project_settings: Dict[str, Any]) -> Dict[st
         "personal_pickup_shipping_names": pickup_shipping_names,
         "personal_pickup_shipping_names_normalized": {_normalize_text(name) for name in pickup_shipping_names},
         "personal_pickup_shipping_ids": {str(value).strip() for value in pickup_shipping_ids if str(value).strip()},
+        "pickup_ready_status_name": pickup_ready_status_name,
+        "pickup_ready_status_name_normalized": _normalize_text(pickup_ready_status_name),
+        "pickup_ready_status_id": _as_int(
+            raw.get("pickup_ready_status_id"),
+            DEFAULT_PICKUP_READY_STATUS_ID,
+            minimum=0,
+        ),
+        "pickup_ready_action_statuses": pickup_ready_action_statuses,
+        "pickup_ready_action_statuses_normalized": {_normalize_text(status) for status in pickup_ready_action_statuses},
+        "pickup_ship_action_statuses": pickup_ship_action_statuses,
+        "pickup_ship_action_statuses_normalized": {_normalize_text(status) for status in pickup_ship_action_statuses},
         "pickup_action_statuses": pickup_action_statuses,
         "pickup_action_statuses_normalized": {_normalize_text(status) for status in pickup_action_statuses},
         "shipped_status_name": shipped_status_name,
@@ -710,6 +733,10 @@ def _is_paid_online(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
     return _normalize_text(_status_name(order)) in settings["paid_statuses_normalized"]
 
 
+def _is_pickup_ready_status(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
+    return _normalize_text(_status_name(order)) == settings["pickup_ready_status_name_normalized"]
+
+
 def _is_cod_fulfillable(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
     return (
         _normalize_text(_status_name(order)) in settings["cod_statuses_normalized"]
@@ -737,8 +764,8 @@ def _is_personal_pickup(order: Dict[str, Any], settings: Dict[str, Any]) -> bool
 def _is_paid_personal_pickup(order: Dict[str, Any], settings: Dict[str, Any]) -> bool:
     return (
         _is_personal_pickup(order, settings)
-        and _is_paid_online(order, settings)
         and _normalize_text(_status_name(order)) != settings["shipped_status_name_normalized"]
+        and (_is_paid_online(order, settings) or _is_pickup_ready_status(order, settings))
     )
 
 
@@ -1069,14 +1096,16 @@ def _public_order_row(order: Dict[str, Any], settings: Dict[str, Any]) -> Dict[s
     is_pickup = _is_personal_pickup(order, settings)
     status_name = _status_name(order)
     status_norm = _normalize_text(status_name)
-    paid_pickup_ready = (
-        is_pickup
-        and reason == "paid_online"
-        and status_norm != settings["shipped_status_name_normalized"]
-    )
-    pickup_action_allowed = (
+    pickup_ready = status_norm == settings["pickup_ready_status_name_normalized"]
+    paid_pickup_ready = _is_paid_personal_pickup(order, settings)
+    pickup_ready_action_allowed = (
         paid_pickup_ready
-        and status_norm in settings["pickup_action_statuses_normalized"]
+        and not pickup_ready
+        and status_norm in settings["pickup_ready_action_statuses_normalized"]
+    )
+    pickup_ship_action_allowed = (
+        paid_pickup_ready
+        and status_norm in settings["pickup_ship_action_statuses_normalized"]
     )
     return {
         "id": order.get("id"),
@@ -1101,7 +1130,10 @@ def _public_order_row(order: Dict[str, Any], settings: Dict[str, Any]) -> Dict[s
         "fulfillment_reason": reason,
         "personal_pickup": is_pickup,
         "paid_personal_pickup": paid_pickup_ready,
-        "pickup_action_allowed": pickup_action_allowed,
+        "pickup_ready": pickup_ready,
+        "pickup_ready_action_allowed": pickup_ready_action_allowed,
+        "pickup_ship_action_allowed": pickup_ship_action_allowed,
+        "pickup_action_allowed": pickup_ship_action_allowed,
     }
 
 
@@ -1129,6 +1161,8 @@ def build_roy_orders_snapshot(
     generated = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     fulfillable_orders.sort(key=lambda row: (str(row.get("purchase_at") or ""), str(row.get("order_num") or "")))
     pickup_orders.sort(key=lambda row: (str(row.get("purchase_at") or ""), str(row.get("order_num") or "")))
+    pickup_ready_actions_available = len([row for row in pickup_orders if row["pickup_ready_action_allowed"]])
+    pickup_ship_actions_available = len([row for row in pickup_orders if row["pickup_ship_action_allowed"]])
 
     return {
         "project": project,
@@ -1139,7 +1173,9 @@ def build_roy_orders_snapshot(
             "paid_online_orders": len(paid_orders),
             "cod_waiting_orders": len(cod_orders),
             "personal_pickups": len(pickup_orders),
-            "pickup_actions_available": len([row for row in pickup_orders if row["pickup_action_allowed"]]),
+            "pickup_actions_available": pickup_ready_actions_available + pickup_ship_actions_available,
+            "pickup_ready_actions_available": pickup_ready_actions_available,
+            "pickup_ship_actions_available": pickup_ship_actions_available,
             "fulfillable_value": round(sum(float(row.get("sum_value") or 0.0) for row in fulfillable_orders), 2),
             "status_counts": dict(sorted(status_counts.items())),
         },
@@ -2300,22 +2336,45 @@ def get_cached_roy_operations_snapshot(
     return payload
 
 
-def _resolve_shipped_status_id(client: Client, settings: Dict[str, Any]) -> int:
-    configured = int(settings.get("shipped_status_id") or 0)
+def _resolve_order_status_id(
+    client: Client,
+    *,
+    configured_id: Any,
+    target_status_name: str,
+    target_status_name_normalized: str,
+) -> int:
+    configured = int(configured_id or 0)
     if configured > 0:
         return configured
     result = client.execute(LIST_ORDER_STATUSES_QUERY, variable_values={"lang_code": "SK"})
-    target = settings["shipped_status_name_normalized"]
     for row in result.get("listOrderStatuses") or []:
-        if _normalize_text(row.get("name")) == target:
+        if _normalize_text(row.get("name")) == target_status_name_normalized:
             return int(row["id"])
-    raise RuntimeError(f"Target status '{settings['shipped_status_name']}' not found in BiznisWeb.")
+    raise RuntimeError(f"Target status '{target_status_name}' not found in BiznisWeb.")
 
 
-def mark_personal_pickup_shipped(project: str, order_num: str) -> Dict[str, Any]:
+def _resolve_pickup_ready_status_id(client: Client, settings: Dict[str, Any]) -> int:
+    return _resolve_order_status_id(
+        client,
+        configured_id=settings.get("pickup_ready_status_id"),
+        target_status_name=settings["pickup_ready_status_name"],
+        target_status_name_normalized=settings["pickup_ready_status_name_normalized"],
+    )
+
+
+def _resolve_shipped_status_id(client: Client, settings: Dict[str, Any]) -> int:
+    return _resolve_order_status_id(
+        client,
+        configured_id=settings.get("shipped_status_id"),
+        target_status_name=settings["shipped_status_name"],
+        target_status_name_normalized=settings["shipped_status_name_normalized"],
+    )
+
+
+def _mark_personal_pickup_status(project: str, order_num: str, action: str) -> Dict[str, Any]:
     project = (project or BASE_DEFAULT_PROJECT).strip() or BASE_DEFAULT_PROJECT
     if project != "roy":
-        raise ValueError("Pickup shipping action is only enabled for project 'roy'.")
+        raise ValueError("Pickup status action is only enabled for project 'roy'.")
 
     load_project_env(project)
     project_settings = load_project_settings(project)
@@ -2353,12 +2412,23 @@ query GetOrderForPickupAction($order_num: String!) {
     row = _public_order_row(order, settings)
     if not row["personal_pickup"]:
         raise ValueError(f"Order '{order_num}' is not configured as personal pickup.")
-    if _normalize_text(row["status"]) == settings["shipped_status_name_normalized"]:
-        raise ValueError(f"Order '{order_num}' is already in target status.")
-    if not row["pickup_action_allowed"]:
-        raise ValueError(f"Order '{order_num}' is not in an allowed pickup action status.")
+    if action == "ready":
+        if row["pickup_ready"]:
+            raise ValueError(f"Order '{order_num}' is already in target status.")
+        if not row["pickup_ready_action_allowed"]:
+            raise ValueError(f"Order '{order_num}' is not in an allowed pickup ready status.")
+        status_id = _resolve_pickup_ready_status_id(client, settings)
+        target_status_name = settings["pickup_ready_status_name"]
+    elif action == "ship":
+        if _normalize_text(row["status"]) == settings["shipped_status_name_normalized"]:
+            raise ValueError(f"Order '{order_num}' is already in target status.")
+        if not row["pickup_ship_action_allowed"]:
+            raise ValueError(f"Order '{order_num}' is not in an allowed pickup ship status.")
+        status_id = _resolve_shipped_status_id(client, settings)
+        target_status_name = settings["shipped_status_name"]
+    else:
+        raise ValueError(f"Unknown pickup action '{action}'.")
 
-    status_id = _resolve_shipped_status_id(client, settings)
     mutation_result = client.execute(
         CHANGE_ORDER_STATUS_MUTATION,
         variable_values={"order_num": order_num, "status_id": status_id},
@@ -2368,7 +2438,16 @@ query GetOrderForPickupAction($order_num: String!) {
         "ok": True,
         "project": project,
         "order_num": order_num,
+        "action": action,
         "target_status_id": status_id,
-        "target_status_name": settings["shipped_status_name"],
+        "target_status_name": target_status_name,
         "result": mutation_result.get("changeOrderStatus"),
     }
+
+
+def mark_personal_pickup_ready(project: str, order_num: str) -> Dict[str, Any]:
+    return _mark_personal_pickup_status(project, order_num, "ready")
+
+
+def mark_personal_pickup_shipped(project: str, order_num: str) -> Dict[str, Any]:
+    return _mark_personal_pickup_status(project, order_num, "ship")

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -2,6 +2,7 @@ import json
 import shutil
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from dashboard_modern import DASHBOARD_PAYLOAD_SCRIPT_ID
 from export_orders import BizniWebExporter
@@ -14,6 +15,8 @@ from roy_operations_dashboard import (
     build_roy_orders_snapshot,
     filter_unprinted_picking_orders,
     mark_picking_orders_printed,
+    mark_personal_pickup_ready,
+    mark_personal_pickup_shipped,
     resolve_roy_operations_settings,
 )
 
@@ -21,23 +24,28 @@ from roy_operations_dashboard import (
 ROOT_DIR = Path(__file__).resolve().parents[1]
 
 
-def make_settings() -> dict:
-    return resolve_roy_operations_settings(
-        {
-            "operations_dashboard": {
-                "enabled": True,
-                "paid_statuses": ["Platba online - zaplatené"],
-                "cod_statuses": ["Čaká na vybavenie"],
-                "cod_payment_patterns": ["dobierka", "dobírka"],
-                "cod_payment_ids": ["7", "10"],
-                "personal_pickup_shipping_names": ["Osobný odber na sklade"],
-                "personal_pickup_shipping_ids": ["11"],
-                "pickup_action_statuses": ["Čaká na vybavenie", "Platba online - zaplatené"],
-                "shipped_status_name": "Odoslaná",
-                "shipped_status_id": 4,
-            }
+def make_project_settings() -> dict:
+    return {
+        "operations_dashboard": {
+            "enabled": True,
+            "paid_statuses": ["Platba online - zaplatené"],
+            "cod_statuses": ["Čaká na vybavenie"],
+            "cod_payment_patterns": ["dobierka", "dobírka"],
+            "cod_payment_ids": ["7", "10"],
+            "personal_pickup_shipping_names": ["Osobný odber na sklade"],
+            "personal_pickup_shipping_ids": ["11"],
+            "pickup_ready_status_name": "Pripravené k odberu",
+            "pickup_ready_status_id": 23,
+            "pickup_ready_action_statuses": ["Platba online - zaplatené"],
+            "pickup_ship_action_statuses": ["Pripravené k odberu"],
+            "shipped_status_name": "Odoslaná",
+            "shipped_status_id": 4,
         }
-    )
+    }
+
+
+def make_settings() -> dict:
+    return resolve_roy_operations_settings(make_project_settings())
 
 
 def price_element(kind: str, title: str, reference_id: str = "") -> dict:
@@ -78,6 +86,24 @@ def make_order(
     }
 
 
+class FakePickupActionClient:
+    def __init__(self, order: dict) -> None:
+        self.order = order
+        self.changed_status_ids: list[int] = []
+
+    def execute(self, query: object, variable_values: dict | None = None) -> dict:
+        values = variable_values or {}
+        if "status_id" in values:
+            self.changed_status_ids.append(values["status_id"])
+            return {
+                "changeOrderStatus": {
+                    "order_num": values["order_num"],
+                    "status": {"id": values["status_id"], "name": "target"},
+                }
+            }
+        return {"getOrder": self.order}
+
+
 class RoyOperationsDashboardTests(unittest.TestCase):
     def test_roy_settings_enable_operations_dashboard_and_lead_times(self) -> None:
         project_settings = json.loads((ROOT_DIR / "projects" / "roy" / "settings.json").read_text(encoding="utf-8"))
@@ -86,6 +112,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
 
         self.assertTrue(operations["enabled"])
         self.assertEqual(90, operations["auto_refresh_seconds"])
+        self.assertEqual(23, operations["pickup_ready_status_id"])
+        self.assertEqual("Pripravené k odberu", operations["pickup_ready_status_name"])
         self.assertEqual(4, operations["shipped_status_id"])
         self.assertEqual(10, operations["wholesale_detection"]["discount_threshold_pct"])
         self.assertTrue(operations["wholesale_detection"]["require_company_customer"])
@@ -112,6 +140,7 @@ class RoyOperationsDashboardTests(unittest.TestCase):
             make_order("R-4", "Odoslaná", price_element("payment", "Dobierkou", "7"), pickup_shipping),
             make_order("R-5", "Platba online - zaplatené", price_element("payment", "Okamžitá platba online", "18"), pickup_shipping),
             make_order("R-6", "Nezaplatená - zrušená objednávka", price_element("payment", "Okamžitá platba online", "18"), pickup_shipping),
+            make_order("R-7", "Pripravené k odberu", price_element("payment", "Okamžitá platba online", "18"), pickup_shipping),
         ]
 
         snapshot = build_roy_orders_snapshot(project="roy", orders=orders, settings=settings)
@@ -121,12 +150,54 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(1, snapshot["summary"]["cod_waiting_orders"])
         self.assertEqual(["R-1", "R-2", "R-5"], [row["order_num"] for row in snapshot["orders"]])
         self.assertEqual("13,70 EUR", snapshot["orders"][0]["items"][0]["unit_price_formatted"])
-        self.assertEqual(["R-5"], [row["order_num"] for row in snapshot["personal_pickups"]])
+        self.assertEqual(["R-5", "R-7"], [row["order_num"] for row in snapshot["personal_pickups"]])
+        self.assertEqual(1, snapshot["summary"]["pickup_ready_actions_available"])
+        self.assertEqual(1, snapshot["summary"]["pickup_ship_actions_available"])
+        self.assertEqual(2, snapshot["summary"]["pickup_actions_available"])
         cod_pickup = next(row for row in snapshot["orders"] if row["order_num"] == "R-2")
         self.assertFalse(cod_pickup["paid_personal_pickup"])
         self.assertFalse(cod_pickup["pickup_action_allowed"])
-        self.assertTrue(snapshot["personal_pickups"][0]["pickup_action_allowed"])
-        self.assertTrue(snapshot["personal_pickups"][0]["paid_personal_pickup"])
+        paid_pickup = snapshot["personal_pickups"][0]
+        ready_pickup = snapshot["personal_pickups"][1]
+        self.assertTrue(paid_pickup["pickup_ready_action_allowed"])
+        self.assertFalse(paid_pickup["pickup_ready"])
+        self.assertFalse(paid_pickup["pickup_ship_action_allowed"])
+        self.assertTrue(paid_pickup["paid_personal_pickup"])
+        self.assertFalse(ready_pickup["pickup_ready_action_allowed"])
+        self.assertTrue(ready_pickup["pickup_ready"])
+        self.assertTrue(ready_pickup["pickup_ship_action_allowed"])
+        self.assertTrue(ready_pickup["pickup_action_allowed"])
+        self.assertTrue(ready_pickup["paid_personal_pickup"])
+
+    def test_pickup_ready_and_ship_actions_use_separate_target_statuses(self) -> None:
+        pickup_shipping = price_element("shipping", "Osobný odber na sklade", "11")
+        paid_payment = price_element("payment", "Okamžitá platba online", "18")
+        project_settings = make_project_settings()
+        ready_client = FakePickupActionClient(
+            make_order("R-READY", "Platba online - zaplatené", paid_payment, pickup_shipping)
+        )
+        ship_client = FakePickupActionClient(
+            make_order("R-SHIP", "Pripravené k odberu", paid_payment, pickup_shipping)
+        )
+
+        with patch("roy_operations_dashboard.load_project_env"), patch(
+            "roy_operations_dashboard.load_project_settings",
+            return_value=project_settings,
+        ), patch("roy_operations_dashboard._build_client", return_value=ready_client):
+            ready_result = mark_personal_pickup_ready("roy", "R-READY")
+
+        with patch("roy_operations_dashboard.load_project_env"), patch(
+            "roy_operations_dashboard.load_project_settings",
+            return_value=project_settings,
+        ), patch("roy_operations_dashboard._build_client", return_value=ship_client):
+            ship_result = mark_personal_pickup_shipped("roy", "R-SHIP")
+
+        self.assertEqual([23], ready_client.changed_status_ids)
+        self.assertEqual("ready", ready_result["action"])
+        self.assertEqual("Pripravené k odberu", ready_result["target_status_name"])
+        self.assertEqual([4], ship_client.changed_status_ids)
+        self.assertEqual("ship", ship_result["action"])
+        self.assertEqual("Odoslaná", ship_result["target_status_name"])
 
     def test_snapshot_exposes_notes_addresses_and_wholesale_signal_for_pdf(self) -> None:
         settings = make_settings()
@@ -438,6 +509,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("loud-two-tone-v2", html)
         self.assertIn("playOrderAlertBurst", html)
         self.assertIn("notifyAboutNewFulfillableOrders", html)
+        self.assertIn("data-ready-pickup", html)
+        self.assertIn("/ready", html)
         self.assertIn("Vysklad. PDF", html)
         self.assertIn("/api/operations/roy/picking-lists.pdf", html)
         self.assertIn("seenFulfillableOrderKeys", html)


### PR DESCRIPTION
## What changed
- adds a separate ROY personal-pickup `Pripravené k odberu` checkbox/action
- adds `POST /api/operations/roy/pickup/<order_num>/ready` to set BiznisWeb status `Pripravené k odberu` (`status_id=23`)
- keeps the existing ship action, but enables it only after the order is already `Pripravené k odberu`
- updates ROY operations settings and dashboard tests
- records the change in `PROJECT_STATE.md`

## Verified
- `python -m json.tool projects/roy/settings.json`
- `python -m unittest tests.test_roy_operations_dashboard`
- `python -m unittest tests.test_roy_operations_dashboard tests.test_reporting_calculation_fixes tests.test_unpaid_order_cancellation`
- BiznisWeb status lookup confirmed `Pripravené k odberu` is id `23` and `Odoslaná` is id `4`