### PR TITLE
Restore report output tag after creditnote guard

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4189,3 +4189,20 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - regenerated local artifacts are not uploaded to S3 yet
 - Next exact step:
   - commit and push correction to PR `#177`, then merge/deploy and run production artifact refresh with required infra hard-gate verification before UI checks
+
+### 2026-06-18 (daily email output tag reset after creditnote guard)
+- Branch: `codex/reset-output-tag-after-storno`
+- Context:
+  - production reporting smoke run `27737957097` refreshed the VEVO scheduled task definition to the new creditnote reporting image and confirmed the Fargate hard-gate context before export
+  - VEVO hard-gate context from that run: instance-id `N/A (scheduled ECS/Fargate task)`, private IP `172.31.14.23`, service `vevo-daily-report-email`, task definition `arn:aws:ecs:eu-central-1:919341186960:task-definition/vevo-reporting-daily:6`, task `arn:aws:ecs:eu-central-1:919341186960:task/vevo-reporting-cluster/694dfb31d74c47f0ab155148ac985417`, image digest `sha256:10202cb947ab0ab50ec2be9fe6331c8cc48e5204df60ebdaffe271369dd03bbd`
+  - the run failed before SES send because `creditnote_storno_guard.py` built its exporter with `output_tag=creditnote_storno_guard`; `BiznisWebExporter.__init__` writes that tag to `REPORT_OUTPUT_TAG`, and the daily export subprocess inherited it
+  - result: the real daily run produced tagged files like `report_...__creditnote_storno_guard.html`, while `daily_report_runner.py` correctly expected untagged daily files for the email
+- Change:
+  - `daily_report_runner.py` now restores the daily runner `REPORT_OUTPUT_TAG` immediately after the creditnote storno guard finishes and before spawning the export subprocess
+  - added a regression test that simulates the guard leaking `REPORT_OUTPUT_TAG=creditnote_storno_guard` and asserts the subsequent daily export receives the intended empty tag
+- Local verification:
+  - `python -m py_compile daily_report_runner.py`
+  - `python -m unittest tests.test_invoice_generation tests.test_creditnote_storno_guard tests.test_creditnote_export tests.test_reporting_calculation_fixes tests.test_dashboard_modern` (`51` tests OK)
+  - `git diff --check`
+- Next exact step:
+  - commit/push this branch, merge through PR, wait for the ECR rebuild, then dispatch `Production Reporting Smoke` with `project=all`, `send_email=true`, and `update_task_image=true` to regenerate and send the corrected VEVO and ROY reports

--- a/daily_report_runner.py
+++ b/daily_report_runner.py
@@ -1262,6 +1262,9 @@ def main() -> None:
         if creditnote_storno_summary and int(creditnote_storno_summary.get("updated_orders") or 0) > 0:
             use_clear_cache = True
             print("Creditnote storno guard updated orders; forcing cache clear before export.")
+        # The guard builds its own exporter and may temporarily set REPORT_OUTPUT_TAG.
+        # Restore the daily-runner tag before spawning the report export subprocess.
+        os.environ["REPORT_OUTPUT_TAG"] = output_tag
 
     if not args.skip_export:
         run_export(

--- a/tests/test_invoice_generation.py
+++ b/tests/test_invoice_generation.py
@@ -1,8 +1,11 @@
 import json
+import os
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import daily_report_runner as daily_runner
 from daily_report_runner import maybe_run_invoice_automation, parse_args as parse_daily_report_args
 from generate_invoices import (
     InvoiceGenerator,
@@ -106,6 +109,61 @@ class InvoiceGenerationTests(unittest.TestCase):
     def test_daily_report_runner_skips_invoices_by_default(self) -> None:
         args = parse_daily_report_args([])
         self.assertTrue(args.skip_invoices)
+
+    def test_daily_report_runner_restores_output_tag_after_creditnote_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            required_outputs = {
+                "report_html": tmp_path / "report.html",
+                "export_csv": tmp_path / "export.csv",
+                "date_csv": tmp_path / "date.csv",
+                "month_csv": tmp_path / "month.csv",
+            }
+            for path in required_outputs.values():
+                path.write_text("ok", encoding="utf-8")
+
+            class FakeArtifactSet:
+                def as_dict(self):
+                    return {
+                        "report_html": required_outputs["report_html"],
+                        "data_quality_json": tmp_path / "data_quality.json",
+                    }
+
+                def required_daily_runner_outputs(self):
+                    return required_outputs
+
+            def guard_side_effect(**_kwargs):
+                os.environ["REPORT_OUTPUT_TAG"] = "creditnote_storno_guard"
+                return {"updated_orders": 1}
+
+            def export_side_effect(**kwargs):
+                self.assertEqual("", kwargs["output_tag"])
+                self.assertEqual("", os.environ.get("REPORT_OUTPUT_TAG"))
+
+            with patch.object(daily_runner.sys, "argv", [
+                "daily_report_runner.py",
+                "--project",
+                "vevo",
+                "--from-date",
+                "2026-06-17",
+                "--to-date",
+                "2026-06-17",
+                "--skip-email",
+                "--skip-invoices",
+            ]), patch.dict(os.environ, {"REPORT_OUTPUT_TAG": ""}, clear=False), \
+                patch.object(daily_runner, "load_dotenv"), \
+                patch.object(daily_runner, "load_project_env"), \
+                patch.object(daily_runner, "load_project_settings", return_value={}), \
+                patch.object(daily_runner, "resolve_reporting_defaults", return_value={}), \
+                patch.object(daily_runner, "maybe_run_creditnote_storno_guard", side_effect=guard_side_effect), \
+                patch.object(daily_runner, "run_export", side_effect=export_side_effect) as run_export_mock, \
+                patch.object(daily_runner, "build_artifact_set", return_value=FakeArtifactSet()), \
+                patch.object(daily_runner, "s3_upload_outputs"), \
+                patch.object(daily_runner, "load_data_quality", return_value={}), \
+                patch.object(daily_runner, "put_metric"):
+                daily_runner.main()
+
+            run_export_mock.assert_called_once()
 
     def test_vevo_and_roy_have_separate_schedule_settings(self) -> None:
         vevo = json.loads((ROOT_DIR / "projects" / "vevo" / "settings.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## What changed
- Restore the daily runner `REPORT_OUTPUT_TAG` immediately after the creditnote storno guard finishes.
- Add a regression test for the guard leaking `REPORT_OUTPUT_TAG=creditnote_storno_guard` into the real daily export.
- Update `PROJECT_STATE.md` with the production smoke failure context and next step.

## Why
The production email rerun refreshed the scheduled task image correctly, but the guard-created exporter left `REPORT_OUTPUT_TAG` set to `creditnote_storno_guard`. The daily export subprocess inherited it, created tagged output files, and the email runner could not find the expected untagged daily artifacts.

## Validation
- `python -m py_compile daily_report_runner.py`
- `python -m unittest tests.test_invoice_generation tests.test_creditnote_storno_guard tests.test_creditnote_export tests.test_reporting_calculation_fixes tests.test_dashboard_modern` (`51` tests OK)
- `git diff --check`