### PR TITLE
Fix stale ROY live dashboard refresh

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-06-09
+Last updated: 2026-06-13
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,14 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- ROY live dashboard failed-to-fetch mitigation is implemented locally on branch `codex/roy-live-stale-cache-refresh` on `2026-06-13`:
+  - root cause found live: `/api/operations/roy/live` is healthy but can take about 49-51 seconds when cache expires because the ROY operations snapshot scans BiznisWeb orders and stock; dashboard auto-refresh is 90 seconds while cache TTL is 60 seconds, so regular live refreshes can hit the slow path
+  - change: normal non-forced ROY operations API calls now return the last cached snapshot immediately when cache is stale and start a background refresh instead of blocking the UI request
+  - change: cache writes are guarded by a lock and invalidation token so an old background refresh cannot overwrite a cache invalidated by dashboard actions
+  - change: the frontend keeps the latest rendered data visible and reports a clearer message if a refresh fails after data was already loaded
+  - local tests: `python -m py_compile roy_operations_dashboard.py live_dashboard_server.py`; `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile`; `git diff --check`
+  - Next exact step: run the broader dashboard regression tests, open PR, merge, deploy App Runner, then verify `/health`, `/production/roy`, `/api/operations/roy/live`, and stale-cache latency on production
 
 - ROY wholesale detection VAT-basis fix is implemented and deployed on `2026-06-10`:
   - root cause: ROY picking-list wholesale detection compared order item prices against current retail final prices on a gross/VAT-including basis; foreign company orders sold without VAT could therefore look like discounted/wholesale orders even when the customer paid the normal net price

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -1705,7 +1705,8 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         if (refreshTimer) clearInterval(refreshTimer);
         refreshTimer = setInterval(() => loadDashboard(false), Math.max(30, Number(data.auto_refresh_seconds || 90)) * 1000);
       } catch (error) {
-        showMessage(error instanceof Error ? error.message : String(error));
+        const message = error instanceof Error ? error.message : String(error);
+        showMessage(latestData ? `Live refresh zlyhal, zobrazujem posledné načítané dáta: ${message}` : message);
       } finally {
         el('refreshBtn').disabled = false;
       }

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -8,6 +8,7 @@ import json
 import math
 import os
 import re
+import threading
 import time
 import unicodedata
 from collections import defaultdict
