### PR TITLE
[codex] Require emailing generated invoices

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-06-02
+Last updated: 2026-06-03
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,15 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- VEVO/ROY invoice email automation change is implemented locally on `2026-06-03`:
+  - branch: `codex/auto-email-created-invoices`
+  - change: `invoice_generation.send_invoice_email` is explicit and enabled for VEVO and ROY; newly created invoices must be emailed through the BizniWeb invoice email action when the setting is enabled
+  - implementation: invoice finalization now resolves invoice id from JSON/HTML response or by re-reading `getOrder(order_num) { invoices { id invoice_num } }`, then calls `/erp/orders/invoices/sendEmail/<invoice_id>` with AJAX headers
+  - runner behavior: `invoice_runner.py` and the legacy daily-report invoice hook now publish email metrics and fail the run if a created invoice cannot be emailed or if the invoice id cannot be resolved
+  - local verification: `python -m py_compile generate_invoices.py invoice_runner.py daily_report_runner.py`; `python -m json.tool projects/vevo/settings.json`; `python -m json.tool projects/roy/settings.json`; `python -m json.tool templates/reporting-client/settings.template.json`; `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`; `git diff --check`
+  - production status: not deployed yet
+  - Next exact step: commit/push branch, open/merge PR, rebuild ECR `latest`, then run production invoice smoke for VEVO and ROY with ECS/Fargate hard-gate context, localhost marker, and only then any UI/public check
 
 - ROY personal pickup ready checkbox was implemented and deployed on `2026-06-02`:
   - change: ROY live dashboard personal pickup cards now have a separate `Pripravené k odberu` checkbox before the existing customer pickup/`Odoslaná` action

--- a/README.md
+++ b/README.md
@@ -317,7 +317,9 @@ python generate_invoices.py --dry-run
 3. **Fetch Orders** - Retrieves orders from GraphQL API for the specified date range
 4. **Filter Orders** - Identifies orders matching the criteria (cash on delivery, no invoice)
 5. **Create Invoices** - Creates invoices for each matching order via web API
-6. **Send Emails** - Automatically sends invoice emails to customers
+6. **Send Emails** - Automatically sends invoice emails to customers through the BizniWeb invoice email action
+
+When `invoice_generation.send_invoice_email` is enabled, the invoice run fails if a newly created invoice cannot be emailed or if the invoice ID cannot be resolved for the BizniWeb send action.
 
 ### Output
 

