### PR TITLE
Add monthly Fargate credential preflight

### DIFF
--- a/.github/workflows/deploy-monthly-creditnote-export.yml
+++ b/.github/workflows/deploy-monthly-creditnote-export.yml
@@ -300,10 +300,12 @@ jobs:
           container = task["containerDefinitions"][0]
           container["image"] = image_identifier
           container["command"] = ["python", "monthly_creditnote_export_runner.py", "--owner-project", owner_project]
+          credential_names = {"BIZNISWEB_USERNAME", "BIZNISWEB_PASSWORD", "BIZNISWEB_API_TOKEN", "BIZNISWEB_API_URL"}
 
           env = [
               item for item in container.get("environment", [])
-              if item.get("name") not in {
+              if item.get("name") not in credential_names
+              and item.get("name") not in {
                   "REPORT_PROJECT",
                   "REPORT_OUTPUT_TAG",
                   "REPORT_SKIP_INVOICES",
@@ -314,14 +316,14 @@ jobs:
           ]
           secrets = [
               item for item in container.get("secrets", [])
-              if not item.get("name", "").startswith(("ROY_", "VEVO_"))
+              if item.get("name") not in credential_names
+              and not item.get("name", "").startswith(("ROY_", "VEVO_"))
           ]
           credential_overrides = {}
           override_path = pathlib.Path("credential-overrides.json")
           if override_path.exists():
               credential_overrides = json.loads(override_path.read_text(encoding="utf-8"))
 
-          credential_names = {"BIZNISWEB_USERNAME", "BIZNISWEB_PASSWORD", "BIZNISWEB_API_TOKEN", "BIZNISWEB_API_URL"}
           for project in projects:
               prefix = project.upper().replace("-", "_")
               path = pathlib.Path(f"source-task-definition-{project}.json")
@@ -583,6 +585,64 @@ jobs:
             done
           }
           trap cleanup EXIT
+          python - <<'PY'
+          import http.cookiejar
+          import json
+          import os
+          import pathlib
+          import re
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          projects = [item.strip() for item in os.environ["CREDITNOTE_EXPORT_PROJECTS"].split(",") if item.strip()]
+
+          def extract_arf(text):
+              match = re.search(r"[?&]arf=([a-zA-Z0-9]+)", text or "")
+              if not match:
+                  match = re.search(
+                      r"CsrfToken\s*=\s*function\s*\(\)\s*\{\s*var\s+\w+\s*=\s*'([a-zA-Z0-9]+)'",
+                      text or "",
+                  )
+              return match.group(1) if match else ""
+
+          for project in projects:
+              prefix = project.upper().replace("-", "_")
+              username = os.environ.get(f"{prefix}_BIZNISWEB_USERNAME", "")
+              password = os.environ.get(f"{prefix}_BIZNISWEB_PASSWORD", "")
+              print(
+                  "FARGATE_RUNTIME_ENV_OK "
+                  f"project={project} "
+                  f"username_present={bool(username)} "
+                  f"password_present={bool(password)} "
+                  f"unprefixed_username_present={bool(os.environ.get('BIZNISWEB_USERNAME'))} "
+                  f"skip_project_env={os.environ.get('REPORT_SKIP_PROJECT_ENV')}"
+              )
+              if not username or not password:
+                  raise SystemExit(f"{project}: missing prefixed runtime admin credentials")
+              settings = json.loads((pathlib.Path("projects") / project / "settings.json").read_text(encoding="utf-8"))
+              api_url = str(settings.get("biznisweb_api_url") or "").strip()
+              parsed = urllib.parse.urlparse(api_url)
+              base_url = f"{parsed.scheme}://{parsed.netloc}"
+              opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(http.cookiejar.CookieJar()))
+              login_page = opener.open(f"{base_url}/erp/main/login", timeout=30).read().decode("utf-8", "replace")
+              arf = extract_arf(login_page)
+              payload = urllib.parse.urlencode(
+                  {"username": username, "password": password, "res": "1890x900", "arf": arf}
+              ).encode("utf-8")
+              request = urllib.request.Request(
+                  f"{base_url}/admin/login/authenticate/",
+                  data=payload,
+                  headers={"Content-Type": "application/x-www-form-urlencoded"},
+              )
+              try:
+                  response = opener.open(request, timeout=30)
+              except urllib.error.HTTPError as exc:
+                  raise SystemExit(f"{project}: Fargate runtime admin login failed status={exc.code}") from exc
+              if response.getcode() >= 400:
+                  raise SystemExit(f"{project}: Fargate runtime admin login failed status={response.getcode()}")
+              print(f"FARGATE_ADMIN_LOGIN_OK project={project} base_url={base_url} arf_present={bool(arf)}")
+          PY
           RUN_ARGS=(--owner-project "${OWNER_PROJECT}" --projects "${PROJECTS}" --email-to "${EMAIL_TO}" --output-tag smoke)
           if [[ -n "${EMAIL_MODE}" ]]; then
             RUN_ARGS+=("${EMAIL_MODE}")

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,18 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- Monthly creditnote export Fargate runtime preflight is in progress on `2026-06-18`:
+  - branch/worktree: `codex/monthly-creditnote-fargate-preflight` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - context: PR `#187` merged as `f04859d22a2b3031b7c2dc8b647475561b5566be`; deploy run `27750334925` proved `GITHUB_SECRET_ADMIN_LOGIN_OK` for ROY and VEVO, `credential_override_count=4`, and `TASK_CREDENTIAL_OVERRIDES_OK`, but the Fargate smoke still failed ROY admin login with `401 Unauthorized`
+  - hard-gate context from failed run: instance-id `N/A (scheduled ECS/Fargate task)`, private IP `172.31.19.15`, service `monthly-creditnote-export`, task definition `arn:aws:ecs:eu-central-1:919341186960:task-definition/monthly-creditnote-export:4`, task `arn:aws:ecs:eu-central-1:919341186960:task/vevo-reporting-cluster/f7fc158140e64bd8ab6fea8979a1e497`, image digest `sha256:0bcb914911f4726949032991bff95a390e8bae1cd7984f91e5604e1b55fe7699`, marker path `http://127.0.0.1:8000/marker.json`
+  - change: monthly task-definition builder now removes inherited unprefixed `BIZNISWEB_USERNAME`, `BIZNISWEB_PASSWORD`, `BIZNISWEB_API_TOKEN`, and `BIZNISWEB_API_URL` from the source daily task so the monthly export cannot silently fall back to stale source credentials
+  - change: host smoke now runs a Fargate-side admin-login preflight before `monthly_creditnote_export_runner.py`, logging only credential presence booleans and `FARGATE_ADMIN_LOGIN_OK` markers, never secret values
+  - local verification:
+    - YAML parse check for `.github/workflows/deploy-monthly-creditnote-export.yml`
+    - embedded Python heredoc syntax check for the workflow
+    - `git diff --check`
+  - Next exact step: merge this workflow diagnostic/fallback removal, rerun `Deploy Monthly Creditnote Export`, and use the Fargate-side preflight result to distinguish runtime credential injection from a BizniWeb/ECS egress authorization problem
+
 - Monthly creditnote export runtime env isolation fix is in progress on `2026-06-18`:
   - branch/worktree: `codex/monthly-creditnote-runtime-env` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
   - context: PR `#186` merged as `8685eea41de88516c462c9261695a5ea9656e679` and deploy run `27749819179` proved that GitHub Secrets were present (`credential_override_count=4`) and task definition `monthly-creditnote-export:3` was registered, but the smoke task still failed ROY admin login with `401 Unauthorized`


### PR DESCRIPTION
## Summary
- remove inherited unprefixed `BIZNISWEB_*` credentials from the monthly creditnote task definition
- keep only project-prefixed ROY/VEVO credential sources for the monthly task
- add a Fargate-side admin-login preflight before `monthly_creditnote_export_runner.py`
- log only credential presence booleans and explicit `FARGATE_ADMIN_LOGIN_OK` markers, never secret values
- record run `27750334925` hard-gate evidence and next diagnostic step in `PROJECT_STATE.md`

## Why
PR #187 proved the GitHub Secrets are valid in the runner and that the ECS task definition contains the SSM override secrets. The Fargate task still failed ROY login with `401 Unauthorized`, so the next check must happen inside the Fargate runtime before the application runner starts.

## Verification
- workflow YAML parse check
- embedded Python heredoc syntax check
- `git diff --check`