### PR TITLE
Add ROY knife brand margin overrides

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-06-24
+Last updated: 2026-07-01
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,20 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- ROY knife-brand VO margin override is implemented locally on `2026-07-01`:
+  - branch/worktree: `codex/roy-knife-brand-35-margin` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - change: reporting runtime now supports generic `margin_override_brands` and `margin_override_label_patterns` percentage maps, applied before SKU cost maps and missing-cost zero-margin fallback
+  - change: `projects/roy/settings.json` sets `35%` product margin for these knife brands: Opinel, Morakniv, Walther, Kizlyar, Higonokami, Ganzo, Ruike, Helle, Cold Steel, Civivi, Victorinox, Bestech, Mikov, Boker, Joker, Kanetsune, Muela, Marttiini, Benchmade, Spyderco
+  - expected runtime effect: matching product labels use cost `65%` of net line price and source `margin_35_override`, so ROY reporting no longer treats those brands as `1 EUR`, `0 EUR`, or zero-margin fallback unless an explicit zero-cost/zero-margin exception takes precedence
+  - local verification:
+    - `python -m json.tool projects\roy\settings.json`
+    - `python -m py_compile export_orders.py reporting_core\runtime.py tests\test_reporting_calculation_fixes.py`
+    - `python -m unittest tests.test_reporting_calculation_fixes` (`23` tests OK)
+    - `python scripts\reporting_qa_smoke.py`
+    - `git diff --check`
+  - Current status: source/config/test change is ready on the task branch; it is not yet deployed to the scheduled ROY reporting runtime
+  - Next exact step: commit and push the branch, merge through PR to `main`, rebuild/reporting image, run ROY production reporting smoke with task image update, then rerun/backfill ROY stable latest artifacts so historical dashboard/report values use the 35% knife-brand margin
 
 - VEVO daily reporting email outage from `2026-06-27` is fixed on `2026-06-29`:
   - symptom: VEVO daily emails stopped after the last successful scheduled runs on `2026-06-25 01:00 Europe/Bratislava` and `2026-06-26 01:00 Europe/Bratislava`; ROY continued sending daily SES emails on `2026-06-27`, `2026-06-28`, and `2026-06-29`

--- a/export_orders.py
+++ b/export_orders.py
@@ -113,6 +113,8 @@ PRODUCT_NAME_ALIASES: Dict[str, str] = {}  # Optional project-scoped aliases for
 ZERO_MARGIN_BRANDS: List[str] = []  # Optional list of brands that should always run at 0 product margin
 ZERO_COST_BRANDS: List[str] = []  # Optional list of brands that should always run at 0 product cost
 ZERO_COST_LABEL_PATTERNS: List[str] = []  # Optional label patterns forced to 0 product cost
+MARGIN_OVERRIDE_BRANDS: Dict[str, float] = {}  # Optional brand -> product margin percent override
+MARGIN_OVERRIDE_LABEL_PATTERNS: Dict[str, float] = {}  # Optional label pattern -> product margin percent override
 MARGIN_15_BRANDS: List[str] = []  # Optional brands forced to 15% product margin
 MARGIN_15_LABEL_PATTERNS: List[str] = []  # Optional label patterns forced to 15% product margin
 EXCLUDE_ZERO_PRICE_LABEL_PATTERNS: List[str] = []  # Optional label patterns excluded only when line price is 0
@@ -2922,6 +2924,26 @@ class BizniWebExporter:
                 return True
         return False
 
+    @classmethod
+    def _margin_override_pct_for_label(cls, label: str) -> Optional[float]:
+        if not label:
+            return None
+        normalized_label = cls._normalize_match_text(label)
+        for pattern, margin_pct in MARGIN_OVERRIDE_BRANDS.items():
+            normalized_pattern = cls._normalize_match_text(pattern)
+            if normalized_pattern and normalized_pattern in normalized_label:
+                return float(margin_pct)
+        for pattern, margin_pct in MARGIN_OVERRIDE_LABEL_PATTERNS.items():
+            normalized_pattern = cls._normalize_match_text(pattern)
+            if normalized_pattern and normalized_pattern in normalized_label:
+                return float(margin_pct)
+        return None
+
+    @staticmethod
+    def _margin_override_source(margin_pct: float) -> str:
+        token = f"{float(margin_pct):g}".replace(".", "_")
+        return f"margin_{token}_override"
+
     def _bundle_accessory_config(self) -> Dict[str, Any]:
         config = self.project_settings.get("bundle_accessory_model") or {}
         return config if isinstance(config, dict) else {}
@@ -5177,10 +5199,11 @@ class BizniWebExporter:
                 ):
                     continue
 
-                # Force 0 cost for configured brands, then optional 0 margin brands, otherwise use configured costs.
+                # Apply explicit cost overrides before falling back to configured product cost maps.
                 force_zero_cost = False
                 force_zero_margin = False
                 force_margin_15 = False
