### PR TITLE
Add ROY inventory cost trend

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,19 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY inventory cost value history is implemented locally on `2026-06-18`:
+  - branch/worktree: `codex/roy-inventory-cost-value` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - context: ROY already calculated current `inventory_cost_value` in the inventory snapshot and showed it as a dashboard KPI, but the daily reporting payload did not persist a historical series for a trend chart
+  - change: ROY product demand analytics now builds `inventory_cost_history_rows` from the current inventory snapshot and merges it with the previous stable `dashboard_payload_latest.json` from local output/S3, deduplicated by snapshot date and capped to `730` points
+  - change: the modern dashboard payload now includes `roy_product_demand.inventory_cost_history_rows`
+  - change: the ROY inventory section now renders an `Inventory cost value trend` chart with inventory cost value, retail value, and dead-stock cost value in time
+  - local verification:
+    - `python -m py_compile export_orders.py dashboard_modern.py daily_report_runner.py`
+    - `python -m unittest tests.test_roy_inventory_model tests.test_dashboard_modern`
+    - `python -m unittest tests.test_roy_inventory_model tests.test_dashboard_modern tests.test_roy_operations_dashboard tests.test_reporting_calculation_fixes tests.test_creditnote_export tests.test_creditnote_storno_guard` (`81` tests OK)
+    - `git diff --check`
+  - Next exact step: commit/push this branch, open/merge PR, wait for ECR rebuild, then run ROY production reporting smoke with `send_email=true`, `update_task_image=true`, localhost marker verification, and UI smoke before treating tomorrow morning's reporting as covered
+
 - Creditnote carrier rate from creditnote documents is implemented and deployed on `2026-06-18`:
   - branch/worktree: `codex/creditnote-rate-from-creditnotes` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
   - context: the daily carrier table showed carriers with `Creditnotes > 0` but `Rate = 0.00%` because the rate used sent-creditnoted order count as the numerator

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -1377,6 +1377,28 @@ def generate_modern_dashboard(
         ],
         limit=160,
     )
