### PR TITLE
[codex] Fix ROY wholesale VAT basis

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,14 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY wholesale detection VAT-basis fix is implemented locally on `2026-06-10`:
+  - root cause: ROY picking-list wholesale detection compared order item prices against current retail final prices on a gross/VAT-including basis; foreign company orders sold without VAT could therefore look like discounted/wholesale orders even when the customer paid the normal net price
+  - change: wholesale detection now compares unit prices on a net basis; order line net price is compared against current retail final price converted to net using `operations_dashboard.wholesale_detection.retail_tax_rate=23`
+  - behavior: foreign B2B VAT-exempt orders at normal net retail price are not marked wholesale; foreign B2B VAT-exempt orders with a true net discount still are marked wholesale
+  - local tests: `python -m json.tool projects\roy\settings.json`; `python -m py_compile roy_operations_dashboard.py live_dashboard_server.py`; `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile`; `git diff --check`
+  - production status: not deployed yet from this branch
+  - Next exact step: merge and deploy ROY App Runner, then verify live smoke and spot-check wholesale flags if a known foreign VAT-exempt company order is available
+
 - ROY multilingual COD fallback is implemented and deployed on `2026-06-09`:
   - change: ROY `operations_dashboard` and `realized_revenue` now include wider COD payment title fallbacks for future foreign-language orders, including English, Polish, Romanian, German, French, Italian, Spanish/Portuguese, Balkan, Dutch, and Cyrillic COD terms
   - change: string normalization in `roy_operations_dashboard.py` and `export_orders.py` now folds Latin characters that do not decompose through standard accent removal, including Polish `ł`, so titles such as `Płatność przy odbiorze` match configured fallback terms

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -301,7 +301,8 @@
     "wholesale_detection": {
       "enabled": true,
       "discount_threshold_pct": 10,
-      "require_company_customer": true
+      "require_company_customer": true,
+      "retail_tax_rate": 23
     }
   },
   "inventory_model": {

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -39,6 +39,7 @@ DEFAULT_CACHE_TTL_SECONDS = 60
 DEFAULT_AUTO_REFRESH_SECONDS = 90
 DEFAULT_WHOLESALE_DETECTION_DISCOUNT_THRESHOLD_PCT = 10.0
 DEFAULT_WHOLESALE_DETECTION_REQUIRE_COMPANY = True
+DEFAULT_WHOLESALE_RETAIL_TAX_RATE = 23.0
 LATIN_FOLD_TRANSLATION = str.maketrans(
     {
         "Ł": "L",
@@ -709,6 +710,11 @@ def resolve_roy_operations_settings(project_settings: Dict[str, Any]) -> Dict[st
                 wholesale_raw.get("require_company_customer"),
                 DEFAULT_WHOLESALE_DETECTION_REQUIRE_COMPANY,
             ),
+            "retail_tax_rate": _as_float(
+                wholesale_raw.get("retail_tax_rate"),
+                DEFAULT_WHOLESALE_RETAIL_TAX_RATE,
+                minimum=0.0,
+            ),
         },
     }
 
@@ -1014,9 +1020,40 @@ def _item_unit_gross_price(item: Dict[str, Any]) -> Optional[float]:
     return unit_price * (1.0 + (tax_rate / 100.0)) if tax_rate > 0 else unit_price
 
 
+def _item_unit_net_price(item: Dict[str, Any]) -> Optional[float]:
+    quantity = _to_float(item.get("quantity"))
+    if quantity <= 0:
+        return None
+    tax_rate = _item_tax_rate(item)
+    net_total = _price_number(item.get("sum"))
+    if net_total is not None:
+        return net_total / quantity
+    gross_total = _price_number(item.get("sum_with_tax"))
+    if gross_total is not None:
+        net_total = gross_total / (1.0 + (tax_rate / 100.0)) if tax_rate > 0 else gross_total
+        return net_total / quantity
+    unit_price = _price_number(item.get("price"))
+    if unit_price is None:
+        return None
+    # BizniWeb ROY item unit prices behave as net values even when is_net_price is false.
+    return unit_price
+
+
 def _product_retail_gross_price(item: Dict[str, Any]) -> Optional[float]:
     product = item.get("product") if isinstance(item.get("product"), dict) else {}
     return _price_as_gross(product.get("final_price"), _item_tax_rate(item))
+
+
+def _product_retail_net_price(item: Dict[str, Any], retail_tax_rate: float) -> Optional[float]:
+    product = item.get("product") if isinstance(item.get("product"), dict) else {}
+    final_price = product.get("final_price")
+    value = _price_number(final_price)
+    if value is None:
+        return None
+    if isinstance(final_price, dict) and bool(final_price.get("is_net_price")):
+        return value
+    tax_rate = _item_tax_rate(item) or retail_tax_rate
+    return value / (1.0 + (tax_rate / 100.0)) if tax_rate > 0 else value
 
 
 def _normalize_discount_signal(value: Any) -> str:
@@ -1050,6 +1087,7 @@ def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], s
     if threshold_pct <= 0:
         threshold_pct = DEFAULT_WHOLESALE_DETECTION_DISCOUNT_THRESHOLD_PCT
     threshold_ratio = max(0.0, 1.0 - (threshold_pct / 100.0))
