### PR TITLE
Support prefixed BizniWeb API runtime

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,19 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- Monthly creditnote prefixed API runtime fix is in progress on `2026-06-18`:
+  - branch/worktree: `codex/monthly-creditnote-prefixed-api-runtime` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - context: deploy run `27750720572` succeeded after PR `#188` and confirmed `FARGATE_ADMIN_LOGIN_OK` for ROY and VEVO, but the generated monthly summary still showed reporting audit errors `BIZNISWEB_API_TOKEN missing for project 'roy'/'vevo'`, causing carrier context to degrade to `Unknown carrier`
+  - root cause: the monthly task now correctly avoids unprefixed source credentials, but reusable reporting runtime still read only unprefixed `BIZNISWEB_API_TOKEN` for order-context/carrier audit; multi-project monthly runtime needs prefixed `ROY_`/`VEVO_` API URL/token support
+  - change: `reporting_core.config` now resolves project-prefixed env values first (`ROY_BIZNISWEB_API_TOKEN`, `VEVO_BIZNISWEB_API_TOKEN`, etc.) with legacy unprefixed fallback
+  - change: `reporting_core.runtime` and `creditnote_export.fetch_project_reporting_order_context()` now use the project-prefixed resolver for API token/runtime context
+  - local verification:
+    - `python -m py_compile creditnote_export.py reporting_core/config.py reporting_core/runtime.py`
+    - `python -m unittest tests.test_creditnote_export`
+    - ECS-like local live smoke with `REPORT_SKIP_PROJECT_ENV=true` and only prefixed ROY/VEVO runtime credentials: `exported_rows=39`, `project_counts={"ROY":14,"VEVO":25}`, `audit_errors={}`, `carrier_rows=15`, `non_unknown_carriers=14`
+    - `git diff --check`
+  - Next exact step: commit/push this code fix, merge through PR, wait for ECR rebuild, then rerun `Deploy Monthly Creditnote Export` so task definition uses the rebuilt image and verify carrier/reporting audit has no API-token errors
+
 - Monthly creditnote export Fargate runtime preflight is in progress on `2026-06-18`:
   - branch/worktree: `codex/monthly-creditnote-fargate-preflight` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
   - context: PR `#187` merged as `f04859d22a2b3031b7c2dc8b647475561b5566be`; deploy run `27750334925` proved `GITHUB_SECRET_ADMIN_LOGIN_OK` for ROY and VEVO, `credential_override_count=4`, and `TASK_CREDENTIAL_OVERRIDES_OK`, but the Fargate smoke still failed ROY admin login with `401 Unauthorized`

--- a/creditnote_export.py
+++ b/creditnote_export.py
@@ -26,6 +26,7 @@ from reporting_core import (
     project_data_dir,
     project_dir,
     resolve_biznisweb_api_url,
+    resolve_project_env_value,
     sanitize_output_tag,
 )
 