+    roy_inventory_cost_history_rows = _frame_rows(
+        (roy_product_demand or {}).get("inventory_cost_history_rows"),
+        [
+            "date",
+            "inventory_cost_value",
+            "inventory_retail_value",
+            "inventory_available_units",
+            "inventory_products_with_stock",
+            "inventory_products_total",
+            "inventory_cost_coverage_units_pct",
+            "inventory_cost_coverage_retail_pct",
+            "dead_stock_cost_value",
+            "dead_stock_count",
+            "stock_risk_critical_count",
+            "stock_risk_30d_count",
+            "stock_risk_45d_count",
+            "negative_stock_count",
+            "revenue_at_risk_30d",
+            "profit_at_risk_30d",
+        ],
+        limit=730,
+    )
     roy_stock_risk_rows = _frame_rows(
         (roy_product_demand or {}).get("stock_risk_rows"),
         [
@@ -2177,6 +2199,7 @@ def generate_modern_dashboard(
             "seasonality_rows": roy_seasonality_rows,
             "forecast_rows": roy_forecast_rows,
             "inventory_rows": roy_inventory_rows,
+            "inventory_cost_history_rows": roy_inventory_cost_history_rows,
             "stock_risk_rows": roy_stock_risk_rows,
             "dead_stock_rows": roy_dead_stock_rows,
             "alert_rows": roy_alert_rows,
@@ -2568,6 +2591,14 @@ def generate_modern_dashboard(
         )
         for row in roy_brand_profit_rows
     ) or '<tr><td colspan="6"><span class="lang-en">No brand profit data available.</span><span class="lang-sk hidden">Data o ziskovosti znaciek nie su dostupne.</span></td></tr>'
+    roy_inventory_cost_history_chart_html = ""
+    if roy_inventory_cost_history_rows:
+        roy_inventory_cost_history_chart_html = f"""
+                    <div class="panel chart-card" style="margin-top:18px;">
+                        <div class="card-head"><div><h3><span class="lang-en">Inventory cost value trend</span><span class="lang-sk hidden">Vyvoj hodnoty skladu</span></h3><p><span class="lang-en">Daily inventory cost snapshots with retail and dead-stock value context.</span><span class="lang-sk hidden">Denne skladove snapshoty v nakupnych cenach s retail a dead-stock kontextom.</span></p></div></div>
+                        <div class="chart-shell compact"><canvas id="royInventoryCostValueChart"></canvas></div>
+                    </div>
+        """
     roy_product_demand_section_html = ""
     if any([
         roy_growing_rows,
@@ -2575,6 +2606,7 @@ def generate_modern_dashboard(
         roy_seasonality_rows,
         roy_forecast_rows,
         roy_inventory_rows,
+        roy_inventory_cost_history_rows,
         roy_stock_risk_rows,
         roy_dead_stock_rows,
         roy_alert_rows,
@@ -2664,6 +2696,7 @@ def generate_modern_dashboard(
                         </div>
                         {roy_inventory_status_note_html}
                     </div>
+                    {roy_inventory_cost_history_chart_html}
                     <div class="panel table-card" style="margin-top:18px;">
                         <div class="card-head"><div><h3><span class="lang-en">Actionable inventory alerts</span><span class="lang-sk hidden">Akcne skladove alerty</span></h3><p><span class="lang-en">This is the operational {roy_alert_delivery_horizon_days}-day alert bucket that should drive daily replenishment decisions and morning email alerts.</span><span class="lang-sk hidden">Toto je operativny {roy_alert_delivery_horizon_days}-dnovy alert bucket, ktory ma riadit denny replenishment a ranne emailove upozornenia.</span></p></div></div>
                         <table>
@@ -4856,6 +4889,21 @@ def generate_modern_dashboard(
                             y1: {{ position: 'right', grid: {{ display: false }}, ticks: {{ color: '#8a8178', font: {{ size: 11 }} }}, border: {{ display: false }} }},
                         }},
                     }},
+                }});
+            }}
+            if ((DATA.roy_product_demand || {{}}).inventory_cost_history_rows?.length && document.getElementById('royInventoryCostValueChart')) {{
+                const inventoryHistory = DATA.roy_product_demand.inventory_cost_history_rows;
+                const inventoryPointRadius = inventoryHistory.length > 14 ? 0 : 3;
+                new Chart(document.getElementById('royInventoryCostValueChart'), {{
+                    data: {{
+                        labels: inventoryHistory.map(x => x.date || '-'),
+                        datasets: [
+                            {{ type: 'line', label: 'Inventory cost value', data: inventoryHistory.map(x => Number(x.inventory_cost_value || 0)), borderColor: '#0f766e', backgroundColor: 'rgba(15,118,110,.10)', fill: true, tension: .32, borderWidth: 2.5, pointRadius: inventoryPointRadius }},
+                            {{ type: 'line', label: 'Inventory retail value', data: inventoryHistory.map(x => Number(x.inventory_retail_value || 0)), borderColor: '#4766ff', tension: .32, borderWidth: 2.1, pointRadius: inventoryPointRadius }},
+                            {{ type: 'bar', label: 'Dead stock value', data: inventoryHistory.map(x => Number(x.dead_stock_cost_value || 0)), backgroundColor: 'rgba(207,80,96,.34)', borderRadius: 6 }},
+                        ],
+                    }},
+                    options: baseOptions(),
                 }});
             }}
             const economicsOpts = baseOptions();

--- a/export_orders.py
+++ b/export_orders.py
@@ -127,6 +127,25 @@ WEATHER_SETTINGS: Dict[str, Any] = {
     "locations": []
 }
 ENABLE_EMAIL_STRATEGY_REPORT = False
+ROY_INVENTORY_COST_HISTORY_COLUMNS = [
+    "date",
+    "inventory_cost_value",
+    "inventory_retail_value",
+    "inventory_available_units",
+    "inventory_products_with_stock",
+    "inventory_products_total",
+    "inventory_cost_coverage_units_pct",
+    "inventory_cost_coverage_retail_pct",
+    "dead_stock_cost_value",
+    "dead_stock_count",
+    "stock_risk_critical_count",
+    "stock_risk_30d_count",
+    "stock_risk_45d_count",
+    "negative_stock_count",
+    "revenue_at_risk_30d",
+    "profit_at_risk_30d",
+]
+ROY_INVENTORY_COST_HISTORY_MAX_POINTS = 730
 
 # Currency conversion rates to EUR
 # These should be updated regularly or fetched from an API
