### PR TITLE
Protect reporting schedule image digests

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -76,6 +76,100 @@ jobs:
             --output text)"
           IMAGE_IDENTIFIER="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}@${IMAGE_DIGEST}"
 
+          protect_ecr_image_tag() {
+            local image_identifier="$1"
+            local protection_tag="$2"
+            if [[ "${image_identifier}" != *@sha256:* ]]; then
+              echo "Skipping ${protection_tag}; image is not digest-pinned: ${image_identifier}"
+              return 0
+            fi
+            local image_digest="${image_identifier##*@}"
+            local existing_digest
+            existing_digest="$(aws ecr describe-images \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-ids imageTag="${protection_tag}" \
+              --region "${AWS_REGION}" \
+              --query 'imageDetails[0].imageDigest' \
+              --output text 2>/dev/null || true)"
+            if [[ "${existing_digest}" == "${image_digest}" ]]; then
+              echo "ECR_IMAGE_PROTECTED:${protection_tag}:${image_digest}:already"
+              return 0
+            fi
+            local manifest_file
+            manifest_file="$(mktemp)"
+            aws ecr batch-get-image \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-ids imageDigest="${image_digest}" \
+              --region "${AWS_REGION}" \
+              --query 'images[0].imageManifest' \
+              --output text > "${manifest_file}"
+            python -m json.tool "${manifest_file}" >/dev/null
+            aws ecr put-image \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-tag "${protection_tag}" \
+              --image-manifest "file://${manifest_file}" \
+              --region "${AWS_REGION}" >/dev/null
+            rm -f "${manifest_file}"
+            echo "ECR_IMAGE_PROTECTED:${protection_tag}:${image_digest}:updated"
+          }
+
+          protect_current_daily_schedule_image() {
+            local report_project="$1"
+            local schedule_name
+            local expected_task_family
+            schedule_name="$(python - "${report_project}" <<'PY'
+          import json
+          import pathlib
+          import sys
+          project = sys.argv[1]
+          settings = json.loads((pathlib.Path("projects") / project / "settings.json").read_text(encoding="utf-8"))
+          print(settings["report_schedule"]["schedule_name"])
+          PY
+            )"
+            expected_task_family="$(python - "${report_project}" <<'PY'
+          import json
+          import pathlib
+          import sys
+          project = sys.argv[1]
+          settings = json.loads((pathlib.Path("projects") / project / "settings.json").read_text(encoding="utf-8"))
+          print(settings["report_schedule"]["task_family"])
+          PY
+            )"
+            aws scheduler get-schedule \
+              --name "${schedule_name}" \
+              --region "${AWS_REGION}" > "schedule-${report_project}.json"
+            local task_definition_arn
+            task_definition_arn="$(python - "${report_project}" <<'PY'
+          import json
+          import sys
+          project = sys.argv[1]
+          schedule = json.load(open(f"schedule-{project}.json", encoding="utf-8"))
+          print(schedule["Target"]["EcsParameters"]["TaskDefinitionArn"])
+          PY
+            )"
+            if [[ "${task_definition_arn}" != *":task-definition/${expected_task_family}:"* ]]; then
+              echo "Schedule ${schedule_name} targets ${task_definition_arn}, expected family ${expected_task_family}" >&2
+              exit 1
+            fi
+            aws ecs describe-task-definition \
+              --task-definition "${task_definition_arn}" \
+              --region "${AWS_REGION}" > "task-definition-${report_project}.json"
+            local task_image
+            task_image="$(python - "${report_project}" <<'PY'
+          import json
+          import sys
+          project = sys.argv[1]
+          task_def = json.load(open(f"task-definition-{project}.json", encoding="utf-8"))["taskDefinition"]
+          print(task_def["containerDefinitions"][0].get("image") or "")
+          PY
+            )"
+            protect_ecr_image_tag "${task_image}" "${expected_task_family}-current"
+          }
+
+          for REPORT_PROJECT in vevo roy; do
+            protect_current_daily_schedule_image "${REPORT_PROJECT}"
+          done
+
           REPORT_SCHEDULE_NAME="$(python - "${PROJECT}" <<'PY'
           import json
           import pathlib
@@ -402,6 +496,7 @@ jobs:
                 --name "${REPORT_SCHEDULE_NAME}" \
                 --region "${AWS_REGION}" > schedule.json
             fi
+            protect_ecr_image_tag "${IMAGE_IDENTIFIER}" "${TASK_FAMILY}-current"
 
             CLUSTER_ARN="$(python - <<'PY'
           import json