--- a/daily_report_runner.py
+++ b/daily_report_runner.py
@@ -180,11 +180,18 @@ def maybe_run_invoice_automation(
     put_metric("InvoiceAutomationSkippedZeroTotal", summary.skipped_zero_total_orders, project, reporting_defaults)
     put_metric("InvoiceAutomationCreated", summary.created_invoices, project, reporting_defaults)
     put_metric("InvoiceAutomationCreateFailures", summary.failed_invoices, project, reporting_defaults)
+    put_metric("InvoiceAutomationEmailed", summary.emailed_invoices, project, reporting_defaults)
+    put_metric("InvoiceAutomationEmailFailures", summary.failed_invoice_emails, project, reporting_defaults)
+    put_metric("InvoiceAutomationMissingInvoiceIds", summary.missing_invoice_ids, project, reporting_defaults)
     put_metric("InvoiceAutomationRunSucceeded", 1, project, reporting_defaults)
 
-    if not dry_run and summary.failed_invoices:
+    if not dry_run and (summary.failed_invoices or summary.failed_invoice_emails):
         raise RuntimeError(
-            f"Invoice automation failed for {summary.failed_invoices} order(s) in project '{project}'"
+            (
+                f"Invoice automation failed for project '{project}': "
+                f"create_failures={summary.failed_invoices}, "
+                f"email_failures={summary.failed_invoice_emails}"
+            )
         )
 
     return {
@@ -193,6 +200,9 @@ def maybe_run_invoice_automation(
         "matched_orders": summary.matched_orders,
         "created_invoices": summary.created_invoices,
         "failed_invoices": summary.failed_invoices,
+        "emailed_invoices": summary.emailed_invoices,
+        "failed_invoice_emails": summary.failed_invoice_emails,
+        "missing_invoice_ids": summary.missing_invoice_ids,
         "skipped_zero_total_orders": summary.skipped_zero_total_orders,
         "dry_run": summary.dry_run,
     }
@@ -1188,6 +1198,8 @@ def main() -> None:
                 f"matched={invoice_summary['matched_orders']} "
                 f"created={invoice_summary['created_invoices']} "
                 f"failed={invoice_summary['failed_invoices']} "
+                f"emailed={invoice_summary['emailed_invoices']} "
+                f"email_failed={invoice_summary['failed_invoice_emails']} "
                 f"skipped_zero_total={invoice_summary['skipped_zero_total_orders']}"
             )
 

--- a/generate_invoices.py
+++ b/generate_invoices.py
@@ -116,6 +116,18 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
 }
 """)
 
+ORDER_INVOICE_QUERY = gql("""
+query GetOrderInvoices($order_num: String!) {
+  getOrder(order_num: $order_num) {
+    order_num
+    invoices {
+      id
+      invoice_num
+    }
+  }
+}
+""")
+
 
 @dataclass
 class InvoiceRunSummary:
@@ -127,8 +139,24 @@ class InvoiceRunSummary:
     matched_orders: int = 0
     created_invoices: int = 0
     failed_invoices: int = 0
+    emailed_invoices: int = 0
+    failed_invoice_emails: int = 0
+    missing_invoice_ids: int = 0
     skipped_zero_total_orders: int = 0
     total_amount: float = 0.0
+
+
+@dataclass
+class InvoiceCreationResult:
+    created: bool = False
+    invoice_id: Optional[str] = None
+    invoice_num: Optional[str] = None
+    email_required: bool = True
+    email_sent: bool = False
+    email_error: str = ""
+
+    def __bool__(self) -> bool:
+        return self.created and (not self.email_required or self.email_sent)
 
 
 def resolve_invoice_generation_settings(project_settings: Dict[str, Any]) -> Dict[str, Any]:
@@ -155,6 +183,7 @@ def resolve_invoice_generation_settings(project_settings: Dict[str, Any]) -> Dic
         "lookback_days": max(1, lookback_days),
         "exclude_zero_total_orders": bool(raw_settings.get("exclude_zero_total_orders", True)),
         "eligible_statuses": eligible_statuses,
+        "send_invoice_email": bool(raw_settings.get("send_invoice_email", True)),
     }
 
 
@@ -232,6 +261,75 @@ def _redact_headers(headers: Dict[str, Any]) -> Dict[str, Any]:
     return sanitized
 
 
+def _extract_invoice_id_from_payload(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+
+    for key in ("invoice_id", "invoiceId", "invoiceID"):
+        value = payload.get(key)
+        if value not in (None, ""):
+            return str(value)
+
+    invoice = payload.get("invoice")
+    if isinstance(invoice, dict):
+        value = invoice.get("id") or invoice.get("invoice_id") or invoice.get("invoiceId")
+        if value not in (None, ""):
+            return str(value)
+
+    for key in ("data", "result", "record"):
+        nested = payload.get(key)
+        nested_invoice_id = _extract_invoice_id_from_payload(nested)
+        if nested_invoice_id:
+            return nested_invoice_id
+
+    value = payload.get("id")
+    if value not in (None, ""):
+        return str(value)
+
+    return None
+
+
+def _extract_invoice_num_from_payload(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+
+    for key in ("invoice_num", "invoiceNum", "number"):
+        value = payload.get(key)
+        if value not in (None, ""):
+            return str(value)
+
+    invoice = payload.get("invoice")
+    if isinstance(invoice, dict):
+        value = invoice.get("invoice_num") or invoice.get("invoiceNum") or invoice.get("number")
+        if value not in (None, ""):
+            return str(value)
+
+    for key in ("data", "result", "record"):
+        nested = payload.get(key)
+        nested_invoice_num = _extract_invoice_num_from_payload(nested)
+        if nested_invoice_num:
+            return nested_invoice_num
+
+    return None
+
+
+def _extract_invoice_id_from_text(*values: Any) -> Optional[str]:
+    patterns = (
+        r"/erp/orders/invoices/(?:detail|edit|sendEmail)/(\d+)",
+        r"[\"']invoice[_-]?id[\"']\s*[:=]\s*[\"']?(\d+)",
+        r"[\"']invoiceId[\"']\s*[:=]\s*[\"']?(\d+)",
+    )
+    for value in values:
+        text = str(value or "")
+        if not text:
+            continue
+        for pattern in patterns:
+            match = re.search(pattern, text, flags=re.IGNORECASE)
+            if match:
+                return match.group(1)
+    return None
+
+
 class InvoiceGenerator:
     def __init__(
         self,
@@ -242,6 +340,7 @@ class InvoiceGenerator:
         password: Optional[str] = None,
         exclude_zero_total_orders: bool = True,
         eligible_statuses: Optional[Iterable[str]] = None,
+        send_invoice_email: bool = True,
     ):
         """Initialize the invoice generator with API credentials"""
         transport = RequestsHTTPTransport(
@@ -262,6 +361,7 @@ class InvoiceGenerator:
         self.arf_token = None
         self.exclude_zero_total_orders = exclude_zero_total_orders
         self.eligible_statuses = tuple(eligible_statuses or DEFAULT_INVOICE_ELIGIBLE_STATUSES)
+        self.send_invoice_email_enabled = bool(send_invoice_email)
         
         # Initialize web session if credentials provided
         if username and password:
@@ -755,6 +855,39 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
             return filtered_orders
 
         return all_orders
+
+    def fetch_latest_invoice_for_order(self, order_num: Any) -> Tuple[Optional[str], Optional[str]]:
+        """Read the order again after invoice finalization and return its invoice id/number."""
+        normalized_order_num = str(order_num or "").strip()
+        if not normalized_order_num:
+            return None, None
+
+        try:
+            result = self.client.execute(
+                ORDER_INVOICE_QUERY,
+                variable_values={"order_num": normalized_order_num},
+            )
+            order = result.get("getOrder") or {}
+            invoices = order.get("invoices") or []
+            if not invoices:
+                logger.warning("Order %s has no invoices after finalization fallback", normalized_order_num)
+                return None, None
+
+            invoice = invoices[-1] or {}
+            invoice_id = invoice.get("id")
+            invoice_num = invoice.get("invoice_num")
+            if invoice_id:
+                logger.info(
+                    "Resolved invoice id %s for order %s via GraphQL fallback",
+                    invoice_id,
+                    normalized_order_num,
+                )
+            return (str(invoice_id) if invoice_id not in (None, "") else None), (
+                str(invoice_num) if invoice_num not in (None, "") else None
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve invoice id for order %s after finalization: %s", normalized_order_num, exc)
+            return None, None
     
     def filter_orders_for_invoice(self, orders: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
         """Filter orders that need invoice generation"""
@@ -797,9 +930,10 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
 
         return filtered_orders, stats
     
-    def create_invoice(self, order: Dict[str, Any]) -> bool:
+    def create_invoice(self, order: Dict[str, Any]) -> InvoiceCreationResult:
         """Create invoice for the order"""
         order_num = order.get('order_num')
+        creation_result = InvoiceCreationResult(email_required=self.send_invoice_email_enabled)
         customer = order.get('customer', {})
         customer_name = customer.get('company_name', '')
         if not customer_name:
@@ -813,128 +947,136 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
         logger.info(f"  Amount: {order_sum}")
         logger.info(f"  Status: {order.get('status', {}).get('name', 'N/A')}")
         
-        # Create invoice using web session
         try:
-                # Add timestamp to avoid caching
-                import time
+            import time
+            timestamp = int(time.time() * 1000)
+
+            order_id = order.get('id')
+            logger.debug(f"Order {order_num} has ID: {order_id}")
+
+            headers = {
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json, text/javascript, */*; q=0.01',
+                'Referer': f'{self.base_url}/erp/orders/orders/detail/{order_num}'
+            }
+
+            create_url = self.invoice_create_url.format(order_num=order_num)
+            if self.arf_token:
+                create_url += f"?arf={self.arf_token}&_dc={timestamp}"
+            else:
+                create_url += f"?_dc={timestamp}"
+
+            logger.debug(f"Attempting to create invoice first: {create_url}")
+            create_response = self.web_session.post(create_url, headers=headers)
+
+            if create_response.status_code == 200:
+                try:
+                    create_result = create_response.json()
+                    logger.debug(f"Create response: {create_result}")
+                    if not create_result.get('success'):
+                        logger.debug(f"Create step failed: {create_result.get('errors', {}).get('reason', 'Unknown error')}")
+                except json.JSONDecodeError:
+                    logger.debug(f"Create response not JSON: {create_response.text[:200]}")
+
+            time.sleep(1)
+
+            response = None
+            finalize_url = ""
+            urls_to_try = [('order_num', order_num)]
+            if order_id:
+                urls_to_try.append(('order_id', order_id))
+
+            for url_type, identifier in urls_to_try:
+                finalize_url = self.invoice_finalize_url.format(order_num=identifier)
                 timestamp = int(time.time() * 1000)
-                
-                # Get order ID from the order data (not order_num)
-                order_id = order.get('id')
-                logger.debug(f"Order {order_num} has ID: {order_id}")
-                
-                # Set headers for AJAX request
-                headers = {
-                    'X-Requested-With': 'XMLHttpRequest',
-                    'Accept': 'application/json, text/javascript, */*; q=0.01',
-                    'Referer': f'{self.base_url}/erp/orders/orders/detail/{order_num}'
-                }
-                
-                # First try to create the invoice (this might be required before finalization)
-                create_url = self.invoice_create_url.format(order_num=order_num)
                 if self.arf_token:
-                    create_url += f"?arf={self.arf_token}&_dc={timestamp}"
+                    finalize_url += f"?arf={self.arf_token}&_dc={timestamp}"
                 else:
-                    create_url += f"?_dc={timestamp}"
-                
-                logger.debug(f"Attempting to create invoice first: {create_url}")
-                create_response = self.web_session.post(create_url, headers=headers)
-                
-                if create_response.status_code == 200:
-                    try:
-                        create_result = create_response.json()
-                        logger.debug(f"Create response: {create_result}")
-                        if not create_result.get('success'):
-                            logger.debug(f"Create step failed: {create_result.get('errors', {}).get('reason', 'Unknown error')}")
-                    except json.JSONDecodeError:
-                        logger.debug(f"Create response not JSON: {create_response.text[:200]}")
-                
-                # Add a small delay to avoid locking issues
-                time.sleep(1)
-                
-                # Now try to finalize the invoice
-                # Try order_num first, then order_id
-                urls_to_try = [('order_num', order_num)]
-                if order_id:
-                    urls_to_try.append(('order_id', order_id))
-                
-                for url_type, identifier in urls_to_try:
-                    # Create invoice URL
-                    finalize_url = self.invoice_finalize_url.format(order_num=identifier)
-                    timestamp = int(time.time() * 1000)  # New timestamp for finalize
-                    if self.arf_token:
-                        finalize_url += f"?arf={self.arf_token}&_dc={timestamp}"
-                    else:
-                        finalize_url += f"?_dc={timestamp}"
-                    
-                    logger.debug(f"Attempting to finalize invoice via {url_type}: {finalize_url}")
-                    
-                    # Try POST first, then GET if it fails
-                    response = self.web_session.post(finalize_url, headers=headers)
-                    
-                    if response.status_code == 405:  # Method not allowed
-                        logger.debug("POST not allowed, trying GET")
-                        response = self.web_session.get(finalize_url, headers=headers)
-                    
-                    # If successful, break out of loop
-                    if response.status_code == 200:
-                        break
-                    elif response.status_code == 400:
-                        logger.debug(f"Got 400 error with {url_type}, trying next...")
-                        continue
-                
-                # Check if invoice was created
+                    finalize_url += f"?_dc={timestamp}"
+
+                logger.debug(f"Attempting to finalize invoice via {url_type}: {finalize_url}")
+                response = self.web_session.post(finalize_url, headers=headers)
+
+                if response.status_code == 405:
+                    logger.debug("POST not allowed, trying GET")
+                    response = self.web_session.get(finalize_url, headers=headers)
+
                 if response.status_code == 200:
-                    # Log the raw response first
-                    logger.debug(f"  Raw response: {response.text[:1000]}")
-                    
-                    # Try to parse response
-                    try:
-                        result = response.json()
-                        logger.debug(f"  JSON response: {result}")
-                        if result.get('success'):
-                            invoice_id = result.get('invoice_id') or result.get('id')
-                            invoice_num = result.get('invoice_num')
-                            logger.info(f"  âś“ Invoice created: {invoice_num}")
-                            
-                            # Try to send email
-                            if invoice_id:
-                                if self.send_invoice_email(invoice_id):
-                                    logger.info(f"  âś“ Invoice email notification sent successfully to customer")
-                                else:
-                                    logger.warning(f"  âš  Failed to send invoice email notification")
-                            
-                            return True
-                        else:
-                            error_msg = result.get('message') or result.get('errors', {}).get('reason', 'Unknown error')
-                            logger.error(f"  âś— Invoice creation failed: {error_msg}")
-                            return False
-                    except json.JSONDecodeError:
-                        # Response might be HTML, check for success indicators
-                        if 'success' in response.text.lower() or 'invoice' in response.text.lower():
-                            logger.info(f"  âś“ Invoice likely created (HTML response)")
-                            return True
-                        else:
-                            logger.error(f"  âś— Invoice creation failed (HTML response)")
-                            logger.debug(f"  âś— HTML response: {response.text[:500]}")
-                            return False
-                elif response.status_code == 400:
-                    # Log the actual error response
-                    logger.error(f"  âś— Bad request (400) - URL: {finalize_url}")
-                    try:
-                        error_detail = response.json()
-                        logger.error(f"  âś— Error details: {error_detail}")
-                    except:
-                        logger.error(f"  âś— Error response: {response.text[:500]}")
-                    return False
+                    break
+                if response.status_code == 400:
+                    logger.debug(f"Got 400 error with {url_type}, trying next...")
+                    continue
+
+            if response is None:
+                logger.error("  âś— Invoice creation failed before finalization response")
+                return creation_result
+
+            if response.status_code == 200:
+                logger.debug(f"  Raw response: {response.text[:1000]}")
+                response_payload = None
+                try:
+                    response_payload = response.json()
+                    logger.debug(f"  JSON response: {response_payload}")
+                except json.JSONDecodeError:
+                    response_payload = None
+
+                if isinstance(response_payload, dict):
+                    if not response_payload.get('success'):
+                        error_msg = response_payload.get('message') or response_payload.get('errors', {}).get('reason', 'Unknown error')
+                        logger.error(f"  âś— Invoice creation failed: {error_msg}")
+                        return creation_result
+                    creation_result.created = True
+                    creation_result.invoice_id = _extract_invoice_id_from_payload(response_payload)
+                    creation_result.invoice_num = _extract_invoice_num_from_payload(response_payload)
+                elif 'success' in response.text.lower() or 'invoice' in response.text.lower():
+                    creation_result.created = True
+                    creation_result.invoice_id = _extract_invoice_id_from_text(response.text, response.url)
+                    logger.info("  âś“ Invoice likely created (HTML response)")
                 else:
-                    logger.error(f"  âś— Invoice creation failed with status {response.status_code}")
-                    logger.error(f"  âś— Response: {response.text[:500]}")
-                    return False
+                    logger.error("  âś— Invoice creation failed (HTML response)")
+                    logger.debug(f"  âś— HTML response: {response.text[:500]}")
+                    return creation_result
+
+                if not creation_result.invoice_id:
+                    fallback_invoice_id, fallback_invoice_num = self.fetch_latest_invoice_for_order(order_num)
+                    creation_result.invoice_id = fallback_invoice_id
+                    creation_result.invoice_num = creation_result.invoice_num or fallback_invoice_num
+
+                logger.info(f"  âś“ Invoice created: {creation_result.invoice_num or creation_result.invoice_id or 'unknown'}")
+
+                if not self.send_invoice_email_enabled:
+                    logger.info("  Invoice email notification skipped by configuration")
+                    return creation_result
+
+                if not creation_result.invoice_id:
+                    creation_result.email_error = "missing_invoice_id"
+                    logger.error("  âś— Invoice email notification not sent: missing invoice id")
+                    return creation_result
+
+                if self.send_invoice_email(creation_result.invoice_id):
+                    creation_result.email_sent = True
+                    logger.info("  âś“ Invoice email notification sent successfully to customer")
+                else:
+                    creation_result.email_error = "send_failed"
+                    logger.error("  âś— Failed to send invoice email notification")
+                return creation_result
+
+            if response.status_code == 400:
+                logger.error(f"  âś— Bad request (400) - URL: {finalize_url}")
+                try:
+                    error_detail = response.json()
+                    logger.error(f"  âś— Error details: {error_detail}")
+                except Exception:
+                    logger.error(f"  âś— Error response: {response.text[:500]}")
+                return creation_result
+
+            logger.error(f"  âś— Invoice creation failed with status {response.status_code}")
+            logger.error(f"  âś— Response: {response.text[:500]}")
+            return creation_result
                             
         except Exception as e:
             logger.error(f"  âś— Error creating invoice: {e}")
-            return False
+            return creation_result
     
     def send_invoice_email(self, invoice_id: str) -> bool:
         """Send invoice email notification to customer"""
@@ -949,7 +1091,15 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
                 send_url += f"?_dc={timestamp}"
             
             logger.debug(f"Sending invoice email via: {send_url}")
-            response = self.web_session.post(send_url)
+            headers = {
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json, text/javascript, */*; q=0.01',
+                'Referer': f'{self.base_url}/erp/orders/invoices/detail/{invoice_id}',
+            }
+            response = self.web_session.post(send_url, headers=headers)
+            if response.status_code == 405:
+                logger.debug("Invoice email POST not allowed, trying GET")
+                response = self.web_session.get(send_url, headers=headers)
             response.raise_for_status()
             
             # Check response
@@ -1039,6 +1189,7 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
         # Process orders for invoice creation
         success_count = 0
         failed_count = 0
+        email_failed_count = 0
         total_amount = 0.0
         processed_orders = []
         
@@ -1047,17 +1198,21 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
             customer = order.get('customer', {})
             customer_email = customer.get('email', 'N/A')
             
-            if self.create_invoice(order):
+            result = self.create_invoice(order)
+            if result.created:
                 success_count += 1
                 # Try to extract numeric value from formatted amount
                 order_sum = order.get('sum', {}).get('value', 0)
                 if order_sum:
                     total_amount += float(order_sum)
-                processed_orders.append({
-                    'order_num': order_num,
-                    'email': customer_email,
-                    'amount': order.get('sum', {}).get('formatted', 'N/A')
-                })
+                if result.email_required and not result.email_sent:
+                    email_failed_count += 1
+                else:
+                    processed_orders.append({
+                        'order_num': order_num,
+                        'email': customer_email,
+                        'amount': order.get('sum', {}).get('formatted', 'N/A')
+                    })
             else:
                 failed_count += 1
         
@@ -1066,6 +1221,8 @@ query GetOrders($filter: OrderFilter, $params: OrderParams) {
         logger.info(f"  âś“ Invoices created: {success_count}")
         if failed_count > 0:
             logger.info(f"  âś— Failed: {failed_count}")
+        if email_failed_count > 0:
+            logger.info(f"  âś— Invoice emails failed: {email_failed_count}")
         logger.info(f"  Skipped zero-total orders: {filter_stats.get('skipped_zero_total_orders', 0)}")
         logger.info(f"  Total amount: â‚¬{total_amount:.2f}")
         logger.info("=" * 60)
@@ -1113,6 +1270,7 @@ def run_invoice_generation(
         None if no_web_login else web_password,
         exclude_zero_total_orders=invoice_settings["exclude_zero_total_orders"],
         eligible_statuses=invoice_settings["eligible_statuses"],
+        send_invoice_email=invoice_settings["send_invoice_email"],
     )
 
     summary = InvoiceRunSummary(
@@ -1153,18 +1311,32 @@ def run_invoice_generation(
         return summary
 
     for order in orders_for_invoice:
-        if generator.create_invoice(order):
+        result = generator.create_invoice(order)
+        if result.created:
             summary.created_invoices += 1
             summary.total_amount += _coerce_order_total_value(order)
+            if result.email_required:
+                if result.email_sent:
+                    summary.emailed_invoices += 1
+                else:
+                    summary.failed_invoice_emails += 1
+                    if result.email_error == "missing_invoice_id":
+                        summary.missing_invoice_ids += 1
         else:
             summary.failed_invoices += 1
 
     logger.info(
-        "Invoice run summary - project=%s matched=%s created=%s failed=%s skipped_zero_total=%s total_amount=%.2f",
+        (
+            "Invoice run summary - project=%s matched=%s created=%s failed=%s "
+            "emailed=%s email_failed=%s missing_invoice_ids=%s skipped_zero_total=%s total_amount=%.2f"
+        ),
         summary.project,
         summary.matched_orders,
         summary.created_invoices,
         summary.failed_invoices,
+        summary.emailed_invoices,
+        summary.failed_invoice_emails,
+        summary.missing_invoice_ids,
         summary.skipped_zero_total_orders,
         summary.total_amount,
     )
@@ -1224,14 +1396,20 @@ def main():
         no_web_login=args.no_web_login,
     )
     logger.info(
-        "Invoice run summary - project=%s matched=%s created=%s failed=%s skipped_zero_total=%s",
+        (
+            "Invoice run summary - project=%s matched=%s created=%s failed=%s "
+            "emailed=%s email_failed=%s missing_invoice_ids=%s skipped_zero_total=%s"
+        ),
         summary.project,
         summary.matched_orders,
         summary.created_invoices,
         summary.failed_invoices,
+        summary.emailed_invoices,
+        summary.failed_invoice_emails,
+        summary.missing_invoice_ids,
         summary.skipped_zero_total_orders,
     )
-    if not args.dry_run and summary.failed_invoices:
+    if not args.dry_run and (summary.failed_invoices or summary.failed_invoice_emails):
         raise SystemExit(1)
 
 

--- a/invoice_runner.py
+++ b/invoice_runner.py
@@ -147,6 +147,9 @@ def run_invoice_runner(args: argparse.Namespace) -> Dict[str, Any]:
     put_metric("InvoiceStandaloneSkippedZeroTotal", summary.skipped_zero_total_orders, project, reporting_defaults)
     put_metric("InvoiceStandaloneCreated", summary.created_invoices, project, reporting_defaults)
     put_metric("InvoiceStandaloneCreateFailures", summary.failed_invoices, project, reporting_defaults)
+    put_metric("InvoiceStandaloneEmailed", summary.emailed_invoices, project, reporting_defaults)
+    put_metric("InvoiceStandaloneEmailFailures", summary.failed_invoice_emails, project, reporting_defaults)
+    put_metric("InvoiceStandaloneMissingInvoiceIds", summary.missing_invoice_ids, project, reporting_defaults)
     put_metric("InvoiceStandaloneRunSucceeded", 1, project, reporting_defaults)
 
     print(
@@ -154,11 +157,20 @@ def run_invoice_runner(args: argparse.Namespace) -> Dict[str, Any]:
         f"matched={summary.matched_orders} "
         f"created={summary.created_invoices} "
         f"failed={summary.failed_invoices} "
+        f"emailed={summary.emailed_invoices} "
+        f"email_failed={summary.failed_invoice_emails} "
+        f"missing_invoice_ids={summary.missing_invoice_ids} "
         f"skipped_zero_total={summary.skipped_zero_total_orders}"
     )
 
-    if not args.dry_run and summary.failed_invoices:
-        raise RuntimeError(f"Invoice automation failed for {summary.failed_invoices} order(s) in project '{project}'")
+    if not args.dry_run and (summary.failed_invoices or summary.failed_invoice_emails):
+        raise RuntimeError(
+            (
+                f"Invoice automation failed for project '{project}': "
+                f"create_failures={summary.failed_invoices}, "
+                f"email_failures={summary.failed_invoice_emails}"
+            )
+        )
 
     return {
         "project": summary.project,
@@ -168,6 +180,9 @@ def run_invoice_runner(args: argparse.Namespace) -> Dict[str, Any]:
         "matched_orders": summary.matched_orders,
         "created_invoices": summary.created_invoices,
         "failed_invoices": summary.failed_invoices,
+        "emailed_invoices": summary.emailed_invoices,
+        "failed_invoice_emails": summary.failed_invoice_emails,
+        "missing_invoice_ids": summary.missing_invoice_ids,
         "skipped_zero_total_orders": summary.skipped_zero_total_orders,
         "dry_run": summary.dry_run,
     }

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -72,6 +72,7 @@
     "enabled": true,
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
+    "send_invoice_email": true,
     "eligible_statuses": [
       "Odoslaná"
     ],

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -43,6 +43,7 @@
     "enabled": true,
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
+    "send_invoice_email": true,
     "eligible_statuses": [
       "Odoslaná"
     ],

--- a/templates/reporting-client/settings.template.json
+++ b/templates/reporting-client/settings.template.json
@@ -18,6 +18,7 @@
     "enabled": false,
     "lookback_days": 7,
     "exclude_zero_total_orders": true,
+    "send_invoice_email": true,
     "eligible_statuses": [
       "Odoslaná"
     ],

--- a/tests/test_invoice_generation.py
+++ b/tests/test_invoice_generation.py
@@ -17,13 +17,70 @@ from invoice_runner import resolve_invoice_runner_window
 ROOT_DIR = Path(__file__).resolve().parents[1]
 
 
+class _FakeInvoiceResponse:
+    def __init__(self, url: str, payload: dict | None = None, status_code: int = 200) -> None:
+        self.url = url
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload or {})
+
+    def json(self) -> dict:
+        if self._payload is None:
+            raise json.JSONDecodeError("no json", self.text, 0)
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeInvoiceWebSession:
+    def __init__(self) -> None:
+        self.post_urls: list[str] = []
+        self.get_urls: list[str] = []
+
+    def post(self, url: str, headers: dict | None = None) -> _FakeInvoiceResponse:
+        self.post_urls.append(url)
+        if "/erp/orders/invoices/create/" in url:
+            return _FakeInvoiceResponse(url, {"success": True})
+        if "/erp/orders/invoices/finalize/" in url:
+            return _FakeInvoiceResponse(url, {"success": True, "invoice_num": "FV-123"})
+        if "/erp/orders/invoices/sendEmail/" in url:
+            return _FakeInvoiceResponse(url, {"success": True})
+        return _FakeInvoiceResponse(url, {"success": False}, status_code=404)
+
+    def get(self, url: str, headers: dict | None = None) -> _FakeInvoiceResponse:
+        self.get_urls.append(url)
+        return _FakeInvoiceResponse(url, {"success": True})
+
+
+class _FakeInvoiceClient:
+    def __init__(self, invoices: list[dict]) -> None:
+        self.invoices = invoices
+
+    def execute(self, query, variable_values=None):
+        return {
+            "getOrder": {
+                "order_num": (variable_values or {}).get("order_num"),
+                "invoices": self.invoices,
+            }
+        }
+
+
 class InvoiceGenerationTests(unittest.TestCase):
     def test_invoice_generation_settings_default_zero_total_exclusion(self) -> None:
         settings = resolve_invoice_generation_settings({"invoice_generation": {"enabled": True}})
         self.assertTrue(settings["enabled"])
         self.assertEqual(settings["lookback_days"], 7)
         self.assertTrue(settings["exclude_zero_total_orders"])
+        self.assertTrue(settings["send_invoice_email"])
         self.assertEqual(["Odoslan\u00e1"], settings["eligible_statuses"])
+
+    def test_invoice_generation_settings_can_disable_invoice_email(self) -> None:
+        settings = resolve_invoice_generation_settings(
+            {"invoice_generation": {"enabled": True, "send_invoice_email": False}}
+        )
+        self.assertFalse(settings["send_invoice_email"])
 
     def test_resolve_invoice_date_window_uses_rolling_lookback(self) -> None:
         from_date, to_date = resolve_invoice_date_window("2026-04-24", 7)
@@ -66,6 +123,8 @@ class InvoiceGenerationTests(unittest.TestCase):
         self.assertEqual("cron(59 23 * * ? *)", roy["invoice_generation"]["final_sweep_schedule_expression"])
         self.assertEqual(["Odoslan\u00e1"], vevo["invoice_generation"]["eligible_statuses"])
         self.assertEqual(["Odoslan\u00e1"], roy["invoice_generation"]["eligible_statuses"])
+        self.assertTrue(vevo["invoice_generation"]["send_invoice_email"])
+        self.assertTrue(roy["invoice_generation"]["send_invoice_email"])
 
         self.assertNotEqual(vevo["report_schedule"]["task_family"], vevo["invoice_generation"]["task_family"])
         self.assertNotEqual(roy["report_schedule"]["task_family"], roy["invoice_generation"]["task_family"])
@@ -102,6 +161,61 @@ class InvoiceGenerationTests(unittest.TestCase):
         )
         self.assertEqual(["A-2"], [order["order_num"] for order in filtered])
         self.assertEqual(1, stats["skipped_zero_total_orders"])
+
+    @patch("time.sleep", return_value=None)
+    def test_create_invoice_sends_email_using_graphql_invoice_fallback(self, _sleep_mock) -> None:
+        generator = InvoiceGenerator(
+            api_url="https://example.com/api/graphql",
+            api_token="token",
+            base_url="https://example.com",
+            send_invoice_email=True,
+        )
+        generator.web_session = _FakeInvoiceWebSession()
+        generator.client = _FakeInvoiceClient([{"id": "INV-123", "invoice_num": "FV-123"}])
+        generator.arf_token = "arf123"
+
+        result = generator.create_invoice(
+            {
+                "id": "ORDER-ID",
+                "order_num": "1001",
+                "customer": {"email": "customer@example.test"},
+                "status": {"name": "Odoslana"},
+                "sum": {"value": 12.5, "formatted": "12.50 EUR"},
+            }
+        )
+
+        self.assertTrue(result)
+        self.assertTrue(result.created)
+        self.assertEqual("INV-123", result.invoice_id)
+        self.assertTrue(result.email_sent)
+        self.assertTrue(any("/erp/orders/invoices/sendEmail/INV-123" in url for url in generator.web_session.post_urls))
+
+    @patch("time.sleep", return_value=None)
+    def test_create_invoice_requires_invoice_id_when_email_enabled(self, _sleep_mock) -> None:
+        generator = InvoiceGenerator(
+            api_url="https://example.com/api/graphql",
+            api_token="token",
+            base_url="https://example.com",
+            send_invoice_email=True,
+        )
+        generator.web_session = _FakeInvoiceWebSession()
+        generator.client = _FakeInvoiceClient([])
+        generator.arf_token = "arf123"
+
+        result = generator.create_invoice(
+            {
+                "id": "ORDER-ID",
+                "order_num": "1001",
+                "customer": {"email": "customer@example.test"},
+                "status": {"name": "Odoslana"},
+                "sum": {"value": 12.5, "formatted": "12.50 EUR"},
+            }
+        )
+
+        self.assertFalse(result)
+        self.assertTrue(result.created)
+        self.assertFalse(result.email_sent)
+        self.assertEqual("missing_invoice_id", result.email_error)
 
     @patch("daily_report_runner.put_metric")
     @patch("daily_report_runner.run_invoice_generation")
@@ -148,12 +262,15 @@ class InvoiceGenerationTests(unittest.TestCase):
                 "matched_orders": 3,
                 "created_invoices": 0,
                 "failed_invoices": 0,
+                "emailed_invoices": 0,
+                "failed_invoice_emails": 0,
+                "missing_invoice_ids": 0,
                 "skipped_zero_total_orders": 2,
                 "dry_run": True,
             },
             result,
         )
-        self.assertEqual(5, put_metric_mock.call_count)
+        self.assertEqual(8, put_metric_mock.call_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- Made `invoice_generation.send_invoice_email` explicit and enabled it for VEVO and ROY.
- Treat BizniWeb invoice email sending as part of a successful generated-invoice run.
- Resolve the created invoice id from finalize responses or by re-reading the order invoices via GraphQL before calling BizniWeb `sendEmail`.
- Added invoice email success/failure/missing-id metrics for standalone invoice runner and the legacy daily-report hook.

## Why
The current automation could create invoices without guaranteeing that BizniWeb emailed them to the customer. Missing invoice ids or send failures were previously easy to miss.

## Validation
- `python -m py_compile generate_invoices.py invoice_runner.py daily_report_runner.py`
- `python -m json.tool projects\vevo\settings.json`
- `python -m json.tool projects\roy\settings.json`
- `python -m json.tool templates\reporting-client\settings.template.json`
- `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity`
- `git diff --check`

## Deploy note
Production is not updated by this PR alone. After merge, rebuild ECR `latest`, then run production invoice smoke for VEVO and ROY with ECS/Fargate hard-gate context and localhost marker before any public/UI check.