@@ -760,6 +779,177 @@ class BizniWebExporter:
         if not self.output_tag:
             return path
         return path.with_name(f"{path.stem}__{self.output_tag}{path.suffix}")
+
+    @staticmethod
+    def _history_float(value: Any, default: float = 0.0) -> float:
+        try:
+            if pd.isna(value):
+                return default
+        except (TypeError, ValueError):
+            pass
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    @classmethod
+    def _history_int(cls, value: Any, default: int = 0) -> int:
+        return int(round(cls._history_float(value, float(default))))
+
+    @staticmethod
+    def _history_date(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str) and not value.strip():
+            return None
+        parsed = pd.to_datetime(value, errors="coerce")
+        if pd.isna(parsed):
+            return None
+        return parsed.strftime("%Y-%m-%d")
+
+    @classmethod
+    def _normalize_roy_inventory_cost_history_point(cls, row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if not isinstance(row, dict):
+            return None
+        date_value = cls._history_date(
+            row.get("date")
+            or row.get("inventory_snapshot_date")
+            or row.get("snapshot_date")
+        )
+        if not date_value:
+            return None
+        return {
+            "date": date_value,
+            "inventory_cost_value": round(cls._history_float(row.get("inventory_cost_value")), 2),
+            "inventory_retail_value": round(cls._history_float(row.get("inventory_retail_value")), 2),
+            "inventory_available_units": round(cls._history_float(row.get("inventory_available_units")), 1),
+            "inventory_products_with_stock": cls._history_int(row.get("inventory_products_with_stock")),
+            "inventory_products_total": cls._history_int(row.get("inventory_products_total")),
+            "inventory_cost_coverage_units_pct": round(cls._history_float(row.get("inventory_cost_coverage_units_pct")), 2),
+            "inventory_cost_coverage_retail_pct": round(cls._history_float(row.get("inventory_cost_coverage_retail_pct")), 2),
+            "dead_stock_cost_value": round(cls._history_float(row.get("dead_stock_cost_value")), 2),
+            "dead_stock_count": cls._history_int(row.get("dead_stock_count")),
+            "stock_risk_critical_count": cls._history_int(row.get("stock_risk_critical_count")),
+            "stock_risk_30d_count": cls._history_int(row.get("stock_risk_30d_count")),
+            "stock_risk_45d_count": cls._history_int(row.get("stock_risk_45d_count")),
+            "negative_stock_count": cls._history_int(row.get("negative_stock_count")),
+            "revenue_at_risk_30d": round(cls._history_float(row.get("revenue_at_risk_30d")), 2),
+            "profit_at_risk_30d": round(cls._history_float(row.get("profit_at_risk_30d")), 2),
+        }
+
+    @classmethod
+    def _build_roy_inventory_cost_history_point(cls, summary: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if not isinstance(summary, dict):
+            return None
+        inventory_status = str(summary.get("inventory_status") or "").strip().lower()
+        if inventory_status and inventory_status != "ok":
+            return None
+        return cls._normalize_roy_inventory_cost_history_point(
+            {
+                "date": summary.get("inventory_snapshot_date"),
+                "inventory_cost_value": summary.get("inventory_cost_value"),
+                "inventory_retail_value": summary.get("inventory_retail_value"),
+                "inventory_available_units": summary.get("inventory_available_units"),
+                "inventory_products_with_stock": summary.get("inventory_products_with_stock"),
+                "inventory_products_total": summary.get("inventory_products_total"),
+                "inventory_cost_coverage_units_pct": summary.get("inventory_cost_coverage_units_pct"),
+                "inventory_cost_coverage_retail_pct": summary.get("inventory_cost_coverage_retail_pct"),
+                "dead_stock_cost_value": summary.get("dead_stock_cost_value"),
+                "dead_stock_count": summary.get("dead_stock_count"),
+                "stock_risk_critical_count": summary.get("stock_risk_critical_count"),
+                "stock_risk_30d_count": summary.get("stock_risk_30d_count"),
+                "stock_risk_45d_count": summary.get("stock_risk_45d_count"),
+                "negative_stock_count": summary.get("negative_stock_count"),
+                "revenue_at_risk_30d": summary.get("revenue_at_risk_30d"),
+                "profit_at_risk_30d": summary.get("profit_at_risk_30d"),
+            }
+        )
+
+    @classmethod
+    def _extract_roy_inventory_cost_history_rows_from_snapshot(cls, snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if not isinstance(snapshot, dict):
+            return []
+        dashboard = snapshot.get("dashboard") if isinstance(snapshot.get("dashboard"), dict) else snapshot
+        roy_payload = dashboard.get("roy_product_demand") if isinstance(dashboard, dict) else {}
+        if not isinstance(roy_payload, dict):
+            return []
+        raw_rows = roy_payload.get("inventory_cost_history_rows")
+        if isinstance(raw_rows, list) and raw_rows:
+            normalized_rows = [
+                point
+                for point in (
+                    cls._normalize_roy_inventory_cost_history_point(row)
+                    for row in raw_rows
+                )
+                if point
+            ]
+            if normalized_rows:
+                return normalized_rows
+        summary = roy_payload.get("summary") if isinstance(roy_payload.get("summary"), dict) else {}
+        point = cls._build_roy_inventory_cost_history_point(summary)
+        return [point] if point else []
+
+    @classmethod
+    def _load_roy_inventory_cost_history_rows_from_payload_path(cls, path: Path) -> List[Dict[str, Any]]:
+        if not path.exists():
+            return []
+        try:
+            snapshot = json.loads(path.read_text(encoding="utf-8-sig"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Previous Roy inventory history payload is unreadable: %s", exc)
+            return []
+        return cls._extract_roy_inventory_cost_history_rows_from_snapshot(snapshot)
+
+    def _load_roy_inventory_cost_history_rows_from_s3(self) -> List[Dict[str, Any]]:
+        if self.project_name != "roy" or self.output_tag:
+            return []
+        bucket = os.getenv("REPORT_S3_BUCKET", "").strip()
+        if not bucket:
+            return []
+        prefix = os.getenv("REPORT_S3_PREFIX", "").strip().strip("/") or f"daily-reports/{self.project_name}"
+        region = os.getenv("AWS_REGION", "eu-central-1").strip()
+        try:
+            import boto3  # type: ignore
+        except ImportError:
+            logger.info("boto3 unavailable; skipping previous Roy inventory history S3 load.")
+            return []
+        key = f"{prefix}/latest/dashboard_payload_latest.json"
+        try:
+            body = boto3.client("s3", region_name=region).get_object(Bucket=bucket, Key=key)["Body"].read()
+            text = body.decode("utf-8-sig") if isinstance(body, bytes) else str(body)
+            snapshot = json.loads(text)
+        except Exception as exc:
+            logger.info("Previous Roy inventory history S3 payload unavailable: %s", exc)
+            return []
+        return self._extract_roy_inventory_cost_history_rows_from_snapshot(snapshot)
+
+    def _load_previous_roy_inventory_cost_history_rows(self) -> List[Dict[str, Any]]:
+        if self.project_name != "roy":
+            return []
+        rows: List[Dict[str, Any]] = []
+        rows.extend(self._load_roy_inventory_cost_history_rows_from_payload_path(self.output_path("dashboard_payload_latest.json")))
+        rows.extend(self._load_roy_inventory_cost_history_rows_from_s3())
+        return rows
+
+    @classmethod
+    def _merge_roy_inventory_cost_history_rows(
+        cls,
+        previous_rows: List[Dict[str, Any]],
+        current_point: Optional[Dict[str, Any]],
+        max_points: int = ROY_INVENTORY_COST_HISTORY_MAX_POINTS,
+    ) -> List[Dict[str, Any]]:
+        by_date: Dict[str, Dict[str, Any]] = {}
+        for row in previous_rows or []:
+            point = cls._normalize_roy_inventory_cost_history_point(row)
+            if point:
+                by_date[point["date"]] = point
+        current = cls._normalize_roy_inventory_cost_history_point(current_point or {})
+        if current:
+            by_date[current["date"]] = current
+        rows = [by_date[key] for key in sorted(by_date)]
+        if max_points > 0 and len(rows) > max_points:
+            rows = rows[-max_points:]
+        return rows
 
     @staticmethod
     def _order_purchase_datetime(order: Dict[str, Any]) -> Optional[datetime]:
@@ -11645,6 +11835,16 @@ class BizniWebExporter:
             "loss_product_rows": loss_product_rows_df,
             "country_rows": country_rows_df,
         }
+        current_inventory_cost_point = self._build_roy_inventory_cost_history_point(result["summary"])
+        inventory_cost_history_rows = self._merge_roy_inventory_cost_history_rows(
+            self._load_previous_roy_inventory_cost_history_rows(),
+            current_inventory_cost_point,
+        ) if current_inventory_cost_point else []
+        result["inventory_cost_history_rows"] = pd.DataFrame(
+            inventory_cost_history_rows,
+            columns=ROY_INVENTORY_COST_HISTORY_COLUMNS,
+        )
+        result["summary"]["inventory_cost_history_points"] = int(len(inventory_cost_history_rows))
         print(
             f"Roy product demand analytics complete: growing={len(growing_rows_df)}, "
             f"declining={len(declining_rows_df)}, forecasted={len(forecast_rows_df)}, "

--- a/tests/test_dashboard_modern.py
+++ b/tests/test_dashboard_modern.py
@@ -110,6 +110,71 @@ class DashboardModernTests(unittest.TestCase):
         self.assertEqual(-3.0, row["gross_profit"])
         self.assertEqual(-10.0, row["gross_margin_pct"])
 
+    def test_roy_inventory_cost_history_payload_and_chart_are_visible(self) -> None:
+        date_agg = pd.DataFrame(
+            [
+                {
+                    "date": pd.Timestamp("2026-06-18"),
+                    "total_revenue": 100.0,
+                    "net_profit": 20.0,
+                    "contribution_profit": 25.0,
+                    "unique_orders": 1,
+                    "fb_ads_spend": 0.0,
+                    "google_ads_spend": 0.0,
+                    "total_items": 1,
+                    "product_expense": 60.0,
+                    "total_cost": 80.0,
+                    "pre_ad_contribution_profit": 35.0,
+                }
+            ]
+        )
+        items_agg = pd.DataFrame([{"item_label": "Test", "total_quantity": 1, "total_revenue": 100.0}])
+        history_rows = pd.DataFrame(
+            [
+                {
+                    "date": "2026-06-17",
+                    "inventory_cost_value": 100.0,
+                    "inventory_retail_value": 180.0,
+                    "dead_stock_cost_value": 15.0,
+                },
+                {
+                    "date": "2026-06-18",
+                    "inventory_cost_value": 150.0,
+                    "inventory_retail_value": 260.0,
+                    "dead_stock_cost_value": 20.0,
+                },
+            ]
+        )
+
+        html = generate_modern_dashboard(
+            date_agg,
+            items_agg,
+            datetime(2026, 6, 18),
+            datetime(2026, 6, 18),
+            report_title="ROY inventory test",
+            advanced_dtc_metrics={
+                "roy_product_demand": {
+                    "summary": {
+                        "inventory_status": "ok",
+                        "inventory_snapshot_date": "2026-06-18",
+                        "inventory_cost_value": 150.0,
+                        "inventory_retail_value": 260.0,
+                    },
+                    "inventory_cost_history_rows": history_rows,
+                }
+            },
+            source_health={"project": "roy"},
+        )
+
+        self.assertIn("royInventoryCostValueChart", html)
+        self.assertIn("Inventory cost value trend", html)
+        payload = extract_embedded_dashboard_payload(html)
+        self.assertEqual(2, len(payload["roy_product_demand"]["inventory_cost_history_rows"]))
+        self.assertEqual(
+            150.0,
+            payload["roy_product_demand"]["inventory_cost_history_rows"][-1]["inventory_cost_value"],
+        )
+
     def test_creditnote_metrics_are_visible_in_modern_dashboard(self) -> None:
         date_agg = pd.DataFrame(
             [

--- a/tests/test_roy_inventory_model.py
+++ b/tests/test_roy_inventory_model.py
@@ -425,6 +425,65 @@ class RoyInventoryModelTests(unittest.TestCase):
         self.assertEqual("CZ", cz_row["country_label"])
         self.assertEqual("P-CZ-A", cz_row["top_products"][0]["sku"])
 
+    def test_inventory_cost_history_merges_previous_rows_by_snapshot_date(self) -> None:
+        current_point = BizniWebExporter._build_roy_inventory_cost_history_point(
+            {
+                "inventory_status": "ok",
+                "inventory_snapshot_date": "2026-06-18",
+                "inventory_cost_value": 150.456,
+                "inventory_retail_value": 300.123,
+                "inventory_available_units": 12.4,
+                "inventory_products_with_stock": 4,
+                "inventory_products_total": 5,
+                "inventory_cost_coverage_units_pct": 88.8,
+                "inventory_cost_coverage_retail_pct": 91.2,
+                "dead_stock_cost_value": 25.5,
+                "dead_stock_count": 1,
+                "stock_risk_critical_count": 2,
+                "stock_risk_30d_count": 3,
+                "stock_risk_45d_count": 4,
+                "negative_stock_count": 0,
+                "revenue_at_risk_30d": 42.42,
+                "profit_at_risk_30d": 12.34,
+            }
+        )
+
+        history_rows = BizniWebExporter._merge_roy_inventory_cost_history_rows(
+            [
+                {"date": "2026-06-17", "inventory_cost_value": 100.0, "inventory_retail_value": 180.0},
+                {"date": "2026-06-18", "inventory_cost_value": 120.0, "inventory_retail_value": 220.0},
+            ],
+            current_point,
+        )
+
+        self.assertEqual(["2026-06-17", "2026-06-18"], [row["date"] for row in history_rows])
+        self.assertEqual(150.46, history_rows[-1]["inventory_cost_value"])
+        self.assertEqual(300.12, history_rows[-1]["inventory_retail_value"])
+        self.assertEqual(25.5, history_rows[-1]["dead_stock_cost_value"])
+        self.assertEqual(3, history_rows[-1]["stock_risk_30d_count"])
+
+    def test_inventory_cost_history_seeds_from_previous_dashboard_summary(self) -> None:
+        rows = BizniWebExporter._extract_roy_inventory_cost_history_rows_from_snapshot(
+            {
+                "dashboard": {
+                    "roy_product_demand": {
+                        "summary": {
+                            "inventory_status": "ok",
+                            "inventory_snapshot_date": "2026-06-17",
+                            "inventory_cost_value": 100.0,
+                            "inventory_retail_value": 180.0,
+                            "dead_stock_cost_value": 15.0,
+                        }
+                    }
+                }
+            }
+        )
+
+        self.assertEqual(1, len(rows))
+        self.assertEqual("2026-06-17", rows[0]["date"])
+        self.assertEqual(100.0, rows[0]["inventory_cost_value"])
+        self.assertEqual(15.0, rows[0]["dead_stock_cost_value"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds ROY inventory cost history rows to the daily dashboard payload and renders a ROY inventory cost value trend chart. The history is merged from the previous stable dashboard payload in local output/S3 and deduplicated by inventory snapshot date. Verification: python -m py_compile export_orders.py dashboard_modern.py daily_report_runner.py; python -m unittest tests.test_roy_inventory_model tests.test_dashboard_modern; python -m unittest tests.test_roy_inventory_model tests.test_dashboard_modern tests.test_roy_operations_dashboard tests.test_reporting_calculation_fixes tests.test_creditnote_export tests.test_creditnote_storno_guard; git diff --check.