### PR TITLE
Compute creditnote carrier rate from documents

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,18 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- Creditnote carrier rate from creditnote documents is implemented locally on `2026-06-18`:
+  - branch/worktree: `codex/creditnote-rate-from-creditnotes` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - context: the daily carrier table showed carriers with `Creditnotes > 0` but `Rate = 0.00%` because the rate used sent-creditnoted order count as the numerator
+  - change: monthly creditnote carrier audit now calculates `Dobropis rate %` as `Dobropisy / Odoslane objednavky` while keeping `Dobropisovane objednavky` as a separate sent-order audit column
+  - change: daily dashboard creditnote metrics now calculate overall and per-carrier `creditnote_rate_pct`, rate index, outlier gating, and carrier sorting from creditnote document count instead of credited sent order count
+  - local verification:
+    - `python -m py_compile export_orders.py creditnote_export.py dashboard_modern.py daily_report_runner.py`
+    - `python -m unittest tests.test_creditnote_export tests.test_reporting_calculation_fixes tests.test_dashboard_modern` (`40` tests OK)
+    - `python -m unittest tests.test_creditnote_export tests.test_creditnote_storno_guard tests.test_reporting_calculation_fixes tests.test_dashboard_modern tests.test_invoice_generation` (`55` tests OK)
+    - `git diff --check`
+  - Next exact step: commit/push this branch, merge through PR, wait for the ECR rebuild, then run production reporting smoke for `project=all` with `send_email=true` and `update_task_image=true` and record VEVO/ROY host marker + UI smoke results
+
 - Monthly combined ROY+VEVO creditnote export deploy is fixed and verified on `2026-06-18`:
   - code/workflow PRs merged to `main`:
     - PR `#186` (`8685eea41de88516c462c9261695a5ea9656e679`) added GitHub Secret -> SSM credential overrides for monthly ROY/VEVO admin credentials

