### PR TITLE
Separate reporting smoke marker from output tag

### DIFF
--- a/.github/workflows/production-reporting-smoke.yml
+++ b/.github/workflows/production-reporting-smoke.yml
@@ -179,7 +179,7 @@ jobs:
             SMOKE_SCRIPT="$(cat <<'SH'
           set -euo pipefail
           PROJECT="${REPORT_PROJECT:?REPORT_PROJECT missing}"
-          MARKER="${REPORT_OUTPUT_TAG:-}"
+          MARKER="${REPORT_MARKER:-${REPORT_OUTPUT_TAG:-}}"
           SEND_EMAIL="${REPORT_SEND_EMAIL:-false}"
           PIDS=()
           cleanup() {
@@ -190,6 +190,7 @@ jobs:
           trap cleanup EXIT
           echo "HOST_SMOKE_START project=${PROJECT} marker=${MARKER} send_email=${SEND_EMAIL}"
           if [[ "${SEND_EMAIL}" == "true" ]]; then
+            unset REPORT_OUTPUT_TAG
             python daily_report_runner.py --project "${PROJECT}" --skip-invoices
           else
             python daily_report_runner.py --project "${PROJECT}" --output-tag "${MARKER}" --skip-email --skip-invoices --creditnote-storno-dry-run
@@ -199,7 +200,7 @@ jobs:
           import os
           from pathlib import Path
           project = os.environ["REPORT_PROJECT"]
-          marker = os.environ["REPORT_OUTPUT_TAG"]
+          marker = os.environ.get("REPORT_MARKER") or os.environ.get("REPORT_OUTPUT_TAG") or ""
           send_email = os.environ.get("REPORT_SEND_EMAIL", "false").strip().lower() == "true"
           data_dir = Path("data") / project
           if send_email:
@@ -326,6 +327,7 @@ jobs:
                       "command": ["/bin/bash", "-lc", os.environ["SMOKE_SCRIPT"]],
                       "environment": [
                           {"name": "REPORT_PROJECT", "value": os.environ["PROJECT"]},
+                          {"name": "REPORT_MARKER", "value": os.environ["MARKER"]},
                           {"name": "REPORT_OUTPUT_TAG", "value": os.environ["MARKER"]},
                           {"name": "REPORT_SKIP_INVOICES", "value": "true"},
                           {"name": "REPORT_SEND_EMAIL", "value": os.environ["SEND_EMAIL"]},

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -71,6 +71,15 @@ Bootstrap entrypoints:
   - local verification: workflow YAML parse check and `git diff --check`
   - Next exact step: commit/push this workflow hardening, merge it through PR, then re-dispatch production reporting with `send_email=true` and record `LOCALHOST_MARKER_OK`, SES message IDs, and UI smoke for VEVO and ROY
 
+- Production email rerun marker/tag correction is in progress on `2026-06-18`:
+  - branch/worktree: `codex/report-email-untagged-rerun` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - rerun `27735689741` for `project=all`, `marker=creditnote-email-20260618-rerun`, `send_email=true` started VEVO task `arn:aws:ecs:eu-central-1:919341186960:task/vevo-reporting-cluster/69ff9f779be0455aa562e17e4d946a98`
+  - VEVO hard-gate context: instance-id `N/A (scheduled ECS/Fargate task)`, private IP `172.31.28.112`, service `vevo-daily-report-email`, CloudWatch stream `/ecs/vevo-reporting-daily:ecs/reporting/69ff9f779be0455aa562e17e4d946a98`
+  - VEVO report generation completed and SES sent `MessageId=0107019ed8eea57d-883dd5e4-7574-44f9-afbe-927d58b6cb9e-000000`
+  - the run still failed before localhost marker/UI smoke because `REPORT_OUTPUT_TAG` was present during `send_email=true`; `daily_report_runner.py` wrote tagged latest files like `report_latest__vevo-creditnote-email-20260618-rerun.html`, while validation correctly expected untagged `report_latest.html`
+  - change in this branch: separate `REPORT_MARKER` from `REPORT_OUTPUT_TAG`, unset `REPORT_OUTPUT_TAG` before real email generation, and keep marker metadata available for localhost validation
+  - Next exact step: validate/merge this workflow fix, then run ROY `send_email=true`; avoid re-sending VEVO unless an untagged production latest refresh is explicitly needed
+
 - Production reporting smoke email dispatch mode is implemented locally on `2026-06-18`:
   - branch/worktree: `codex/report-email-dispatch` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
   - workflow `.github/workflows/production-reporting-smoke.yml` keeps the default `send_email=false` dry-run behavior


### PR DESCRIPTION
## Summary
- keep workflow markers separate from report output tags
- unset REPORT_OUTPUT_TAG before real send_email=true report generation
- record the VEVO rerun result and tagged/untagged smoke failure in PROJECT_STATE

## Verification
- workflow YAML parse check
- git diff --check