### PR TITLE
[codex] Recognize ROY Hungarian COD orders

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,14 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY HU COD fulfillment fix is implemented locally on `2026-06-09`:
+  - root cause: Hungarian COD orders such as `2679000027` and `2679000026` use BiznisWeb payment `Utánvétes fizetés` with `reference_id=16`; ROY operations dashboard only recognized SK/CZ COD IDs `7` and `10`, so those orders stayed `not_ready` and were not included in picking-list PDF generation
+  - change: `projects/roy/settings.json` now recognizes `cod_payment_ids=["7","10","16"]` and text fallbacks `utanvetes`/`utanvet` in both `operations_dashboard` and `realized_revenue`
+  - local live-data verification: direct BiznisWeb checks for orders `2679000027` and `2679000026` now return `fulfillable=True`, `fulfillment_reason=cod_waiting`
+  - local tests: `python -m json.tool projects\roy\settings.json`; `python -m py_compile roy_operations_dashboard.py export_orders.py live_dashboard_server.py`; `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile`; `git diff --check`
+  - production status: not deployed yet from this branch
+  - Next exact step: push branch `codex/roy-hu-cod-fulfillable`, open/merge PR, deploy ROY App Runner, then verify live API/PDF preview includes orders `2679000027` and `2679000026` as `cod_waiting`
+
 - VEVO/ROY invoice email automation change is implemented locally on `2026-06-03`:
   - branch: `codex/auto-email-created-invoices`; merged PR `#163` into `main` (`63a0f40`)
   - change: `invoice_generation.send_invoice_email` is explicit and enabled for VEVO and ROY; newly created invoices must be emailed through the BizniWeb invoice email action when the setting is enabled

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -96,11 +96,14 @@
       "dobierkou",
       "dobírka",
       "dobírkou",
-      "cash on delivery"
+      "cash on delivery",
+      "utanvetes",
+      "utanvet"
     ],
     "cod_payment_ids": [
       "7",
-      "10"
+      "10",
+      "16"
     ],
     "prepaid_fulfilled_statuses": [
       "Odoslana"
@@ -206,11 +209,14 @@
       "dobierka",
       "dobierkou",
       "dobírka",
-      "dobírkou"
+      "dobírkou",
+      "utanvetes",
+      "utanvet"
     ],
     "cod_payment_ids": [
       "7",
-      "10"
+      "10",
+      "16"
     ],
     "personal_pickup_shipping_names": [
       "Osobný odber na sklade"

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -10,11 +10,11 @@ from export_orders import BizniWebExporter
 from reporting_core.cfo_kpis import build_order_records_from_export_df
 
 
-def make_exporter() -> BizniWebExporter:
+def make_exporter(project_name: str = "vevo") -> BizniWebExporter:
     return BizniWebExporter(
         api_url="https://example.com/api/graphql",
         api_token="token",
-        project_name="vevo",
+        project_name=project_name,
         output_tag="unit",
         enable_period_bundle=False,
     )
@@ -294,6 +294,15 @@ class ReportingCalculationFixTests(unittest.TestCase):
 
         self.assertEqual(
             (True, "prepaid_fulfilled_status"),
+            exporter._realized_revenue_decision(order),
+        )
+
+    def test_roy_realized_revenue_counts_hungarian_cod(self) -> None:
+        exporter = make_exporter("roy")
+        order = reporting_order("HU-COD", "Čaká na vybavenie", "Utánvétes fizetés", "16")
+
+        self.assertEqual(
+            (True, "cod_status_and_payment"),
             exporter._realized_revenue_decision(order),
         )
 

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -30,8 +30,8 @@ def make_project_settings() -> dict:
             "enabled": True,
             "paid_statuses": ["Platba online - zaplatené"],
             "cod_statuses": ["Čaká na vybavenie"],
-            "cod_payment_patterns": ["dobierka", "dobírka"],
-            "cod_payment_ids": ["7", "10"],
+            "cod_payment_patterns": ["dobierka", "dobírka", "utanvetes", "utanvet"],
+            "cod_payment_ids": ["7", "10", "16"],
             "personal_pickup_shipping_names": ["Osobný odber na sklade"],
             "personal_pickup_shipping_ids": ["11"],
             "pickup_ready_status_name": "Pripravené k odberu",
@@ -118,6 +118,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(10, operations["wholesale_detection"]["discount_threshold_pct"])
         self.assertTrue(operations["wholesale_detection"]["require_company_customer"])
         self.assertIn("Čaká na vybavenie", operations["cod_statuses"])
+        self.assertIn("16", operations["cod_payment_ids"])
+        self.assertIn("utanvetes", operations["cod_payment_patterns"])
         self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["wachman"])
         self.assertEqual(30, inventory["lead_time_working_days_by_brand"]["roy"])
         self.assertEqual(12, inventory["lead_time_working_days_by_brand"]["maco_stop"])
@@ -141,14 +143,15 @@ class RoyOperationsDashboardTests(unittest.TestCase):
             make_order("R-5", "Platba online - zaplatené", price_element("payment", "Okamžitá platba online", "18"), pickup_shipping),
             make_order("R-6", "Nezaplatená - zrušená objednávka", price_element("payment", "Okamžitá platba online", "18"), pickup_shipping),
             make_order("R-7", "Pripravené k odberu", price_element("payment", "Okamžitá platba online", "18"), pickup_shipping),
+            make_order("R-8", "Čaká na vybavenie", price_element("payment", "Utánvétes fizetés", "16"), packeta_shipping),
         ]
 
         snapshot = build_roy_orders_snapshot(project="roy", orders=orders, settings=settings)
 
-        self.assertEqual(3, snapshot["summary"]["fulfillable_orders"])
+        self.assertEqual(4, snapshot["summary"]["fulfillable_orders"])
         self.assertEqual(2, snapshot["summary"]["paid_online_orders"])
-        self.assertEqual(1, snapshot["summary"]["cod_waiting_orders"])
-        self.assertEqual(["R-1", "R-2", "R-5"], [row["order_num"] for row in snapshot["orders"]])
+        self.assertEqual(2, snapshot["summary"]["cod_waiting_orders"])
+        self.assertEqual(["R-1", "R-2", "R-5", "R-8"], [row["order_num"] for row in snapshot["orders"]])
         self.assertEqual("13,70 EUR", snapshot["orders"][0]["items"][0]["unit_price_formatted"])
         self.assertEqual(["R-5", "R-7"], [row["order_num"] for row in snapshot["personal_pickups"]])
         self.assertEqual(1, snapshot["summary"]["pickup_ready_actions_available"])


### PR DESCRIPTION
## What changed
- Added ROY Hungarian COD payment ID 16 and text fallbacks utanvetes/utanvet to operations dashboard fulfillment settings.
- Added the same ROY COD recognition to realized revenue settings so reporting and live operations stay consistent.
- Added regression coverage for HU COD fulfillment and ROY realized revenue.

## Root cause
Orders 2679000027 and 2679000026 were in status Čaká na vybavenie, but their payment was Utánvétes fizetés with BiznisWeb reference_id 16. The dashboard only recognized SK/CZ COD IDs 7 and 10, so they were excluded before picking-list PDF generation.

## Validation
- python -m json.tool projects\\roy\\settings.json
- python -m py_compile roy_operations_dashboard.py export_orders.py live_dashboard_server.py
- python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile
- git diff --check
- Direct BiznisWeb check: orders 2679000027 and 2679000026 now resolve as ulfillable=True, cod_waiting.