@@ -809,7 +810,7 @@ def fetch_project_reporting_order_context(
         load_project_env(project, logger=_SilentLogger())
         settings = load_project_settings(project)
         api_url = resolve_biznisweb_api_url(project, settings)
-        api_token = os.getenv("BIZNISWEB_API_TOKEN", "").strip()
+        api_token = resolve_project_env_value(project, "BIZNISWEB_API_TOKEN")
         if not api_token:
             raise RuntimeError(f"BIZNISWEB_API_TOKEN missing for project '{project}'")
 

--- a/reporting_core/__init__.py
+++ b/reporting_core/__init__.py
@@ -15,6 +15,7 @@ from .config import (
     project_data_dir,
     project_dir,
     resolve_biznisweb_api_url,
+    resolve_project_env_value,
     resolve_reporting_defaults,
 )
 from .contracts import ReportingArtifactSet, apply_output_tag, build_artifact_set, sanitize_output_tag
@@ -43,6 +44,7 @@ __all__ = [
     "project_data_dir",
     "project_dir",
     "resolve_biznisweb_api_url",
+    "resolve_project_env_value",
     "resolve_reporting_defaults",
     "sanitize_output_tag",
 ]

--- a/reporting_core/config.py
+++ b/reporting_core/config.py
@@ -69,6 +69,12 @@ def load_project_settings(project_name: str) -> Dict[str, Any]:
     return _load_json_file(settings_path)
 
 
+def resolve_project_env_value(project_name: str, key: str) -> str:
+    """Resolve a project-prefixed env value with the legacy unprefixed value as fallback."""
+    prefix = project_name.upper().replace("-", "_")
+    return os.getenv(f"{prefix}_{key}", "").strip() or os.getenv(key, "").strip()
+
+
 def build_project_context(project_name: str, settings: Optional[Dict[str, Any]] = None) -> ReportingProjectContext:
     loaded_settings = settings or load_project_settings(project_name)
     return ReportingProjectContext(
@@ -92,7 +98,9 @@ def get_project_display_name(project_name: str, settings: Optional[Dict[str, Any
 
 def resolve_biznisweb_api_url(project_name: str, settings: Optional[Dict[str, Any]] = None) -> str:
     settings = settings or {}
-    api_url = os.getenv("BIZNISWEB_API_URL", "").strip() or str(settings.get("biznisweb_api_url", "")).strip()
+    api_url = resolve_project_env_value(project_name, "BIZNISWEB_API_URL") or str(
+        settings.get("biznisweb_api_url", "")
+    ).strip()
     if not api_url:
         raise ValueError(
             f"BIZNISWEB_API_URL not found for project '{project_name}'. "

--- a/reporting_core/runtime.py
+++ b/reporting_core/runtime.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .config import project_dir, resolve_biznisweb_api_url, resolve_reporting_defaults
+from .config import project_dir, resolve_biznisweb_api_url, resolve_project_env_value, resolve_reporting_defaults
 
 
 @dataclass(frozen=True)
@@ -135,7 +135,7 @@ def load_project_runtime(
     return ProjectRuntime(
         project_name=project_name,
         api_url=resolve_biznisweb_api_url(project_name, settings),
-        api_token=os.getenv("BIZNISWEB_API_TOKEN", ""),
+        api_token=resolve_project_env_value(project_name, "BIZNISWEB_API_TOKEN"),
         item_price_values_are_net=bool(settings.get("item_price_values_are_net", False)),
         expense_match_mode=str(settings.get("expense_match_mode", "identifier_first")).strip().lower() or "identifier_first",
         product_name_aliases=dict(product_name_aliases),

--- a/tests/test_creditnote_export.py
+++ b/tests/test_creditnote_export.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 import unittest
 from datetime import date
@@ -19,6 +20,8 @@ from monthly_creditnote_export_runner import (
     resolve_creditnote_export_window,
     run_creditnote_export_runner,
 )
+from reporting_core import resolve_biznisweb_api_url, resolve_project_env_value
+from reporting_core.runtime import load_project_runtime
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -54,6 +57,33 @@ class CreditnoteExportTests(unittest.TestCase):
                 to_date="2026-05-31",
             ),
         )
+
+    def test_project_prefixed_biznisweb_env_wins_for_monthly_multi_project_runtime(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "BIZNISWEB_API_URL": "https://legacy.example.test/api/graphql",
+                "BIZNISWEB_API_TOKEN": "legacy-token",
+                "ROY_BIZNISWEB_API_URL": "https://roy.example.test/api/graphql",
+                "ROY_BIZNISWEB_API_TOKEN": "roy-token",
+            },
+            clear=False,
+        ):
+            self.assertEqual("roy-token", resolve_project_env_value("roy", "BIZNISWEB_API_TOKEN"))
+            self.assertEqual(
+                "https://roy.example.test/api/graphql",
+                resolve_biznisweb_api_url("roy", {"biznisweb_api_url": "https://settings.example.test/api/graphql"}),
+            )
+            runtime = load_project_runtime(
+                "roy",
+                settings={},
+                default_packaging_cost_per_order=0.3,
+                default_shipping_subsidy_per_order=0.2,
+                default_fixed_monthly_cost=0,
+                default_fixed_daily_cost=0,
+            )
+            self.assertEqual("https://roy.example.test/api/graphql", runtime.api_url)
+            self.assertEqual("roy-token", runtime.api_token)
 
     def test_build_creditnote_rows_filters_created_window_and_signs_amounts(self) -> None:
         rows = build_creditnote_export_rows(


### PR DESCRIPTION
## Summary
- add a shared `resolve_project_env_value(project, key)` helper that prefers project-prefixed env vars and keeps legacy unprefixed fallback
- use prefixed `ROY_`/`VEVO_` API URL/token values in reporting runtime and monthly creditnote reporting audit
- add a regression test for prefixed multi-project runtime credentials
- record the successful Fargate credential deploy plus remaining carrier-audit API-token gap in `PROJECT_STATE.md`

## Why
Run `27750720572` proved the monthly Fargate task now receives valid admin credentials and the export completes. The summary still had `BIZNISWEB_API_TOKEN missing` audit errors, so carrier stats fell back to mostly `Unknown carrier`. The monthly task intentionally removes unprefixed source credentials, so reusable reporting code must support prefixed API credentials for multi-project runtime.

## Verification
- `python -m py_compile creditnote_export.py reporting_core/config.py reporting_core/runtime.py`
- `python -m unittest tests.test_creditnote_export`
- ECS-like local live smoke with `REPORT_SKIP_PROJECT_ENV=true` and only prefixed ROY/VEVO runtime credentials: `exported_rows=39`, `project_counts={ROY:14,VEVO:25}`, `audit_errors={}`, `carrier_rows=15`, `non_unknown_carriers=14`
- `git diff --check`