@@ -252,7 +253,17 @@ ROY_PRODUCT_STOCK_SEARCH_FIELDS = """
 
 
 _CACHE: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+_CACHE_LOCK = threading.RLock()
+_BACKGROUND_REFRESH: Dict[str, Dict[str, Any]] = {}
+_CACHE_TOKENS: Dict[str, int] = {}
 STATE_VERSION = 1
+
+
+def _clear_operations_cache(project: str) -> None:
+    with _CACHE_LOCK:
+        _CACHE.pop(project, None)
+        _BACKGROUND_REFRESH.pop(project, None)
+        _CACHE_TOKENS[project] = _CACHE_TOKENS.get(project, 0) + 1
 
 
 def _empty_operations_state() -> Dict[str, Any]:
@@ -495,7 +506,7 @@ def acknowledge_loss_product(project: str, sku: str, product: str = "") -> Dict[
         "acknowledged_at": _state_now_iso(),
     }
     storage = save_roy_operations_state(project, state, project_settings)
-    _CACHE.pop(project, None)
+    _clear_operations_cache(project)
     return {"ok": True, "project": project, "sku": sku, "storage": storage}
 
 
@@ -532,7 +543,7 @@ def set_inbound_stock_order(
         "updated_at": now,
     }
     storage = save_roy_operations_state(project, state, project_settings)
-    _CACHE.pop(project, None)
+    _clear_operations_cache(project)
     return {"ok": True, "project": project, "sku": sku, "storage": storage, "inbound_order": state["inbound_orders"][sku]}
 
 
@@ -547,7 +558,7 @@ def clear_inbound_stock_order(project: str, sku: str) -> Dict[str, Any]:
     state = load_roy_operations_state(project, project_settings)
     removed = (state.get("inbound_orders") or {}).pop(sku, None)
     storage = save_roy_operations_state(project, state, project_settings)
-    _CACHE.pop(project, None)
+    _clear_operations_cache(project)
     return {"ok": True, "project": project, "sku": sku, "removed": bool(removed), "storage": storage}
 
 
@@ -2340,6 +2351,66 @@ def generate_roy_operations_snapshot(project: str, report_payload: Optional[Dict
     }
 
 
+def _cache_payload(
+    project: str,
+    payload: Dict[str, Any],
+    *,
+    token: Optional[int] = None,
+) -> bool:
+    cached_at = time.monotonic()
+    with _CACHE_LOCK:
+        current_token = _CACHE_TOKENS.get(project, 0)
+        if token is not None and token != current_token:
+            return False
+        _CACHE[project] = (cached_at, copy.deepcopy(payload))
+        return True
+
+
+def _background_refresh_state(project: str) -> Dict[str, Any]:
+    with _CACHE_LOCK:
+        return copy.deepcopy(_BACKGROUND_REFRESH.get(project) or {})
+
+
+def _start_background_operations_refresh(project: str, report_payload: Optional[Dict[str, Any]]) -> None:
+    with _CACHE_LOCK:
+        state = _BACKGROUND_REFRESH.setdefault(project, {})
+        if state.get("running"):
+            return
+        token = _CACHE_TOKENS.get(project, 0)
+        state.update(
+            {
+                "running": True,
+                "started_at": time.monotonic(),
+                "last_error": "",
+            }
+        )
+
+    report_payload_copy = copy.deepcopy(report_payload)
+
+    def _worker() -> None:
+        try:
+            payload = generate_roy_operations_snapshot(project, report_payload=report_payload_copy)
+            stored = _cache_payload(project, payload, token=token)
+            with _CACHE_LOCK:
+                state = _BACKGROUND_REFRESH.setdefault(project, {})
+                state["running"] = False
+                state["last_completed_at"] = time.monotonic()
+                state["last_error"] = "" if stored else "Cache invalidated while refresh was running."
+        except Exception as exc:
+            with _CACHE_LOCK:
+                state = _BACKGROUND_REFRESH.setdefault(project, {})
+                state["running"] = False
+                state["last_failed_at"] = time.monotonic()
+                state["last_error"] = str(exc)
+
+    thread = threading.Thread(
+        target=_worker,
+        name=f"roy-operations-refresh-{project}",
+        daemon=True,
+    )
+    thread.start()
+
+
 def get_cached_roy_operations_snapshot(
     project: str,
     *,
@@ -2354,17 +2425,31 @@ def get_cached_roy_operations_snapshot(
 
     cache_key = project
     now = time.monotonic()
-    cached = _CACHE.get(cache_key)
+    with _CACHE_LOCK:
+        cached = _CACHE.get(cache_key)
     if cached and not force_refresh:
         cached_at, payload = cached
-        if now - cached_at <= settings["cache_ttl_seconds"]:
+        age_seconds = now - cached_at
+        if age_seconds <= settings["cache_ttl_seconds"]:
             result = copy.deepcopy(payload)
             result["cache"] = {
                 "status": "fresh",
-                "age_seconds": round(now - cached_at, 1),
+                "age_seconds": round(age_seconds, 1),
                 "ttl_seconds": settings["cache_ttl_seconds"],
             }
             return result
+        _start_background_operations_refresh(project, report_payload)
+        background_state = _background_refresh_state(project)
+        result = copy.deepcopy(payload)
+        result["cache"] = {
+            "status": "stale_revalidating",
+            "age_seconds": round(age_seconds, 1),
+            "ttl_seconds": settings["cache_ttl_seconds"],
+            "refresh_in_progress": bool(background_state.get("running")),
+        }
+        if background_state.get("last_error"):
+            result["cache"]["last_refresh_error"] = str(background_state["last_error"])
+        return result
 
     generate_attempts = 3 if cached is None else 1
     last_error: Optional[Exception] = None
@@ -2390,7 +2475,7 @@ def get_cached_roy_operations_snapshot(
             return result
         raise last_error or RuntimeError("Failed to generate ROY operations snapshot")
 
-    _CACHE[cache_key] = (now, copy.deepcopy(payload))
+    _cache_payload(cache_key, payload)
     payload["cache"] = {
         "status": "refreshed",
         "age_seconds": 0,
@@ -2496,7 +2581,7 @@ query GetOrderForPickupAction($order_num: String!) {
         CHANGE_ORDER_STATUS_MUTATION,
         variable_values={"order_num": order_num, "status_id": status_id},
     )
-    _CACHE.pop(project, None)
+    _clear_operations_cache(project)
     return {
         "ok": True,
         "project": project,

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import shutil
 import unittest
@@ -7,6 +8,7 @@ from unittest.mock import patch
 from dashboard_modern import DASHBOARD_PAYLOAD_SCRIPT_ID
 from export_orders import BizniWebExporter
 from live_dashboard_server import build_roy_operations_dashboard_html
+import roy_operations_dashboard as rod
 from roy_operations_dashboard import (
     _select_current_stock_for_target,
     build_executive_kpi_snapshot,
@@ -651,6 +653,89 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("nová objednávka na odoslanie", html)
         self.assertIn("replace(/[\"\\\\]/g, '\\\\$&')", html)
         self.assertNotIn('replace(/["\\]/g', html)
+
+    def test_stale_operations_cache_returns_cached_snapshot_and_revalidates_in_background(self) -> None:
+        project = "roy"
+        settings = make_project_settings()
+        settings["operations_dashboard"]["cache_ttl_seconds"] = 1
+        cached_payload = {
+            "marker": "roy-operations-dashboard",
+            "project": project,
+            "generated_at": "old",
+        }
+        with rod._CACHE_LOCK:
+            previous_cache = copy.deepcopy(rod._CACHE)
+            previous_background = copy.deepcopy(rod._BACKGROUND_REFRESH)
+            previous_tokens = copy.deepcopy(rod._CACHE_TOKENS)
+            rod._CACHE.clear()
+            rod._BACKGROUND_REFRESH.clear()
+            rod._CACHE_TOKENS.clear()
+            rod._CACHE[project] = (100.0, copy.deepcopy(cached_payload))
+        try:
+            with (
+                patch("roy_operations_dashboard.load_project_settings", return_value=settings),
+                patch("roy_operations_dashboard.time.monotonic", return_value=105.0),
+                patch("roy_operations_dashboard._start_background_operations_refresh") as start_background,
+                patch("roy_operations_dashboard.generate_roy_operations_snapshot") as generate_snapshot,
+            ):
+                result = rod.get_cached_roy_operations_snapshot(project)
+
+            self.assertEqual("old", result["generated_at"])
+            self.assertEqual("stale_revalidating", result["cache"]["status"])
+            start_background.assert_called_once_with(project, None)
+            generate_snapshot.assert_not_called()
+        finally:
+            with rod._CACHE_LOCK:
+                rod._CACHE.clear()
+                rod._CACHE.update(previous_cache)
+                rod._BACKGROUND_REFRESH.clear()
+                rod._BACKGROUND_REFRESH.update(previous_background)
+                rod._CACHE_TOKENS.clear()
+                rod._CACHE_TOKENS.update(previous_tokens)
+
+    def test_force_refresh_bypasses_stale_cache_and_generates_snapshot(self) -> None:
+        project = "roy"
+        settings = make_project_settings()
+        settings["operations_dashboard"]["cache_ttl_seconds"] = 1
+        cached_payload = {
+            "marker": "roy-operations-dashboard",
+            "project": project,
+            "generated_at": "old",
+        }
+        fresh_payload = {
+            "marker": "roy-operations-dashboard",
+            "project": project,
+            "generated_at": "new",
+        }
+        with rod._CACHE_LOCK:
+            previous_cache = copy.deepcopy(rod._CACHE)
+            previous_background = copy.deepcopy(rod._BACKGROUND_REFRESH)
+            previous_tokens = copy.deepcopy(rod._CACHE_TOKENS)
+            rod._CACHE.clear()
+            rod._BACKGROUND_REFRESH.clear()
+            rod._CACHE_TOKENS.clear()
+            rod._CACHE[project] = (100.0, copy.deepcopy(cached_payload))
+        try:
+            with (
+                patch("roy_operations_dashboard.load_project_settings", return_value=settings),
+                patch("roy_operations_dashboard.time.monotonic", return_value=105.0),
+                patch("roy_operations_dashboard._start_background_operations_refresh") as start_background,
+                patch("roy_operations_dashboard.generate_roy_operations_snapshot", return_value=fresh_payload) as generate_snapshot,
+            ):
+                result = rod.get_cached_roy_operations_snapshot(project, force_refresh=True)
+
+            self.assertEqual("new", result["generated_at"])
+            self.assertEqual("refreshed", result["cache"]["status"])
+            start_background.assert_not_called()
+            generate_snapshot.assert_called_once_with(project, report_payload=None)
+        finally:
+            with rod._CACHE_LOCK:
+                rod._CACHE.clear()
+                rod._CACHE.update(previous_cache)
+                rod._BACKGROUND_REFRESH.clear()
+                rod._BACKGROUND_REFRESH.update(previous_background)
+                rod._CACHE_TOKENS.clear()
+                rod._CACHE_TOKENS.update(previous_tokens)
 
     def test_inbound_order_units_suppress_covered_stock_alert_until_restock(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary
- return cached ROY operations snapshots immediately when the live cache is stale
- refresh stale snapshots in the background instead of blocking normal auto-refresh calls
- keep last rendered dashboard data visible when a refresh fails
- add cache behavior regression tests and update PROJECT_STATE

## Tests
- python -m py_compile roy_operations_dashboard.py live_dashboard_server.py
- python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile
- git diff --check