+                margin_override_pct = self._margin_override_pct_for_label(item_label)
                 if (ZERO_COST_BRANDS or ZERO_MARGIN_BRANDS or MARGIN_15_BRANDS) and item_label:
                     label_lc = str(item_label).lower()
                     force_zero_cost = any(brand in label_lc for brand in ZERO_COST_BRANDS)
@@ -5196,6 +5219,9 @@ class BizniWebExporter:
                 elif force_zero_margin and item_quantity:
                     expense_per_item = item_total_without_tax / item_quantity
                     expense_source = "zero_margin_override"
+                elif margin_override_pct is not None and item_quantity:
+                    expense_per_item = (item_total_without_tax / item_quantity) * (1 - margin_override_pct / 100)
+                    expense_source = self._margin_override_source(margin_override_pct)
                 elif force_margin_15 and item_quantity:
                     # Keep product margin at 15%: cost = 85% of net unit selling price.
                     expense_per_item = (item_total_without_tax / item_quantity) * 0.85

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -468,6 +468,28 @@
   "exclude_zero_price_label_patterns": [
     "Roy Hunter Knife 11004"
   ],
+  "margin_override_brands": {
+    "Opinel": 35,
+    "Morakniv": 35,
+    "Walther": 35,
+    "Kizlyar": 35,
+    "Higonokami": 35,
+    "Ganzo": 35,
+    "Ruike": 35,
+    "Helle": 35,
+    "Cold Steel": 35,
+    "Civivi": 35,
+    "Victorinox": 35,
+    "Bestech": 35,
+    "Mikov": 35,
+    "Boker": 35,
+    "Joker": 35,
+    "Kanetsune": 35,
+    "Muela": 35,
+    "Marttiini": 35,
+    "Benchmade": 35,
+    "Spyderco": 35
+  },
   "margin_15_brands": [
     "Pixfra",
     "Pard"

--- a/reporting_core/runtime.py
+++ b/reporting_core/runtime.py
@@ -32,6 +32,8 @@ class ProjectRuntime:
     zero_margin_brands: List[str]
     zero_cost_brands: List[str]
     zero_cost_label_patterns: List[str]
+    margin_override_brands: Dict[str, float]
+    margin_override_label_patterns: Dict[str, float]
     margin_15_brands: List[str]
     margin_15_label_patterns: List[str]
     exclude_zero_price_label_patterns: List[str]
@@ -69,6 +71,8 @@ class ProjectRuntime:
             "zero_margin_brands": list(self.zero_margin_brands),
             "zero_cost_brands": list(self.zero_cost_brands),
             "zero_cost_label_patterns": list(self.zero_cost_label_patterns),
+            "margin_override_brands": dict(self.margin_override_brands),
+            "margin_override_label_patterns": dict(self.margin_override_label_patterns),
             "margin_15_brands": list(self.margin_15_brands),
             "margin_15_label_patterns": list(self.margin_15_label_patterns),
             "exclude_zero_price_label_patterns": list(self.exclude_zero_price_label_patterns),
@@ -79,6 +83,25 @@ class ProjectRuntime:
             "weather": copy.deepcopy(self.weather),
             "reporting_defaults": dict(self.reporting_defaults),
         }