--- a/.github/workflows/production-reporting-smoke.yml
+++ b/.github/workflows/production-reporting-smoke.yml
@@ -95,6 +95,43 @@ jobs:
             --output text)"
           IMAGE_IDENTIFIER="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}@${IMAGE_DIGEST}"
 
+          protect_ecr_image_tag() {
+            local image_identifier="$1"
+            local protection_tag="$2"
+            if [[ "${image_identifier}" != *@sha256:* ]]; then
+              echo "Skipping ${protection_tag}; image is not digest-pinned: ${image_identifier}"
+              return 0
+            fi
+            local image_digest="${image_identifier##*@}"
+            local existing_digest
+            existing_digest="$(aws ecr describe-images \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-ids imageTag="${protection_tag}" \
+              --region "${AWS_REGION}" \
+              --query 'imageDetails[0].imageDigest' \
+              --output text 2>/dev/null || true)"
+            if [[ "${existing_digest}" == "${image_digest}" ]]; then
+              echo "ECR_IMAGE_PROTECTED:${protection_tag}:${image_digest}:already"
+              return 0
+            fi
+            local manifest_file
+            manifest_file="$(mktemp)"
+            aws ecr batch-get-image \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-ids imageDigest="${image_digest}" \
+              --region "${AWS_REGION}" \
+              --query 'images[0].imageManifest' \
+              --output text > "${manifest_file}"
+            python -m json.tool "${manifest_file}" >/dev/null
+            aws ecr put-image \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-tag "${protection_tag}" \
+              --image-manifest "file://${manifest_file}" \
+              --region "${AWS_REGION}" >/dev/null
+            rm -f "${manifest_file}"
+            echo "ECR_IMAGE_PROTECTED:${protection_tag}:${image_digest}:updated"
+          }
+
           for PROJECT in $PROJECTS; do
             echo "::group::Production smoke for ${PROJECT}"
             SCHEDULE_NAME="$(python - "$PROJECT" <<'PY'
@@ -269,6 +306,7 @@ jobs:
               TASK_IMAGE_UPDATED="true"
               TASK_IMAGE="${IMAGE_IDENTIFIER}"
             fi
