### PR TITLE
[codex] Fix ROY picking PDF print confirmation flow

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-07-01
+Last updated: 2026-07-07
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,19 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- ROY picking-list print confirmation fix is implemented locally on `2026-07-07`:
+  - branch/worktree: `codex/roy-picking-print-confirmation` in `C:\Users\Patrik jankech\Desktop\biznisweb-creditnote-carrier-audit`
+  - live symptom: ROY live dashboard still showed active orders from `2026-07-06`, but the normal picking-list PDF flow skipped them while newer `2026-07-07` orders could still be printed
+  - live root cause evidence: `s3://biznisweb-reporting-artifacts-919341186960-eu-central-1/daily-reports/roy-sk/operations/state.json` already contained active `2026-07-06` orders in `printed_picking_orders`, including batch `picking-20260707062639`; therefore the normal PDF endpoint filtered those orders out
+  - code root cause: `GET /api/operations/roy/picking-lists.pdf` generated the PDF and immediately called `mark_picking_orders_printed()` before the browser/user could prove that the download or physical print succeeded
+  - change: picking-list PDF GET is now read-only; it defaults to currently unprinted active orders and can still render all active orders for preview with `preview=1`/`include_printed=1`
+  - change: a separate explicit `POST /api/operations/roy/picking-lists/printed` marks only the submitted order numbers as printed
+  - change: `/api/operations/roy/live` annotates active orders with `picking_printed`, `picking_printed_at`, and print summary counts, and the ROY dashboard shows the print state plus separate `Vysklad. PDF` and `Označiť vytlačené` controls
+  - local verification:
+    - `python -m py_compile live_dashboard_server.py roy_operations_dashboard.py`
+    - `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile` (`37` tests OK)
+  - Next exact step: run `git diff --check`, push branch, merge through PR, deploy `biznisweb-roy-operations-dashboard`, remove the erroneous active `2026-07-06` printed flags from remote operations state, then verify PDF/API/UI on the live App Runner service
 
 - ROY recent zero-margin product SKU override is deployed and stable latest artifacts were regenerated on `2026-07-01`:
   - source audit: ROY stable export `s3://biznisweb-reporting-artifacts-919341186960-eu-central-1/daily-reports/roy-sk/20260701T083224Z/export_20250924-20260630.csv` showed `70` product labels / `66` unique SKUs with `missing_cost_zero_margin_fallback` in `2026-04-01..2026-06-30`

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -18,7 +18,6 @@ from production_board import get_cached_production_board_snapshot, resolve_produ
 from roy_operations_dashboard import (
     acknowledge_loss_product,
     clear_inbound_stock_order,
-    filter_unprinted_picking_orders,
     get_cached_roy_operations_snapshot,
     load_roy_operations_state,
     mark_picking_orders_printed,
@@ -26,6 +25,7 @@ from roy_operations_dashboard import (
     mark_personal_pickup_shipped,
     resolve_roy_operations_settings,
     save_roy_operations_state,
+    select_picking_orders_for_print,
     set_inbound_stock_order,
 )
 from roy_picking_lists_pdf import build_roy_picking_lists_filename, build_roy_picking_lists_pdf
@@ -1045,7 +1045,8 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       </div>
       <div class="actions">
         <button id="soundToggleBtn" class="sound" type="button" aria-pressed="false">Zvuk vyp.</button>
-        <a class="button" href="/api/operations/roy/picking-lists.pdf?refresh=1">Vysklad. PDF</a>
+        <a id="pickingPdfLink" class="button" href="/api/operations/roy/picking-lists.pdf?refresh=1" target="_blank" rel="noopener">Vysklad. PDF</a>
+        <button id="markPickingPrintedBtn" type="button">Označiť vytlačené</button>
         <button id="refreshBtn" class="primary" type="button">Refresh</button>
         <a class="button" href="/">Dashboardy</a>
       </div>
@@ -1084,7 +1085,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
           </div>
           <div class="table-wrap">
             <table>
-              <thead><tr><th>Objednávka</th><th>Status</th><th>Platba</th><th>Doprava</th><th>Suma</th><th>Položky</th></tr></thead>
+              <thead><tr><th>Objednávka</th><th>Status</th><th>Tlač</th><th>Platba</th><th>Doprava</th><th>Suma</th><th>Položky</th></tr></thead>
               <tbody id="ordersBody"></tbody>
             </table>
           </div>
@@ -1191,7 +1192,7 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         <div class="panel-head"><h2>Všetky vybaviteľné objednávky</h2><p id="ordersScanMeta">-</p></div>
         <div class="table-wrap">
           <table>
-            <thead><tr><th>Objednávka</th><th>Dátum</th><th>Status</th><th>Platba</th><th>Doprava</th><th>Suma</th><th>Položky</th></tr></thead>
+            <thead><tr><th>Objednávka</th><th>Dátum</th><th>Status</th><th>Tlač</th><th>Platba</th><th>Doprava</th><th>Suma</th><th>Položky</th></tr></thead>
             <tbody id="ordersFullBody"></tbody>
           </table>
         </div>
@@ -1503,10 +1504,36 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       if (!items.length) return '<span class="muted">bez položiek</span>';
       return `<div class="items">${items.slice(0, 6).map((item) => `<div class="item-line"><span>${safe(item.label)}</span><strong>${fmtQty(item.quantity)} ks</strong></div>`).join('')}${items.length > 6 ? `<div class="muted">+${fmtInt(items.length - 6)} ďalších</div>` : ''}</div>`;
     }