--- a/creditnote_export.py
+++ b/creditnote_export.py
@@ -993,6 +993,7 @@ def build_creditnote_reporting_audit(
         denominator = denominator_by_carrier.get(key) or {}
         denominator_count = len(denominator.get("orders") or set())
         creditnote_order_count = len(numerator.get("Dobropisovane objednavky") or set())
+        creditnote_count = int(numerator.get("Dobropisy") or 0)
         carrier_ids = sorted(
             {
                 str(value).strip()
@@ -1004,7 +1005,7 @@ def build_creditnote_reporting_audit(
             },
             key=_carrier_id_sort_key,
         )
-        rate = round((creditnote_order_count / denominator_count) * 100, 2) if denominator_count > 0 else None
+        rate = round((creditnote_count / denominator_count) * 100, 2) if denominator_count > 0 else None
         carrier_rows.append(
             {
                 "Eshop": project,
@@ -1013,7 +1014,7 @@ def build_creditnote_reporting_audit(
                 "Realized objednavky": denominator_count,
                 "Odoslane objednavky": denominator_count,
                 "Dobropisovane objednavky": creditnote_order_count,
-                "Dobropisy": int(numerator.get("Dobropisy") or 0),
+                "Dobropisy": creditnote_count,
                 "Dobropis rate %": rate,
                 "Suma_s_DPH": round(float(numerator.get("Suma_s_DPH") or 0.0), 2),
                 "Suma_bez_DPH": round(float(numerator.get("Suma_bez_DPH") or 0.0), 2),
@@ -1022,6 +1023,7 @@ def build_creditnote_reporting_audit(
     carrier_rows.sort(
         key=lambda row: (
             -1 if row.get("Dobropis rate %") is None else -float(row.get("Dobropis rate %") or 0.0),
+            -int(row.get("Dobropisy") or 0),
             -int(row.get("Dobropisovane objednavky") or 0),
             str(row.get("Prepravca") or ""),
         )
@@ -1289,7 +1291,7 @@ def _draw_creditnote_pdf(
     pdf.drawString(margin_x, y, "Dobropisy podla prepravcu")
     y -= 5 * mm
     pdf.setFont(fonts["regular"], 7)
-    pdf.drawString(margin_x, y, "Rate = dobropisovane objednavky / odoslane objednavky daneho prepravcu v reportovanom obdobi.")
+    pdf.drawString(margin_x, y, "Rate = pocet dobropisov / odoslane objednavky daneho prepravcu v reportovanom obdobi.")
     y -= 6 * mm
     carrier_columns = [
         ("Eshop", 18 * mm),

--- a/export_orders.py
+++ b/export_orders.py
@@ -4507,7 +4507,8 @@ class BizniWebExporter:
         realized_orders_total = int(date_agg["unique_orders"].sum()) if "unique_orders" in date_agg.columns else len(orders or [])
         sent_creditnoted_order_count = int(audit.get("sent_creditnoted_orders") or 0)
         creditnoted_order_count = sent_creditnoted_order_count
-        overall_rate_pct = round((creditnoted_order_count / realized_orders_total) * 100, 2) if realized_orders_total else 0.0
+        creditnote_count = len(enriched_rows)
+        overall_rate_pct = round((creditnote_count / realized_orders_total) * 100, 2) if realized_orders_total else 0.0
 
         normalized_carrier_rows = []
         for row in carrier_rows:
@@ -4516,6 +4517,7 @@ class BizniWebExporter:
             carrier = str(row.get("Prepravca") or "Unknown carrier")
             realized_count = int(row.get("Realized objednavky") or 0)
             creditnote_order_count = int(row.get("Dobropisovane objednavky") or 0)
+            carrier_creditnote_count = int(row.get("Dobropisy") or 0)
             rate_pct = row.get("Dobropis rate %")
             rate_value = float(rate_pct) if rate_pct is not None else None
             rate_index = round((rate_value / overall_rate_pct), 2) if rate_value is not None and overall_rate_pct > 0 else None
@@ -4523,7 +4525,7 @@ class BizniWebExporter:
             outlier = bool(
                 rate_value is not None
                 and realized_count >= 5
-                and creditnote_order_count >= 2
+                and carrier_creditnote_count >= 2
                 and overall_rate_pct > 0
                 and rate_value >= max(overall_rate_pct * 2.0, overall_rate_pct + 3.0)
             )
@@ -4533,7 +4535,7 @@ class BizniWebExporter:
                     "carrier_id": row.get("Prepravca ID") or "",
                     "realized_orders": realized_count,
                     "creditnoted_orders": creditnote_order_count,
-                    "creditnotes": int(row.get("Dobropisy") or 0),
+                    "creditnotes": carrier_creditnote_count,
                     "creditnote_rate_pct": rate_value,
                     "rate_index": rate_index,
                     "rate_delta_pct": round((rate_value or 0.0) - overall_rate_pct, 2) if rate_value is not None else None,
@@ -4545,6 +4547,7 @@ class BizniWebExporter:
         normalized_carrier_rows.sort(
             key=lambda row: (
                 -1 if row.get("creditnote_rate_pct") is None else -float(row.get("creditnote_rate_pct") or 0.0),
+                -int(row.get("creditnotes") or 0),
                 -int(row.get("creditnoted_orders") or 0),
                 str(row.get("carrier") or ""),
             )
@@ -4561,7 +4564,7 @@ class BizniWebExporter:
             "date_from": date_from.strftime("%Y-%m-%d"),
             "date_to": date_to.strftime("%Y-%m-%d"),
             "reported_total_rows": int(reported_total or 0),
-            "creditnotes": len(enriched_rows),
+            "creditnotes": creditnote_count,
             "creditnoted_orders": creditnoted_order_count,
             "all_creditnoted_orders": len(creditnoted_order_nums),
             "sent_creditnoted_orders": sent_creditnoted_order_count,

--- a/tests/test_creditnote_export.py
+++ b/tests/test_creditnote_export.py
@@ -236,6 +236,49 @@ class CreditnoteExportTests(unittest.TestCase):
         self.assertEqual(66.67, packeta_row["Dobropis rate %"])
         self.assertEqual(61.5, packeta_row["Suma_s_DPH"])
 
+    def test_carrier_rate_uses_creditnote_documents_not_only_sent_creditnoted_orders(self) -> None:
+        export_rows = [
+            {
+                "Eshop": "VEVO",
+                "Dobropis cislo": "260002",
+                "Objednavka": "2602009001",
+                "Mena": "EUR",
+                "Suma bez DPH": -20.0,
+                "Suma s DPH": -24.6,
+            },
+            {
+                "Eshop": "VEVO",
+                "Dobropis cislo": "260003",
+                "Objednavka": "2602009002",
+                "Mena": "EUR",
+                "Suma bez DPH": -30.0,
+                "Suma s DPH": -36.9,
+            },
+        ]
+        packeta = {"type": "shipping", "title": "Packeta - vydajne miesto/box - (100) Foo", "reference_id": "9"}
+        context = {
+            "vevo": {
+                "available": True,
+                "included_orders": [],
+                "all_orders": [
+                    {"order_num": "2602008001", "status": {"name": "Odoslana"}, "price_elements": [packeta]},
+                    {"order_num": "2602008002", "status": {"name": "Odoslana"}, "price_elements": [packeta]},
+                    {"order_num": "2602009001", "status": {"name": "Storno"}, "price_elements": [packeta]},
+                    {"order_num": "2602009002", "status": {"name": "Storno"}, "price_elements": [packeta]},
+                ],
+                "status_change_audit": {"orders": []},
+            }
+        }
+
+        _, carrier_rows, audit = build_creditnote_reporting_audit(export_rows, context)
+
+        self.assertEqual(0, audit["sent_creditnoted_orders"])
+        packeta_row = next(row for row in carrier_rows if row["Prepravca"] == "Packeta")
+        self.assertEqual(2, packeta_row["Odoslane objednavky"])
+        self.assertEqual(0, packeta_row["Dobropisovane objednavky"])
+        self.assertEqual(2, packeta_row["Dobropisy"])
+        self.assertEqual(100.0, packeta_row["Dobropis rate %"])
+
     def test_daily_email_summary_includes_creditnote_metrics(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             payload_path = Path(tmp) / "dashboard_payload_latest.json"

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -362,7 +362,7 @@ class ReportingCalculationFixTests(unittest.TestCase):
         self.assertEqual(100.0, packeta_row["creditnote_rate_pct"])
 
     @patch("creditnote_export.fetch_project_creditnotes")
-    def test_creditnote_reporting_metrics_exclude_unproven_canceled_orders_from_sent_rate(self, fetch_mock) -> None:
+    def test_creditnote_reporting_metrics_use_creditnote_count_for_rate(self, fetch_mock) -> None:
         exporter = make_exporter()
         exporter.project_settings["currency_rates_to_eur"] = {"EUR": 1.0}
         exporter._creditnote_status_change_audit_cache = {"project": "vevo", "orders": []}
@@ -429,10 +429,12 @@ class ReportingCalculationFixTests(unittest.TestCase):
         self.assertEqual(2, summary["all_creditnoted_orders"])
         self.assertEqual(1, summary["creditnoted_orders"])
         self.assertEqual(1, summary["sent_creditnoted_orders"])
+        self.assertEqual(200.0, summary["creditnote_rate_pct"])
         packeta_row = next(row for row in metrics["carrier_rows"] if row["carrier"] == "Packeta")
         self.assertEqual(1, packeta_row["realized_orders"])
         self.assertEqual(1, packeta_row["creditnoted_orders"])
-        self.assertEqual(100.0, packeta_row["creditnote_rate_pct"])
+        self.assertEqual(2, packeta_row["creditnotes"])
+        self.assertEqual(200.0, packeta_row["creditnote_rate_pct"])
 
     def test_period_customer_history_marks_prior_customer_returning(self) -> None:
         exporter = make_exporter()


### PR DESCRIPTION
## Summary
- calculate carrier creditnote rates from creditnote document count over sent orders
- keep credited sent orders as a separate audit column
- update daily dashboard metric normalization and monthly PDF rate note

## Verification
- python -m py_compile export_orders.py creditnote_export.py dashboard_modern.py daily_report_runner.py
- python -m unittest tests.test_creditnote_export tests.test_reporting_calculation_fixes tests.test_dashboard_modern
- python -m unittest tests.test_creditnote_export tests.test_creditnote_storno_guard tests.test_reporting_calculation_fixes tests.test_dashboard_modern tests.test_invoice_generation
- git diff --check