+    retail_tax_rate = _to_float(detection.get("retail_tax_rate"))
 
     priced_lines = 0
     discounted_lines = 0
@@ -1059,8 +1097,8 @@ def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], s
     for item in order.get("items") or []:
         if not isinstance(item, dict):
             continue
-        item_price = _item_unit_gross_price(item)
-        retail_price = _product_retail_gross_price(item)
+        item_price = _item_unit_net_price(item)
+        retail_price = _product_retail_net_price(item, retail_tax_rate)
         if item_price is None or retail_price is None or item_price <= 0 or retail_price <= 0:
             continue
         priced_lines += 1
@@ -1074,8 +1112,9 @@ def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], s
                     {
                         "import_code": str(item.get("import_code") or "").strip(),
                         "label": str(item.get("item_label") or "").strip(),
-                        "order_unit_gross": round(item_price, 2),
-                        "retail_unit_gross": round(retail_price, 2),
+                        "order_unit_net": round(item_price, 2),
+                        "retail_unit_net": round(retail_price, 2),
+                        "comparison_basis": "net",
                         "discount_pct": round(discount_pct, 1),
                     }
                 )
@@ -1105,6 +1144,7 @@ def _detect_wholesale_pricing(order: Dict[str, Any], customer: Dict[str, Any], s
         "discount_code_used": discount_code_used,
         "max_discount_pct": round(max_discount_pct, 1),
         "threshold_pct": round(threshold_pct, 1),
+        "comparison_basis": "net",
         "reason": reason,
         "examples": examples,
     }

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -51,6 +51,12 @@ def make_project_settings() -> dict:
             "pickup_ship_action_statuses": ["Pripravené k odberu"],
             "shipped_status_name": "Odoslaná",
             "shipped_status_id": 4,
+            "wholesale_detection": {
+                "enabled": True,
+                "discount_threshold_pct": 10,
+                "require_company_customer": True,
+                "retail_tax_rate": 23,
+            },
         }
     }
 
@@ -128,6 +134,7 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual(4, operations["shipped_status_id"])
         self.assertEqual(10, operations["wholesale_detection"]["discount_threshold_pct"])
         self.assertTrue(operations["wholesale_detection"]["require_company_customer"])
+        self.assertEqual(23, operations["wholesale_detection"]["retail_tax_rate"])
         self.assertIn("Čaká na vybavenie", operations["cod_statuses"])
         self.assertIn("16", operations["cod_payment_ids"])
         self.assertIn("utanvetes", operations["cod_payment_patterns"])
@@ -298,6 +305,7 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("Sklad B2B", row["delivery_address"]["lines"])
         self.assertTrue(row["wholesale_pricing"]["is_wholesale"])
         self.assertEqual(20.0, row["wholesale_pricing"]["max_discount_pct"])
+        self.assertEqual("net", row["wholesale_pricing"]["comparison_basis"])
 
     def test_discounted_person_order_is_not_wholesale_when_company_signal_is_required(self) -> None:
         settings = make_settings()
@@ -368,6 +376,87 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertTrue(wholesale["customer_is_company"])
         self.assertEqual(0.0, wholesale["max_discount_pct"])
         self.assertEqual("company customer, no wholesale price discount detected", wholesale["reason"])
