### PR TITLE
Isolate monthly creditnote runtime env

### DIFF
--- a/.github/workflows/deploy-monthly-creditnote-export.yml
+++ b/.github/workflows/deploy-monthly-creditnote-export.yml
@@ -163,6 +163,63 @@ jobs:
               --region "${AWS_REGION}" > "source-task-definition-${project}.json"
           done
 
+          python - "${CREDITNOTE_PROJECTS}" <<'PY'
+          import http.cookiejar
+          import json
+          import os
+          import pathlib
+          import re
+          import sys
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          projects = [item.strip() for item in sys.argv[1].split(",") if item.strip()]
+
+          def base_url_for(project):
+              settings = json.loads((pathlib.Path("projects") / project / "settings.json").read_text(encoding="utf-8"))
+              api_url = str(settings.get("biznisweb_api_url") or "").strip()
+              if not api_url:
+                  raise SystemExit(f"{project}: biznisweb_api_url missing in settings")
+              parsed = urllib.parse.urlparse(api_url)
+              return f"{parsed.scheme}://{parsed.netloc}"
+
+          def extract_arf(text):
+              match = re.search(r"[?&]arf=([a-zA-Z0-9]+)", text or "")
+              if not match:
+                  match = re.search(
+                      r"CsrfToken\s*=\s*function\s*\(\)\s*\{\s*var\s+\w+\s*=\s*'([a-zA-Z0-9]+)'",
+                      text or "",
+                  )
+              return match.group(1) if match else ""
+
+          for project in projects:
+              prefix = project.upper().replace("-", "_")
+              username = os.environ.get(f"{prefix}_BIZNISWEB_USERNAME", "")
+              password = os.environ.get(f"{prefix}_BIZNISWEB_PASSWORD", "")
+              if not username or not password:
+                  raise SystemExit(f"{project}: GitHub Secret admin credentials are missing")
+              base_url = base_url_for(project)
+              opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(http.cookiejar.CookieJar()))
+              login_page = opener.open(f"{base_url}/erp/main/login", timeout=30).read().decode("utf-8", "replace")
+              arf = extract_arf(login_page)
+              payload = urllib.parse.urlencode(
+                  {"username": username, "password": password, "res": "1890x900", "arf": arf}
+              ).encode("utf-8")
+              request = urllib.request.Request(
+                  f"{base_url}/admin/login/authenticate/",
+                  data=payload,
+                  headers={"Content-Type": "application/x-www-form-urlencoded"},
+              )
+              try:
+                  response = opener.open(request, timeout=30)
+              except urllib.error.HTTPError as exc:
+                  raise SystemExit(f"{project}: GitHub Secret admin login failed status={exc.code}") from exc
+              if response.getcode() >= 400:
+                  raise SystemExit(f"{project}: GitHub Secret admin login failed status={response.getcode()}")
+              print(f"GITHUB_SECRET_ADMIN_LOGIN_OK project={project} base_url={base_url} arf_present={bool(arf)}")
+          PY
+
           : > credential-overrides.tsv
           put_credential_override() {
             local env_name="$1"
@@ -291,6 +348,7 @@ jobs:
           env.extend(
               [
                   {"name": "REPORT_PROJECT", "value": owner_project},
+                  {"name": "REPORT_SKIP_PROJECT_ENV", "value": "true"},
                   {"name": "CREDITNOTE_EXPORT_OWNER_PROJECT", "value": owner_project},
                   {"name": "CREDITNOTE_EXPORT_PROJECTS", "value": projects_csv},
                   {"name": "CREDITNOTE_EXPORT_EMAIL_TO", "value": email_to},
@@ -325,6 +383,27 @@ jobs:
           aws ecs describe-task-definition \
             --task-definition "${REGISTERED_TASK_DEFINITION_ARN}" \
             --region "${AWS_REGION}" > task-definition-creditnote-registered.json
+          python - "${CREDITNOTE_PROJECTS}" <<'PY'
+          import json
+          import sys
+
+          projects = [item.strip() for item in sys.argv[1].split(",") if item.strip()]
+          required_secrets = {
+              f"{project.upper().replace('-', '_')}_BIZNISWEB_{name}"
+              for project in projects
+              for name in ("USERNAME", "PASSWORD")
+          }
+          task_def = json.load(open("task-definition-creditnote-registered.json", encoding="utf-8"))["taskDefinition"]
+          container = task_def["containerDefinitions"][0]
+          env = {item.get("name"): item.get("value") for item in container.get("environment", [])}
+          secrets = {item.get("name") for item in container.get("secrets", [])}
+          missing = sorted(required_secrets - secrets)
+          if missing:
+              raise SystemExit(f"Monthly task credential override secrets missing: {missing}")
+          if env.get("REPORT_SKIP_PROJECT_ENV") != "true":
+              raise SystemExit("Monthly task must set REPORT_SKIP_PROJECT_ENV=true")
+          print(f"TASK_CREDENTIAL_OVERRIDES_OK secret_count={len(required_secrets)} skip_project_env=true")
+          PY
 
           if [[ -n "${SCHEDULE_ROLE_ARN}" ]]; then
             SCHEDULE_ROLE_NAME="$(python - "${SCHEDULE_ROLE_ARN}" <<'PY'
@@ -559,6 +638,7 @@ jobs:
                       "command": ["/bin/bash", "-lc", os.environ["SMOKE_SCRIPT"]],
                       "environment": [
                           {"name": "REPORT_PROJECT", "value": os.environ["OWNER_PROJECT"]},
+                          {"name": "REPORT_SKIP_PROJECT_ENV", "value": "true"},
                           {"name": "CREDITNOTE_EXPORT_OWNER_PROJECT", "value": os.environ["OWNER_PROJECT"]},
                           {"name": "CREDITNOTE_EXPORT_PROJECTS", "value": os.environ["CREDITNOTE_PROJECTS"]},
                           {"name": "CREDITNOTE_EXPORT_EMAIL_TO", "value": os.environ["CREDITNOTE_EMAIL_TO"]},

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,21 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- Monthly creditnote export runtime env isolation fix is in progress on `2026-06-18`:
+  - branch/worktree: `codex/monthly-creditnote-runtime-env` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - context: PR `#186` merged as `8685eea41de88516c462c9261695a5ea9656e679` and deploy run `27749819179` proved that GitHub Secrets were present (`credential_override_count=4`) and task definition `monthly-creditnote-export:3` was registered, but the smoke task still failed ROY admin login with `401 Unauthorized`
+  - hard-gate context from failed follow-up run: instance-id `N/A (scheduled ECS/Fargate task)`, private IP `172.31.3.234`, service `monthly-creditnote-export`, task definition `arn:aws:ecs:eu-central-1:919341186960:task-definition/monthly-creditnote-export:3`, task `arn:aws:ecs:eu-central-1:919341186960:task/vevo-reporting-cluster/91f56b39195d4c6dafe608ac072767c3`, image digest `sha256:0bcb914911f4726949032991bff95a390e8bae1cd7984f91e5604e1b55fe7699`, marker path `http://127.0.0.1:8000/marker.json`
+  - local finding: clean-process admin login using `projects/roy/.env` and `projects/vevo/.env` succeeds for both projects, so the local credential values are valid; the monthly runtime must avoid image/project `.env` overriding ECS runtime credentials
+  - change: monthly deploy workflow now sets `REPORT_SKIP_PROJECT_ENV=true` in the registered ECS task definition and in the host-smoke container override
+  - change: monthly deploy workflow now performs a runner-side ROY/VEVO GitHub Secret admin-login preflight before writing SSM overrides, and asserts the registered task definition contains the required `ROY_`/`VEVO_` credential override secrets
+  - local verification:
+    - YAML parse check for `.github/workflows/deploy-monthly-creditnote-export.yml`
+    - embedded Python heredoc syntax check for the workflow
+    - stdlib admin-login preflight succeeds locally for ROY and VEVO using the same request shape added to the workflow
+    - `_login_admin()` succeeds locally for ROY and VEVO with `REPORT_SKIP_PROJECT_ENV=true` and prefixed runtime credentials
+    - `git diff --check`
+  - Next exact step: validate/merge this workflow follow-up, then rerun `Deploy Monthly Creditnote Export` and require `GITHUB_SECRET_ADMIN_LOGIN_OK`, `TASK_CREDENTIAL_OVERRIDES_OK`, `CREDITNOTE_EXPORT_MARKER_OK`, and localhost marker before closing the monthly export deploy issue
+
 - Monthly creditnote export credential override fix is in progress on `2026-06-18`:
   - branch/worktree: `codex/fix-monthly-creditnote-credentials` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
   - context: deploy workflow run `27742671211` failed in the monthly creditnote export host smoke because the Fargate task received stale ROY BizniWeb web credentials and `/admin/login/authenticate/` returned `401 Unauthorized`


### PR DESCRIPTION
## Summary
- set `REPORT_SKIP_PROJECT_ENV=true` in the monthly creditnote ECS task definition and host-smoke override
- add a runner-side ROY/VEVO GitHub Secret admin-login preflight before writing SSM overrides
- assert the registered monthly task definition contains the required `ROY_`/`VEVO_` credential override secrets
- record the failed follow-up run and local verification in `PROJECT_STATE.md`

## Why
PR #186 proved the GitHub Secrets were present (`credential_override_count=4`) and registered task definition `monthly-creditnote-export:3`, but the Fargate smoke still failed ROY admin login with `401 Unauthorized`. Local clean-process login works for both ROY and VEVO from the project `.env` files, and `_login_admin()` works with `REPORT_SKIP_PROJECT_ENV=true` plus prefixed runtime credentials. The monthly task should therefore ignore image/project `.env` files and use ECS runtime credentials only.

## Verification
- workflow YAML parse check
- embedded Python heredoc syntax check
- `git diff --check`
- local stdlib admin-login preflight for ROY and VEVO
- local `_login_admin()` smoke with `REPORT_SKIP_PROJECT_ENV=true` and prefixed runtime credentials for ROY and VEVO