### PR TITLE
[codex] Raise ROY fixed monthly cost to 6500

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-06-23
+Last updated: 2026-06-24
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,20 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- ROY fixed monthly expenses are raised to `6500 EUR/month` in source-of-truth on `2026-06-24`:
+  - branch/worktree: `codex/roy-fixed-monthly-6500` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - change: `projects/roy/settings.json` now sets `fixed_monthly_cost` to `6500`
+  - change: `scripts/reporting_qa_smoke.py` now asserts ROY runtime loads `fixed_monthly_cost = 6500.0`
+  - expected runtime effect after production image refresh: ROY fixed overhead spreads as `6500 / days_in_month`, e.g. June daily fixed allocation becomes `216.67 EUR/day` before CSV rounding
+  - local verification:
+    - `python -m json.tool projects\roy\settings.json`
+    - `python -m py_compile export_orders.py scripts\reporting_qa_smoke.py reporting_core\runtime.py`
+    - `python scripts\reporting_qa_smoke.py`
+    - `python -m unittest tests.test_reporting_calculation_fixes tests.test_dashboard_modern` (`26` tests OK)
+    - `git diff --check`
+  - Current status: code change is locally verified and still needs commit, push, PR merge, ECR rebuild, and production reporting smoke before scheduled ROY reports use the new fixed expense
+  - Next exact step: commit/push this branch, merge through PR, wait for ECR, then run ROY production reporting smoke and verify localhost marker before UI smoke
 
 - VEVO live dashboard App Runner outage is fixed and deployed on `2026-06-23`:
   - symptom verified before code: VEVO App Runner public URL returned HTTP `404` for `/health`, `/production/vevo`, and `/api/production/vevo/live?refresh=1`, while ROY `/health` returned `200`

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -67,7 +67,7 @@
   ],
   "packaging_cost_per_order": 0.05,
   "shipping_net_per_order": -0.2,
-  "fixed_monthly_cost": 5500,
+  "fixed_monthly_cost": 6500,
   "invoice_generation": {
     "enabled": true,
     "lookback_days": 7,

--- a/scripts/reporting_qa_smoke.py
+++ b/scripts/reporting_qa_smoke.py
@@ -406,7 +406,7 @@ def assert_roy_fixed_cost_source_of_truth() -> None:
         default_fixed_monthly_cost=FIXED_MONTHLY_COST,
         default_fixed_daily_cost=FIXED_DAILY_COST,
     )
-    assert math.isclose(runtime.fixed_monthly_cost, 5500.0, rel_tol=1e-9, abs_tol=1e-9), runtime.to_dict()
+    assert math.isclose(runtime.fixed_monthly_cost, 6500.0, rel_tol=1e-9, abs_tol=1e-9), runtime.to_dict()
     assert math.isclose(runtime.fixed_daily_cost, 0.0, rel_tol=1e-9, abs_tol=1e-9), runtime.to_dict()
 
 


### PR DESCRIPTION
## What changed
- Raised ROY `fixed_monthly_cost` from `5500` to `6500` in `projects/roy/settings.json`.
- Updated the reporting QA smoke guard to assert the new ROY runtime fixed monthly cost.
- Recorded the change, verification, and deployment next step in `PROJECT_STATE.md`.

## Impact
Future ROY reporting runs will spread `6500 EUR/month` across each calendar month after this branch is merged and the production image is refreshed. For June, the daily fixed allocation becomes `216.67 EUR/day` before CSV rounding.

## Validation
- `python -m json.tool projects\roy\settings.json`
- `python -m py_compile export_orders.py scripts\reporting_qa_smoke.py reporting_core\runtime.py`
- `python scripts\reporting_qa_smoke.py`
- `python -m unittest tests.test_reporting_calculation_fixes tests.test_dashboard_modern` (`26` tests OK)
- `git diff --check`