+
+    def test_foreign_vat_exempt_company_full_net_price_is_not_wholesale(self) -> None:
+        settings = make_settings()
+        paid_payment = price_element("payment", "Okamžitá platba online", "18")
+        packeta_shipping = price_element("shipping", "Packeta - výdajné miesto", "9")
+        order = make_order("R-EU-B2B-FULL", settings["paid_statuses"][0], paid_payment, packeta_shipping)
+        order["customer"] = {
+            "__typename": "Company",
+            "company_name": "EU Buyer Kft.",
+            "company_id": "12345678",
+            "vat_id": "HU12345678",
+        }
+        order["invoice_address"] = {
+            "company_name": "EU Buyer Kft.",
+            "city": "Budapest",
+            "country": "Maďarsko",
+        }
+        order["items"][0].update(
+            {
+                "tax_rate": 0,
+                "quantity": 1,
+                "price": {"raw_value": 100.0, "value": 100.0, "formatted": "100,00 €", "is_net_price": True},
+                "sum": {"raw_value": 100.0, "value": 100.0, "formatted": "100,00 €", "is_net_price": True},
+                "sum_with_tax": {"raw_value": 100.0, "value": 100.0, "formatted": "100,00 €", "is_net_price": True},
+                "product": {
+                    "final_price": {
+                        "raw_value": 123.0,
+                        "value": 123.0,
+                        "formatted": "123,00 €",
+                        "is_net_price": False,
+                    }
+                },
+            }
+        )
+
+        snapshot = build_roy_orders_snapshot(project="roy", orders=[order], settings=settings)
+        wholesale = snapshot["orders"][0]["wholesale_pricing"]
+
+        self.assertFalse(wholesale["is_wholesale"])
+        self.assertTrue(wholesale["customer_is_company"])
+        self.assertEqual(0.0, wholesale["max_discount_pct"])
+        self.assertEqual("net", wholesale["comparison_basis"])
+        self.assertEqual("company customer, no wholesale price discount detected", wholesale["reason"])
+
+    def test_foreign_vat_exempt_company_discounted_net_price_is_wholesale(self) -> None:
+        settings = make_settings()
+        paid_payment = price_element("payment", "Okamžitá platba online", "18")
+        packeta_shipping = price_element("shipping", "Packeta - výdajné miesto", "9")
+        order = make_order("R-EU-B2B-VO", settings["paid_statuses"][0], paid_payment, packeta_shipping)
+        order["customer"] = {
+            "__typename": "Company",
+            "company_name": "EU Buyer Kft.",
+            "company_id": "12345678",
+            "vat_id": "HU12345678",
+        }
+        order["items"][0].update(
+            {
+                "tax_rate": 0,
+                "quantity": 1,
+                "price": {"raw_value": 80.0, "value": 80.0, "formatted": "80,00 €", "is_net_price": True},
+                "sum": {"raw_value": 80.0, "value": 80.0, "formatted": "80,00 €", "is_net_price": True},
+                "sum_with_tax": {"raw_value": 80.0, "value": 80.0, "formatted": "80,00 €", "is_net_price": True},
+                "product": {
+                    "final_price": {
+                        "raw_value": 123.0,
+                        "value": 123.0,
+                        "formatted": "123,00 €",
+                        "is_net_price": False,
+                    }
+                },
+            }
+        )
+
+        snapshot = build_roy_orders_snapshot(project="roy", orders=[order], settings=settings)
+        wholesale = snapshot["orders"][0]["wholesale_pricing"]
+
+        self.assertTrue(wholesale["is_wholesale"])
+        self.assertEqual(20.0, wholesale["max_discount_pct"])
+        self.assertEqual("net", wholesale["comparison_basis"])
+        self.assertEqual(80.0, wholesale["examples"][0]["order_unit_net"])
+        self.assertEqual(100.0, wholesale["examples"][0]["retail_unit_net"])
 
     def test_discount_code_prevents_wholesale_flag(self) -> None:
         settings = make_settings()


### PR DESCRIPTION
## What changed
- ROY wholesale detection now compares order and retail prices on a net/VAT-excluded basis.
- Added `operations_dashboard.wholesale_detection.retail_tax_rate=23` for converting current retail final prices to net when order item tax is 0%.
- Added regression coverage for foreign VAT-exempt company orders at normal net price and true discounted net price.

## Why
Foreign company orders without VAT were being compared against VAT-including retail prices, so normal B2B VAT-exempt sales could be marked as wholesale on picking lists.

## Validation
- `python -m json.tool projects\roy\settings.json`
- `python -m py_compile roy_operations_dashboard.py live_dashboard_server.py`
- `python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_reporting_calculation_fixes tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile`
- `git diff --check`