+            protect_ecr_image_tag "${TASK_IMAGE}" "${EXPECTED_TASK_FAMILY}-current"
             CONTAINER_NAME="$(python - <<'PY'
           import json
           task_def = json.load(open("task-definition.json", encoding="utf-8"))["taskDefinition"]

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-07-07
+Last updated: 2026-07-09
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,26 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- VEVO daily reporting email outage on `2026-07-09` is fixed and ECR digest protection is being hardened:
+  - symptom: the regular `vevo-daily-report-email` run for `2026-07-09 01:00 Europe/Bratislava` did not send a VEVO reporting email; ROY sent normally at `2026-07-09 01:30 Europe/Bratislava`
+  - root cause: `vevo-daily-report-email` still targeted `vevo-reporting-daily:12` with image digest `sha256:ebd43d8904940e03bdcc1253a749119eb943d80565b387611b2a23d73e6d28a9`; the digest had become untagged after the `2026-07-07` ROY App Runner deploy pushed `latest` to `sha256:c7aa0845f40a773da717c5ddf076de0e7413217a6d8d3ccb9116ca97b866dede`, then ECR lifecycle deleted the untagged VEVO digest
+  - evidence: ECR `batch-get-image` for `sha256:ebd43d8904940e03bdcc1253a749119eb943d80565b387611b2a23d73e6d28a9` returned `ImageNotFound`; CloudTrail still showed the scheduled VEVO `RunTask` at `2026-07-08T23:00:13Z` for task `adfca2c7aed64091ab3fe1a342503817`, but `/ecs/vevo-reporting-daily` had no application log stream for that run; ROY task `fa90233638d04cd1931bd03c29824417` logged SES `MessageId=0107019f442e998f-8c6f3367-f63f-4db9-a941-2616b6e0fed5-000000`
+  - drift source: CloudTrail showed `Deploy Live Dashboard App Runner` run `28850346056` registered `roy-reporting-daily:43` and updated only `roy-daily-report-email` at `2026-07-07T07:49Z`, bypassing the earlier `production-reporting-smoke` guard that only protected that workflow
+  - repair run: `Production Reporting Smoke` run `29000488380` with `project=all`, `send_email=false`, `update_task_image=true` updated VEVO from `vevo-reporting-daily:12` to `vevo-reporting-daily:13` on `sha256:c7aa0845f40a773da717c5ddf076de0e7413217a6d8d3ccb9116ca97b866dede`
+  - repair hard-gate: instance-id `N/A (scheduled ECS/Fargate task)`, private IP `172.31.1.133`, service `vevo-daily-report-email`, task definition `arn:aws:ecs:eu-central-1:919341186960:task-definition/vevo-reporting-daily:13`, task `arn:aws:ecs:eu-central-1:919341186960:task/vevo-reporting-cluster/b44ca918db124255be1fbb6891a31662`, marker path `http://127.0.0.1:8000/marker.json`
+  - repair verification: VEVO dry host smoke in run `29000488380` showed `LOCALHOST_MARKER_OK`, `UI_SMOKE_OK:vevo:production-board`, `UI_SMOKE_OK:vevo:daily-profit-loss`; ROY dry smoke also passed with task `a752e29e34324e98b943bf92e91a365d`
+  - email resend: `Production Reporting Smoke` run `29008069794` with `project=vevo`, `send_email=true`, `update_task_image=false` sent the missing VEVO report via SES `MessageId=0107019f4645cbeb-c78b87bb-a6c3-49fa-83fa-bc1768a9b9d6-000000`
+  - resend hard-gate: instance-id `N/A (scheduled ECS/Fargate task)`, private IP `172.31.15.232`, service `vevo-daily-report-email`, task definition `arn:aws:ecs:eu-central-1:919341186960:task-definition/vevo-reporting-daily:13`, task `arn:aws:ecs:eu-central-1:919341186960:task/vevo-reporting-cluster/2b322c0fec82493b980a806472573746`, marker path `http://127.0.0.1:8000/marker.json`
+  - resend verification: CloudWatch showed `data/vevo/report_latest.html`, `data/vevo/dashboard_payload_latest.json`, `LOCALHOST_MARKER_OK`, `daily_profit_rows=432`, `creditnote_count=280`, `credited_gross_eur=4938.74`, `send_email=true`, `PRODUCTION_BOARD_OK`, `UI_SMOKE_OK:vevo:production-board`, and `UI_SMOKE_OK:vevo:daily-profit-loss`
+  - immediate ECR protection: digest `sha256:c7aa0845f40a773da717c5ddf076de0e7413217a6d8d3ccb9116ca97b866dede` now has tags `latest`, `vevo-reporting-daily-current`, and `roy-reporting-daily-current`, so it is protected from the current untagged-image lifecycle rule
+  - code hardening branch: `codex/protect-reporting-schedule-images` updates `.github/workflows/production-reporting-smoke.yml` and `.github/workflows/deploy-live-dashboard-apprunner.yml` so daily schedule digests are protected with project-specific ECR tags whenever report smoke runs or App Runner deploy touches reporting artifacts
+  - local verification for hardening branch:
+    - YAML parse for both workflows returned `YAML_OK`
+    - extracted workflow bash blocks passed `bash -n` after LF normalization
+    - `git diff --check`
+  - Current status: VEVO scheduled daily reporting is enabled at `01:00 Europe/Bratislava`, targets `vevo-reporting-daily:13`, and uses the current protected digest `sha256:c7aa0845f40a773da717c5ddf076de0e7413217a6d8d3ccb9116ca97b866dede`
+  - Next exact step: merge the hardening PR, then monitor the next regular `vevo-daily-report-email` run on `2026-07-10 01:00 Europe/Bratislava` for a new CloudWatch stream and SES `MessageId`
 
 - ROY picking-list print confirmation fix is merged, deployed, and live state is repaired on `2026-07-07`:
   - code PR: `https://github.com/vzeman/biznisweb/pull/207`, merged as `ff1fa6e Fix ROY picking PDF print confirmation flow`


### PR DESCRIPTION
## Summary
- Document and close the 2026-07-09 VEVO daily reporting email outage in PROJECT_STATE.md
- Protect reporting schedule image digests with project-specific ECR tags from production reporting smoke
- Protect both current VEVO/ROY daily schedule digests before App Runner deploys, and protect updated reporting digests after ROY artifact refresh updates

## Runtime recovery already completed
- Updated `vevo-daily-report-email` to `vevo-reporting-daily:13` on `sha256:c7aa0845f40a773da717c5ddf076de0e7413217a6d8d3ccb9116ca97b866dede` via run `29000488380`
- Sent the missing VEVO email via run `29008069794`, SES `MessageId=0107019f4645cbeb-c78b87bb-a6c3-49fa-83fa-bc1768a9b9d6-000000`
- Added ECR tags `vevo-reporting-daily-current` and `roy-reporting-daily-current` to the current digest

## Verification
- YAML_OK for modified workflows
- Extracted workflow bash blocks passed `bash -n` after LF normalization
- `git diff --check`