+
+
+def _coerce_margin_override_map(raw: Any) -> Dict[str, float]:
+    if not raw:
+        return {}
+
+    items = raw.items() if isinstance(raw, dict) else []
+    result: Dict[str, float] = {}
+    for key, value in items:
+        key_text = str(key or "").strip()
+        if not key_text:
+            continue
+        try:
+            margin_pct = float(str(value).strip().rstrip("%"))
+        except (TypeError, ValueError):
+            continue
+        if 0.0 <= margin_pct < 100.0:
+            result[key_text] = margin_pct
+    return result
 
 
 def load_project_runtime(
@@ -156,6 +179,8 @@ def load_project_runtime(
         zero_margin_brands=[str(v).strip() for v in settings.get("zero_margin_brands", []) if str(v).strip()],
         zero_cost_brands=[str(v).strip() for v in settings.get("zero_cost_brands", []) if str(v).strip()],
         zero_cost_label_patterns=[str(v).strip() for v in settings.get("zero_cost_label_patterns", []) if str(v).strip()],
+        margin_override_brands=_coerce_margin_override_map(settings.get("margin_override_brands", {})),
+        margin_override_label_patterns=_coerce_margin_override_map(settings.get("margin_override_label_patterns", {})),
         margin_15_brands=[str(v).strip() for v in settings.get("margin_15_brands", []) if str(v).strip()],
         margin_15_label_patterns=[str(v).strip() for v in settings.get("margin_15_label_patterns", []) if str(v).strip()],
         exclude_zero_price_label_patterns=[
@@ -194,6 +219,8 @@ def apply_project_runtime(runtime: ProjectRuntime, target_globals: Dict[str, Any
     target_globals["ZERO_MARGIN_BRANDS"] = [str(v).strip().lower() for v in runtime.zero_margin_brands if str(v).strip()]
     target_globals["ZERO_COST_BRANDS"] = [str(v).strip().lower() for v in runtime.zero_cost_brands if str(v).strip()]
     target_globals["ZERO_COST_LABEL_PATTERNS"] = [str(v).strip() for v in runtime.zero_cost_label_patterns if str(v).strip()]
+    target_globals["MARGIN_OVERRIDE_BRANDS"] = dict(runtime.margin_override_brands)
+    target_globals["MARGIN_OVERRIDE_LABEL_PATTERNS"] = dict(runtime.margin_override_label_patterns)
     target_globals["MARGIN_15_BRANDS"] = [str(v).strip().lower() for v in runtime.margin_15_brands if str(v).strip()]
     target_globals["MARGIN_15_LABEL_PATTERNS"] = [str(v).strip() for v in runtime.margin_15_label_patterns if str(v).strip()]
     target_globals["EXCLUDE_ZERO_PRICE_LABEL_PATTERNS"] = [

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from export_orders import ORDER_CACHE_SCHEMA_VERSION, BizniWebExporter
 from reporting_core.cfo_kpis import build_order_records_from_export_df
+from reporting_core.runtime import load_project_runtime
 
 
 def make_exporter(project_name: str = "vevo") -> BizniWebExporter:
@@ -89,6 +90,76 @@ class ReportingCalculationFixTests(unittest.TestCase):
         self.assertEqual(50.0, rows[0]["expense_per_item"])
         self.assertEqual(100.0, rows[0]["total_expense"])
         self.assertEqual(0.0, rows[0]["profit_before_ads"])
+
+    def test_margin_override_brand_forces_configured_product_margin(self) -> None:
+        exporter = make_exporter(project_name="roy")
+
+        with patch("export_orders.MARGIN_OVERRIDE_BRANDS", {"Ganzo": 35.0}), patch(
+            "export_orders.MARGIN_OVERRIDE_LABEL_PATTERNS", {}
+        ):
+            rows = exporter.flatten_order(
+                {
+                    "id": "1",
+                    "order_num": "R-1",
+                    "pur_date": "2026-04-20 10:00:00",
+                    "sum": {"value": 123.0, "currency": {"code": "EUR"}},
+                    "customer": {"email": "a@example.com"},
+                    "items": [
+                        {
+                            "item_label": "Noz Ganzo G7211-BK",
+                            "ean": "",
+                            "quantity": 1,
+                            "tax_rate": 23,
+                            "price": {"value": 100.0, "currency": {"code": "EUR"}},
+                            "sum": {"value": 100.0, "currency": {"code": "EUR"}},
+                            "sum_with_tax": {"value": 123.0, "currency": {"code": "EUR"}},
+                        }
+                    ],
+                }
+            )
+
+        self.assertEqual("margin_35_override", rows[0]["expense_source"])
+        self.assertEqual(65.0, rows[0]["expense_per_item"])
+        self.assertEqual(65.0, rows[0]["total_expense"])
+        self.assertEqual(35.0, rows[0]["profit_before_ads"])
+
+    def test_roy_knife_brand_margin_overrides_cover_requested_brands(self) -> None:
+        expected_brands = [
+            "Opinel",
+            "Morakniv",
+            "Walther",
+            "Kizlyar",
+            "Higonokami",
+            "Ganzo",
+            "Ruike",
+            "Helle",
+            "Cold Steel",
+            "Civivi",
+            "Victorinox",
+            "Bestech",
+            "Mikov",
+            "Boker",
+            "Joker",
+            "Kanetsune",
+            "Muela",
+            "Marttiini",
+            "Benchmade",
+            "Spyderco",
+        ]
+        settings_path = Path(__file__).resolve().parents[1] / "projects" / "roy" / "settings.json"
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        runtime = load_project_runtime(
+            "roy",
+            settings=settings,
+            default_packaging_cost_per_order=0.0,
+            default_shipping_subsidy_per_order=0.0,
+            default_fixed_monthly_cost=0.0,
+            default_fixed_daily_cost=0.0,
+        )
+
+        for brand in expected_brands:
+            with self.subTest(brand=brand):
+                self.assertEqual(35.0, runtime.margin_override_brands[brand])
 
     def test_zero_revenue_order_allocates_item_level_overhead(self) -> None:
         exporter = make_exporter()


### PR DESCRIPTION
## Summary
- add generic margin override maps to the reporting runtime
- configure ROY knife brands from the provided category list at 35% product margin
- add tests for the override calculation and ROY brand coverage

## Verification
- python -m json.tool projects\roy\settings.json
- python -m py_compile export_orders.py reporting_core\runtime.py tests\test_reporting_calculation_fixes.py
- python -m unittest tests.test_reporting_calculation_fixes
- python scripts\reporting_qa_smoke.py
- python -m unittest tests.test_reporting_calculation_fixes tests.test_roy_inventory_model tests.test_dashboard_modern
- git diff --check