### PR TITLE
Harden production reporting smoke logs

### DIFF
--- a/.github/workflows/production-reporting-smoke.yml
+++ b/.github/workflows/production-reporting-smoke.yml
@@ -152,6 +152,29 @@ jobs:
           PY
             )"
 
+            dump_task_logs() {
+              if [[ -z "$LOG_GROUP" || -z "$LOG_PREFIX" ]]; then
+                echo "CloudWatch log stream unavailable: missing log group or prefix"
+                return 0
+              fi
+              local log_stream="${LOG_PREFIX}/${CONTAINER_NAME}/${TASK_ID}"
+              echo "CloudWatch log stream: ${LOG_GROUP}:${log_stream}"
+              set +e
+              aws logs get-log-events \
+                --log-group-name "$LOG_GROUP" \
+                --log-stream-name "$log_stream" \
+                --region "$AWS_REGION" \
+                --limit 200 \
+                --no-paginate \
+                --query 'events[].message' \
+                --output text
+              local log_rc=$?
+              set -e
+              if [[ "$log_rc" != "0" ]]; then
+                echo "CloudWatch log fetch failed with exit code ${log_rc}" >&2
+              fi
+            }
+
             MARKER="${PROJECT}-${MARKER_SUFFIX}"
             SMOKE_SCRIPT="$(cat <<'SH'
           set -euo pipefail
@@ -387,16 +410,30 @@ jobs:
 
             if [[ "$TASK_STOPPED" != "true" ]]; then
               echo "Task ${TASK_ARN} did not stop within 60 minutes; stopping smoke task." >&2
-              if [[ -n "$LOG_GROUP" && -n "$LOG_PREFIX" ]]; then
-                LOG_STREAM="${LOG_PREFIX}/${CONTAINER_NAME}/${TASK_ID}"
-                echo "CloudWatch log stream: ${LOG_GROUP}:${LOG_STREAM}"
-                aws logs get-log-events \
-                  --log-group-name "$LOG_GROUP" \
-                  --log-stream-name "$LOG_STREAM" \
-                  --region "$AWS_REGION" \
-                  --query 'events[].message' \
-                  --output text || true
-              fi
+              echo "TASK_TIMEOUT_CONTEXT_BEGIN"
+              python - <<'PY'
+          import json
+          from pathlib import Path
+          data = json.loads(Path("describe-stopped.json").read_text(encoding="utf-8"))
+          task = (data.get("tasks") or [{}])[0]
+          print(json.dumps({
+              "lastStatus": task.get("lastStatus"),
+              "desiredStatus": task.get("desiredStatus"),
+              "stopCode": task.get("stopCode"),
+              "stoppedReason": task.get("stoppedReason"),
+              "containers": [
+                  {
+                      "name": container.get("name"),
+                      "lastStatus": container.get("lastStatus"),
+                      "exitCode": container.get("exitCode"),
+                      "reason": container.get("reason"),
+                  }
+                  for container in task.get("containers", [])
+              ],
+          }, ensure_ascii=False, sort_keys=True))
+          PY
+              echo "TASK_TIMEOUT_CONTEXT_END"
+              dump_task_logs
               aws ecs stop-task \
                 --cluster "$CLUSTER_ARN" \
                 --task "$TASK_ARN" \
@@ -408,20 +445,34 @@ jobs:
             EXIT_CODE="$(python - <<'PY'
           import json
           task = json.load(open("describe-stopped.json", encoding="utf-8"))["tasks"][0]
-          print(task["containers"][0].get("exitCode", ""))
+          print(task["containers"][0].get("exitCode", "MISSING"))
           PY
             )"
 
-            if [[ -n "$LOG_GROUP" && -n "$LOG_PREFIX" ]]; then
-              LOG_STREAM="${LOG_PREFIX}/${CONTAINER_NAME}/${TASK_ID}"
-              echo "CloudWatch log stream: ${LOG_GROUP}:${LOG_STREAM}"
-              aws logs get-log-events \
-                --log-group-name "$LOG_GROUP" \
-                --log-stream-name "$LOG_STREAM" \
-                --region "$AWS_REGION" \
-                --query 'events[].message' \
-                --output text || true
-            fi
+            echo "TASK_STOPPED_CONTEXT_BEGIN"
+            python - <<'PY'
+          import json
+          from pathlib import Path
+          data = json.loads(Path("describe-stopped.json").read_text(encoding="utf-8"))
+          task = data["tasks"][0]
+          print(json.dumps({
+              "lastStatus": task.get("lastStatus"),
+              "desiredStatus": task.get("desiredStatus"),
+              "stopCode": task.get("stopCode"),
+              "stoppedReason": task.get("stoppedReason"),
+              "containers": [
+                  {
+                      "name": container.get("name"),
+                      "lastStatus": container.get("lastStatus"),
+                      "exitCode": container.get("exitCode"),
+                      "reason": container.get("reason"),
+                  }
+                  for container in task.get("containers", [])
+              ],
+          }, ensure_ascii=False, sort_keys=True))
+          PY
+            echo "TASK_STOPPED_CONTEXT_END"
+            dump_task_logs
 
             if [[ "$EXIT_CODE" != "0" ]]; then
               echo "Task ${TASK_ARN} failed with exit code ${EXIT_CODE}" >&2

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,16 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- Production report email regeneration follow-up is in progress on `2026-06-18`:
+  - branch/worktree: `codex/report-smoke-logs` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - PR `#177` and PR `#178` are merged to `main`; ECR rebuild run `27734814979` succeeded for `vevo-reporting:latest` with digest `sha256:10202cb947ab0ab50ec2be9fe6331c8cc48e5204df60ebdaffe271369dd03bbd`
+  - first manual `Production Reporting Smoke` dispatch run `27734954008` used `project=all`, `marker=creditnote-email-20260618`, `send_email=true`
+  - VEVO hard-gate context from that run: instance-id `N/A (scheduled ECS/Fargate task)`, private IP `172.31.40.4`, service `vevo-daily-report-email`, task definition `arn:aws:ecs:eu-central-1:919341186960:task-definition/vevo-reporting-daily:5`, task `arn:aws:ecs:eu-central-1:919341186960:task/vevo-reporting-cluster/b992759c693845039e84f6f58542f268`
+  - the run failed before `LOCALHOST_MARKER_OK`, SES proof, or UI smoke could be recorded; GitHub log showed the VEVO task running through `840s` and then ended after the CloudWatch log stream line without enough task-stop context
+  - change in this branch: production smoke now prints explicit task timeout/stopped context, container exit code/reason, and bounded `--no-paginate` CloudWatch log output so the next run can distinguish report failure from smoke/log collection failure
+  - local verification: workflow YAML parse check and `git diff --check`
+  - Next exact step: commit/push this workflow hardening, merge it through PR, then re-dispatch production reporting with `send_email=true` and record `LOCALHOST_MARKER_OK`, SES message IDs, and UI smoke for VEVO and ROY
+
 - Production reporting smoke email dispatch mode is implemented locally on `2026-06-18`:
   - branch/worktree: `codex/report-email-dispatch` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
   - workflow `.github/workflows/production-reporting-smoke.yml` keeps the default `send_email=false` dry-run behavior


### PR DESCRIPTION
## Summary
- add explicit ECS task timeout/stopped context to production reporting smoke
- make CloudWatch log fetch bounded and non-fatal so failures retain useful diagnostics
- record the failed first creditnote email regeneration attempt in PROJECT_STATE

## Verification
- workflow YAML parse check
- git diff --check