+    function currentUnprintedPickingOrderNums() {
+      return ((((latestData || {}).orders || {}).orders) || [])
+        .filter((order) => !order.picking_printed)
+        .map((order) => String(order.order_num || order.id || '').trim())
+        .filter(Boolean);
+    }
+    function updatePickingControls() {
+      const orderNums = currentUnprintedPickingOrderNums();
+      const pdfUrl = new URL(`/api/operations/${encodeURIComponent(project)}/picking-lists.pdf`, window.location.origin);
+      pdfUrl.searchParams.set('refresh', '1');
+      orderNums.forEach((orderNum) => pdfUrl.searchParams.append('order_num', orderNum));
+      const link = el('pickingPdfLink');
+      const markButton = el('markPickingPrintedBtn');
+      link.href = `${pdfUrl.pathname}${pdfUrl.search}`;
+      link.textContent = `Vysklad. PDF (${fmtInt(orderNums.length)})`;
+      link.classList.toggle('disabled', !orderNums.length);
+      link.setAttribute('aria-disabled', orderNums.length ? 'false' : 'true');
+      markButton.disabled = !orderNums.length;
+      markButton.textContent = `Označiť vytlačené (${fmtInt(orderNums.length)})`;
+    }
+    function pickingPrintBadge(order) {
+      if (!order.picking_printed) return '<span class="badge good">nové</span>';
+      const printedAt = text(order.picking_printed_at, '');
+      return `<span class="badge warn">vytlačené</span>${printedAt ? `<div class="muted">${safe(printedAt)}</div>` : ''}`;
+    }
     function orderRow(order, includeDate=false) {
       return `<tr>
         <td><strong class="mono">${safe(order.order_num)}</strong>${includeDate ? `<div class="muted">${safe(order.purchase_at)}</div>` : ''}</td>
         <td><span class="badge ${order.fulfillment_reason === 'paid_online' ? 'good' : 'warn'}">${safe(order.status)}</span></td>
+        <td>${pickingPrintBadge(order)}</td>
         <td>${safe((order.payment || {}).title)}</td>
         <td>${safe((order.shipping || {}).title)}</td>
         <td>${safe(order.sum)}</td>
@@ -1517,11 +1544,13 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       const ordersPayload = data.orders || {};
       const orders = ordersPayload.orders || [];
       const scan = ordersPayload.scan || {};
-      el('ordersMeta').textContent = `${fmtInt(orders.length)} objednávok · hodnota ${fmtMoney((ordersPayload.summary || {}).fulfillable_value)}`;
+      const summary = ordersPayload.summary || {};
+      el('ordersMeta').textContent = `${fmtInt(orders.length)} objednávok · ${fmtInt(summary.picking_unprinted_orders)} nevytlačených · hodnota ${fmtMoney(summary.fulfillable_value)}`;
       el('ordersScanMeta').textContent = `${fmtInt(scan.orders_scanned)} skenovaných objednávok, ${fmtInt(scan.pages_scanned)} strán, stop=${text(scan.stop_reason)}`;
       const limited = orders.slice(0, 24);
-      el('ordersBody').innerHTML = limited.length ? limited.map((order) => orderRow(order)).join('') : '<tr><td colspan="6" class="muted">Žiadne vybaviteľné objednávky.</td></tr>';
-      el('ordersFullBody').innerHTML = orders.length ? orders.map((order) => orderRow(order, true)).join('') : '<tr><td colspan="7" class="muted">Žiadne vybaviteľné objednávky.</td></tr>';
+      el('ordersBody').innerHTML = limited.length ? limited.map((order) => orderRow(order)).join('') : '<tr><td colspan="7" class="muted">Žiadne vybaviteľné objednávky.</td></tr>';
+      el('ordersFullBody').innerHTML = orders.length ? orders.map((order) => orderRow(order, true)).join('') : '<tr><td colspan="8" class="muted">Žiadne vybaviteľné objednávky.</td></tr>';
+      updatePickingControls();
     }
     function renderPickups(data) {
       const pickups = ((data.orders || {}).personal_pickups) || [];
@@ -1801,6 +1830,32 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
         button.disabled = false;
       }
     }
+    async function markPickingPrinted() {
+      const orderNums = currentUnprintedPickingOrderNums();
+      if (!orderNums.length) {
+        showMessage('Nie sú žiadne nevytlačené objednávky na označenie.', true);
+        return;
+      }
+      if (!window.confirm(`Označiť ${orderNums.length} objednávok z posledného PDF ako vytlačené?`)) return;
+      const button = el('markPickingPrintedBtn');
+      button.disabled = true;
+      try {
+        const response = await fetchApi(`/api/operations/${encodeURIComponent(project)}/picking-lists/printed`, {
+          method:'POST',
+          cache:'no-store',
+          headers:{ 'Content-Type':'application/json' },
+          body: JSON.stringify({ order_nums: orderNums }),
+        });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        showMessage(`Označené ako vytlačené: ${fmtInt((data.batch || {}).order_count)} objednávok.`, true);
+        await loadDashboard(true);
+      } catch (error) {
+        showMessage(error instanceof Error ? error.message : String(error));
+      } finally {
+        button.disabled = false;
+      }
+    }
     async function acknowledgeLossProduct(input) {
       const sku = input.dataset.ackLoss;
       input.disabled = true;
@@ -1822,6 +1877,13 @@ def build_roy_operations_dashboard_html(project: str = "roy") -> str:
       }
     }
     el('refreshBtn').addEventListener('click', () => loadDashboard(true));
+    el('markPickingPrintedBtn').addEventListener('click', () => markPickingPrinted());
+    el('pickingPdfLink').addEventListener('click', (event) => {
+      if (!currentUnprintedPickingOrderNums().length) {
+        event.preventDefault();
+        showMessage('Nie sú žiadne nevytlačené objednávky na PDF.', true);
+      }
+    });
     initializeOrderSound();
     document.querySelectorAll('[data-view]').forEach((button) => button.addEventListener('click', () => {
       document.querySelectorAll('[data-view]').forEach((btn) => btn.classList.toggle('active', btn === button));
@@ -1979,7 +2041,16 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 )
                 return
             force_refresh = (query.get("refresh", ["1"])[0] or "").strip().lower() not in {"0", "false", "no"}
-            preview_only = (query.get("preview", [""])[0] or "").strip().lower() in {"1", "true", "yes"}
+            include_printed = (
+                (query.get("preview", [""])[0] or "").strip().lower() in {"1", "true", "yes"}
+                or (query.get("include_printed", [""])[0] or "").strip().lower() in {"1", "true", "yes"}
+            )
+            requested_order_nums = [
+                value.strip()
+                for raw in query.get("order_num", []) + query.get("order_nums", [])
+                for value in str(raw).replace(",", " ").split()
+                if value.strip()
+            ]
             try:
                 payload = get_cached_roy_operations_snapshot(
                     project,
@@ -1990,14 +2061,16 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
                 operations_state = load_roy_operations_state(
                     project,
                     project_settings,
-                    require_configured_remote=not preview_only,
+                    require_configured_remote=not include_printed,
                 )
-                orders = list(all_orders) if preview_only else filter_unprinted_picking_orders(all_orders, operations_state)
+                orders = select_picking_orders_for_print(
+                    all_orders,
+                    operations_state,
+                    order_nums=requested_order_nums or None,
+                    include_printed=include_printed,
+                )
                 pdf = build_roy_picking_lists_pdf(orders)
                 filename = build_roy_picking_lists_filename(orders)
-                if orders and not preview_only:
-                    mark_picking_orders_printed(operations_state, orders)
-                    save_roy_operations_state(project, operations_state, project_settings)
                 self._send_download(pdf, content_type="application/pdf", filename=filename)
             except Exception as exc:
                 self._send_text(
@@ -2122,6 +2195,46 @@ class LiveDashboardHandler(BaseHTTPRequestHandler):
 
         projects = available_projects()
         parts = [part for part in path.split("/") if part]
+        if (
+            len(parts) == 5
+            and parts[0] == "api"
+            and parts[1] == "operations"
+            and parts[3] == "picking-lists"
+            and parts[4] == "printed"
+        ):
+            project = parts[2]
+            if project not in projects:
+                self._send_json({"error": f"Unknown project '{project}'."}, status=404)
+                return
+            if project != "roy":
+                self._send_json({"error": f"Picking-list printing is not enabled for '{project}'."}, status=404)
+                return
+            try:
+                body = self._read_json_body()
+                requested_order_nums = body.get("order_nums")
+                if not isinstance(requested_order_nums, list) or not requested_order_nums:
+                    raise ValueError("order_nums must contain at least one order number.")
+                project_settings = load_project_settings(project)
+                payload = get_cached_roy_operations_snapshot(
+                    project,
+                    report_payload=read_latest_dashboard_payload(project),
+                    force_refresh=False,
+                )
+                all_orders = ((payload.get("orders") or {}).get("orders") or [])
+                operations_state = load_roy_operations_state(project, project_settings, require_configured_remote=True)
+                orders = select_picking_orders_for_print(
+                    all_orders,
+                    operations_state,
+                    order_nums=requested_order_nums,
+                    include_printed=False,
+                )
+                batch = mark_picking_orders_printed(operations_state, orders)
+                storage = save_roy_operations_state(project, operations_state, project_settings)
+                self._send_json({"ok": True, "project": project, "batch": batch, "storage": storage})
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=400)
+            return
+
         if (
             len(parts) == 6
             and parts[0] == "api"

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -432,6 +432,55 @@ def filter_unprinted_picking_orders(
     return result
 
 
+def select_picking_orders_for_print(
+    orders: Iterable[Dict[str, Any]],
+    state: Optional[Dict[str, Any]],
+    *,
+    order_nums: Optional[Iterable[Any]] = None,
+    include_printed: bool = False,
+) -> List[Dict[str, Any]]:
+    selected_keys = None
+    if order_nums is not None:
+        selected_keys = {str(value).strip() for value in order_nums if str(value).strip()}
+
+    selected: List[Dict[str, Any]] = []
+    for order in orders:
+        key = _picking_order_key(order)
+        if selected_keys is not None and key not in selected_keys:
+            continue
+        selected.append(order)
+    if include_printed:
+        return selected
+    return filter_unprinted_picking_orders(selected, state)
+
+
+def annotate_picking_print_state(order_snapshot: Dict[str, Any], state: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    printed = (state or {}).get("printed_picking_orders")
+    printed_records = printed if isinstance(printed, dict) else {}
+    active_printed_count = 0
+    for order in order_snapshot.get("orders") or []:
+        if not isinstance(order, dict):
+            continue
+        key = _picking_order_key(order)
+        record = printed_records.get(key) if key else None
+        if isinstance(record, dict):
+            order["picking_printed"] = True
+            order["picking_printed_at"] = str(record.get("printed_at") or "").strip()
+            order["picking_print_batch_id"] = str(record.get("batch_id") or "").strip()
+            active_printed_count += 1
+        else:
+            order["picking_printed"] = False
+            order["picking_printed_at"] = ""
+            order["picking_print_batch_id"] = ""
+
+    summary = order_snapshot.setdefault("summary", {})
+    if isinstance(summary, dict):
+        total = len([order for order in order_snapshot.get("orders") or [] if isinstance(order, dict)])
+        summary["picking_printed_orders"] = active_printed_count
+        summary["picking_unprinted_orders"] = max(total - active_printed_count, 0)
+    return order_snapshot
+
+
 def mark_picking_orders_printed(
     state: Dict[str, Any],
     orders: Iterable[Dict[str, Any]],
@@ -2304,6 +2353,7 @@ def generate_roy_operations_snapshot(project: str, report_payload: Optional[Dict
     order_snapshot = build_roy_orders_snapshot(project=project, orders=orders, settings=settings, scan=scan)
     payload = report_payload or {}
     operations_state = load_roy_operations_state(project, project_settings)
+    annotate_picking_print_state(order_snapshot, operations_state)
     base_inventory, _ = build_inventory_snapshot(payload, project_settings=project_settings)
     try:
         current_stock_by_sku, live_stock_diagnostics = fetch_current_stock_for_inventory_alerts(

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -11,6 +11,7 @@ from live_dashboard_server import build_roy_operations_dashboard_html
 import roy_operations_dashboard as rod
 from roy_operations_dashboard import (
     _select_current_stock_for_target,
+    annotate_picking_print_state,
     build_executive_kpi_snapshot,
     build_commercial_snapshot,
     build_inventory_snapshot,
@@ -20,6 +21,7 @@ from roy_operations_dashboard import (
     mark_personal_pickup_ready,
     mark_personal_pickup_shipped,
     resolve_roy_operations_settings,
+    select_picking_orders_for_print,
 )
 
 
@@ -536,6 +538,51 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         unprinted = filter_unprinted_picking_orders(orders, state)
 
         self.assertEqual(["R-3"], [row["order_num"] for row in unprinted])
+
+    def test_picking_pdf_selection_is_read_only_until_explicit_print_mark(self) -> None:
+        orders = [{"order_num": "R-1"}, {"order_num": "R-2"}, {"order_num": "R-3"}]
+        state = {
+            "version": 1,
+            "printed_picking_orders": {
+                "R-1": {"order_num": "R-1", "printed_at": "2026-05-28T10:00:00Z"},
+            },
+        }
+
+        selected = select_picking_orders_for_print(orders, state, order_nums=["R-1", "R-2", "R-3"])
+
+        self.assertEqual(["R-2", "R-3"], [row["order_num"] for row in selected])
+        self.assertEqual({"R-1"}, set(state["printed_picking_orders"]))
+
+    def test_operations_snapshot_marks_active_printed_orders(self) -> None:
+        order_snapshot = {
+            "orders": [{"order_num": "R-1"}, {"order_num": "R-2"}],
+            "summary": {},
+        }
+        state = {
+            "version": 1,
+            "printed_picking_orders": {
+                "R-1": {
+                    "order_num": "R-1",
+                    "printed_at": "2026-05-28T10:00:00Z",
+                    "batch_id": "picking-20260528100000",
+                },
+            },
+        }
+
+        annotate_picking_print_state(order_snapshot, state)
+
+        self.assertTrue(order_snapshot["orders"][0]["picking_printed"])
+        self.assertEqual("2026-05-28T10:00:00Z", order_snapshot["orders"][0]["picking_printed_at"])
+        self.assertFalse(order_snapshot["orders"][1]["picking_printed"])
+        self.assertEqual(1, order_snapshot["summary"]["picking_printed_orders"])
+        self.assertEqual(1, order_snapshot["summary"]["picking_unprinted_orders"])
+
+    def test_operations_dashboard_has_explicit_print_confirmation_action(self) -> None:
+        html = build_roy_operations_dashboard_html("roy")
+
+        self.assertIn("/api/operations/roy/picking-lists.pdf", html)
+        self.assertIn("/api/operations/${encodeURIComponent(project)}/picking-lists/printed", html)
+        self.assertIn("Označiť vytlačené", html)
 
     def test_snapshot_expands_bundle_order_items_to_pickable_components(self) -> None:
         project_settings = json.loads((ROOT_DIR / "projects" / "roy" / "settings.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## What changed
- Makes `GET /api/operations/roy/picking-lists.pdf` read-only, so opening/downloading the PDF no longer marks orders as printed.
- Adds explicit `POST /api/operations/roy/picking-lists/printed` to mark only submitted order numbers as printed after confirmation.
- Adds per-order `picking_printed` metadata to the ROY operations payload and shows print state in the dashboard.
- Adds regression tests for read-only PDF selection, printed-state annotation, and the explicit dashboard confirmation action.

## Root cause
The live ROY dashboard PDF endpoint generated the picking-list PDF and immediately called `mark_picking_orders_printed()` during the GET request. If the browser download or physical print failed, active orders were still stored in `operations/state.json` under `printed_picking_orders`, so future normal PDFs filtered those orders out. This matched the live issue: active `2026-07-06` orders were already marked printed in the S3 operations state while newer `2026-07-07` orders remained printable.

## Validation
- `python -m py_compile live_dashboard_server.py roy_operations_dashboard.py`
- `python -m unittest tests.test_roy_operations_dashboard tests.test_roy_picking_lists_pdf tests.test_live_dashboard_auth tests.test_live_dashboard_mobile` (37 tests OK)
- `git diff --check`

## Follow-up after merge
- Deploy the ROY App Runner dashboard.
- Remove the erroneous active `2026-07-06` printed flags from remote ROY operations state.
- Verify `/health`, `/api/operations/roy/live`, picking-list PDF generation, and browser UI on the live App Runner URL.