### PR TITLE
Set ROY missing-cost margin to 35 percent

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-07-09
+Last updated: 2026-07-15
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,18 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- ROY missing-purchase-cost fallback is being changed to a permanent `35%` product margin on `2026-07-15`:
+  - branch: `codex/roy-missing-cost-35-margin`
+  - source-of-truth rule: `projects/roy/settings.json` sets `missing_cost_margin_pct = 35`; only rows with no resolvable configured purchase cost use cost `65%` of net item revenue
+  - mapped purchase costs keep precedence in the normal cost-resolution path, including real negative-margin clearance sales; regression coverage preserves a mapped `80 EUR` cost on `50 EUR` net revenue as `-30 EUR` product profit
+  - VEVO remains unchanged because its missing-cost margin defaults to `0%`
+  - bundle components without a resolvable cost use the same project-scoped fallback, and product-expense coverage QA recognizes both direct and bundle missing-cost sources
+  - current ROY data check: `Roy powerbanka 10000mAh` SKU `IS-Q6L` uses mapped source `mapped_legacy_title_hash`, so the new missing-cost fallback does not replace its real loss; SKU overrides and configured product-cost keys currently have `0` intersections
+  - pre-deploy hard-gate: instance-id `N/A (AWS ECS/Fargate)`, no stable task IP before a task starts, service `roy-daily-report-email`, current task definition `roy-reporting-daily:43`, current image `919341186960.dkr.ecr.eu-central-1.amazonaws.com/vevo-reporting@sha256:c7aa0845f40a773da717c5ddf076de0e7413217a6d8d3ccb9116ca97b866dede`, marker path `http://127.0.0.1:8000/marker.json`, stable artifact path `s3://biznisweb-reporting-artifacts-919341186960-eu-central-1/daily-reports/roy-sk/latest/`
+  - local verification: `python -m json.tool projects/roy/settings.json`; `python -m py_compile export_orders.py reporting_core/runtime.py scripts/reporting_qa_smoke.py tests/test_reporting_calculation_fixes.py`; `python -m unittest tests.test_reporting_calculation_fixes` (`27` tests OK); `python scripts/reporting_qa_smoke.py`; related reporting suite (`46` tests OK); `git diff --check`
+  - Current status: code and regression coverage are ready for commit/PR; production is not changed yet
+  - Next exact step: commit and push the branch, merge the PR, wait for the ECR image build, then run the guarded production reporting smoke before the full ROY backfill
 
 - VEVO daily reporting email outage on `2026-07-09` is fixed and ECR digest protection is being hardened:
   - symptom: the regular `vevo-daily-report-email` run for `2026-07-09 01:00 Europe/Bratislava` did not send a VEVO reporting email; ROY sent normally at `2026-07-09 01:30 Europe/Bratislava`

--- a/export_orders.py
+++ b/export_orders.py
@@ -110,6 +110,7 @@ FIXED_MONTHLY_COST = 0  # EUR per month (Marek, Uctovnictvo)
 FIXED_DAILY_COST = 0  # EUR per day; when set, overrides monthly fixed-cost spreading
 EXPENSE_MATCH_MODE = "identifier_first"  # Match product costs by identifiers first unless project opts into title-first
 PRODUCT_NAME_ALIASES: Dict[str, str] = {}  # Optional project-scoped aliases for canonical reporting product names
+MISSING_COST_MARGIN_PCT = 0.0  # Product margin used only when no configured purchase cost can be resolved
 ZERO_MARGIN_BRANDS: List[str] = []  # Optional list of brands that should always run at 0 product margin
 ZERO_COST_BRANDS: List[str] = []  # Optional list of brands that should always run at 0 product cost
 ZERO_COST_LABEL_PATTERNS: List[str] = []  # Optional label patterns forced to 0 product cost
@@ -1986,8 +1987,10 @@ class BizniWebExporter:
         total_revenue = float(item_df["item_total_without_tax"].sum())
         total_profit = float(item_df["profit_before_ads"].sum())
 
-        fallback_sources = {"fallback_default", "missing_cost_zero_margin_fallback"}
-        fallback_df = item_df.loc[item_df["expense_source"].isin(fallback_sources)].copy()
+        fallback_mask = item_df["expense_source"].eq("fallback_default") | item_df["expense_source"].str.contains(
+            "missing_cost_", regex=False
+        )
+        fallback_df = item_df.loc[fallback_mask].copy()
         fallback_rows = int(len(fallback_df.index))
         fallback_units = float(fallback_df["item_quantity"].sum())
         fallback_revenue = float(fallback_df["item_total_without_tax"].sum())
@@ -2043,7 +2046,7 @@ class BizniWebExporter:
         failures: List[str] = []
         if fallback_rows > 0:
             warnings.append(
-                f"{fallback_rows} item row(s) ({fallback_row_share_pct:.2f}%) use a missing-cost zero-margin fallback."
+                f"{fallback_rows} item row(s) ({fallback_row_share_pct:.2f}%) use a configured missing-cost fallback."
             )
             if fallback_revenue_share_pct >= 5 or fallback_profit_share_pct >= 5:
                 warnings.append(
@@ -2455,8 +2458,11 @@ class BizniWebExporter:
                 expense_per_item = spec["expense_per_item"]
                 expense_source = spec["expense_source"]
                 if expense_per_item is None:
-                    expense_per_item = (component_revenue / component_units) if component_units else 0.0
-                    expense_source = "bundle_component_missing_cost_zero_margin_fallback"
+                    expense_per_item, expense_source = self._missing_cost_expense(
+                        component_revenue,
+                        component_units,
+                    )
+                    expense_source = f"bundle_component_{expense_source}"
                 component_total_expense = round(float(expense_per_item or 0.0) * component_units, 2)
                 component_profit = round(component_revenue - component_total_expense, 2)
                 component_roi = (
@@ -2953,6 +2959,16 @@ class BizniWebExporter:
     def _margin_override_source(margin_pct: float) -> str:
         token = f"{float(margin_pct):g}".replace(".", "_")
         return f"margin_{token}_override"
+
+    @staticmethod
+    def _missing_cost_expense(net_revenue: float, quantity: float) -> Tuple[float, str]:
+        margin_pct = float(MISSING_COST_MARGIN_PCT)
+        net_unit_revenue = (float(net_revenue) / float(quantity)) if quantity else 0.0
+        expense_per_item = net_unit_revenue * (1 - margin_pct / 100)
+        if margin_pct == 0.0:
+            return expense_per_item, "missing_cost_zero_margin_fallback"
+        token = f"{margin_pct:g}".replace(".", "_")
+        return expense_per_item, f"missing_cost_margin_{token}_fallback"
 
     def _bundle_accessory_config(self) -> Dict[str, Any]:
         config = self.project_settings.get("bundle_accessory_model") or {}
@@ -5245,12 +5261,10 @@ class BizniWebExporter:
                         ean=item_ean,
                     )
                     if expense_per_item is None:
-                        expense_per_item = (
-                            (item_total_without_tax / item_quantity)
-                            if item_quantity and item_total_without_tax > 0
-                            else 0.0
+                        expense_per_item, expense_source = self._missing_cost_expense(
+                            item_total_without_tax,
+                            item_quantity,
                         )
-                        expense_source = "missing_cost_zero_margin_fallback"
                 total_expense = expense_per_item * item_quantity
                 
                 # Calculate profit and ROI (Note: FB ads will be added at aggregation level)

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -68,6 +68,7 @@
   "packaging_cost_per_order": 0.05,
   "shipping_net_per_order": -0.2,
   "fixed_monthly_cost": 6500,
+  "missing_cost_margin_pct": 35,
   "invoice_generation": {
     "enabled": true,
     "lookback_days": 7,

--- a/reporting_core/runtime.py
+++ b/reporting_core/runtime.py
@@ -29,6 +29,7 @@ class ProjectRuntime:
     fixed_daily_cost: float
     currency_rates_to_eur: Dict[str, float]
     product_expenses: Dict[str, float]
+    missing_cost_margin_pct: float
     zero_margin_brands: List[str]
     zero_cost_brands: List[str]
     zero_cost_label_patterns: List[str]
@@ -69,6 +70,7 @@ class ProjectRuntime:
             "fixed_daily_cost": self.fixed_daily_cost,
             "currency_rates_to_eur": dict(self.currency_rates_to_eur),
             "product_expenses": dict(self.product_expenses),
+            "missing_cost_margin_pct": self.missing_cost_margin_pct,
             "zero_margin_brands": list(self.zero_margin_brands),
             "zero_cost_brands": list(self.zero_cost_brands),
             "zero_cost_label_patterns": list(self.zero_cost_label_patterns),
@@ -104,6 +106,18 @@ def _coerce_margin_override_map(raw: Any) -> Dict[str, float]:
         if 0.0 <= margin_pct < 100.0:
             result[key_text] = margin_pct
     return result
+
+
+def _coerce_margin_pct(raw: Any, *, setting_name: str, default: float = 0.0) -> float:
+    if raw in (None, ""):
+        return float(default)
+    try:
+        margin_pct = float(str(raw).strip().rstrip("%"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{setting_name} must be a number from 0 up to, but not including, 100") from exc
+    if not 0.0 <= margin_pct < 100.0:
+        raise ValueError(f"{setting_name} must be from 0 up to, but not including, 100")
+    return margin_pct
 
 
 def load_project_runtime(
@@ -178,6 +192,10 @@ def load_project_runtime(
             for k, v in dict(settings.get("currency_rates_to_eur", default_currency_rates or {})).items()
         },
         product_expenses={str(k): float(v) for k, v in product_expenses.items()},
+        missing_cost_margin_pct=_coerce_margin_pct(
+            settings.get("missing_cost_margin_pct"),
+            setting_name="missing_cost_margin_pct",
+        ),
         zero_margin_brands=[str(v).strip() for v in settings.get("zero_margin_brands", []) if str(v).strip()],
         zero_cost_brands=[str(v).strip() for v in settings.get("zero_cost_brands", []) if str(v).strip()],
         zero_cost_label_patterns=[str(v).strip() for v in settings.get("zero_cost_label_patterns", []) if str(v).strip()],
@@ -219,6 +237,7 @@ def apply_project_runtime(runtime: ProjectRuntime, target_globals: Dict[str, Any
     target_globals["FIXED_DAILY_COST"] = float(runtime.fixed_daily_cost)
     target_globals["CURRENCY_RATES_TO_EUR"] = dict(runtime.currency_rates_to_eur)
     target_globals["PRODUCT_EXPENSES"] = dict(runtime.product_expenses)
+    target_globals["MISSING_COST_MARGIN_PCT"] = float(runtime.missing_cost_margin_pct)
     target_globals["ZERO_MARGIN_BRANDS"] = [str(v).strip().lower() for v in runtime.zero_margin_brands if str(v).strip()]
     target_globals["ZERO_COST_BRANDS"] = [str(v).strip().lower() for v in runtime.zero_cost_brands if str(v).strip()]
     target_globals["ZERO_COST_LABEL_PATTERNS"] = [str(v).strip() for v in runtime.zero_cost_label_patterns if str(v).strip()]

--- a/scripts/reporting_qa_smoke.py
+++ b/scripts/reporting_qa_smoke.py
@@ -408,6 +408,7 @@ def assert_roy_fixed_cost_source_of_truth() -> None:
     )
     assert math.isclose(runtime.fixed_monthly_cost, 6500.0, rel_tol=1e-9, abs_tol=1e-9), runtime.to_dict()
     assert math.isclose(runtime.fixed_daily_cost, 0.0, rel_tol=1e-9, abs_tol=1e-9), runtime.to_dict()
+    assert math.isclose(runtime.missing_cost_margin_pct, 35.0, rel_tol=1e-9, abs_tol=1e-9), runtime.to_dict()
 
 
 def assert_daily_runner_fixed_overhead_not_double_subtracted() -> None:

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -63,7 +63,7 @@ class ReportingCalculationFixTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             exporter.convert_to_eur(10.0, "BTC")
 
-    def test_missing_product_cost_uses_zero_margin_fallback(self) -> None:
+    def test_vevo_missing_product_cost_keeps_zero_margin_fallback(self) -> None:
         exporter = make_exporter()
         rows = exporter.flatten_order(
             {
@@ -90,6 +90,71 @@ class ReportingCalculationFixTests(unittest.TestCase):
         self.assertEqual(50.0, rows[0]["expense_per_item"])
         self.assertEqual(100.0, rows[0]["total_expense"])
         self.assertEqual(0.0, rows[0]["profit_before_ads"])
+
+    def test_roy_missing_product_cost_uses_configured_35_percent_margin(self) -> None:
+        exporter = make_exporter(project_name="roy")
+
+        with patch("export_orders.MISSING_COST_MARGIN_PCT", 35.0):
+            rows = exporter.flatten_order(
+                {
+                    "id": "1",
+                    "order_num": "R-MISSING",
+                    "pur_date": "2026-07-14 10:00:00",
+                    "sum": {"value": 123.0, "currency": {"code": "EUR"}},
+                    "customer": {"email": "a@example.com"},
+                    "items": [
+                        {
+                            "item_label": "Unknown ROY product",
+                            "ean": "",
+                            "quantity": 2,
+                            "tax_rate": 23,
+                            "price": {"value": 50.0, "currency": {"code": "EUR"}},
+                            "sum": {"value": 100.0, "currency": {"code": "EUR"}},
+                            "sum_with_tax": {"value": 123.0, "currency": {"code": "EUR"}},
+                        }
+                    ],
+                }
+            )
+
+        self.assertEqual("missing_cost_margin_35_fallback", rows[0]["expense_source"])
+        self.assertEqual(32.5, rows[0]["expense_per_item"])
+        self.assertEqual(65.0, rows[0]["total_expense"])
+        self.assertEqual(35.0, rows[0]["profit_before_ads"])
+
+    def test_roy_mapped_cost_keeps_real_loss_despite_missing_cost_margin(self) -> None:
+        exporter = make_exporter(project_name="roy")
+        exporter.product_expenses_exact["LOSS-SKU"] = 80.0
+
+        with patch("export_orders.MISSING_COST_MARGIN_PCT", 35.0), patch(
+            "export_orders.MARGIN_OVERRIDE_SKUS", {}
+        ), patch("export_orders.MARGIN_OVERRIDE_BRANDS", {}), patch(
+            "export_orders.MARGIN_OVERRIDE_LABEL_PATTERNS", {}
+        ):
+            rows = exporter.flatten_order(
+                {
+                    "id": "1",
+                    "order_num": "R-LOSS",
+                    "pur_date": "2026-07-14 10:00:00",
+                    "sum": {"value": 61.5, "currency": {"code": "EUR"}},
+                    "customer": {"email": "a@example.com"},
+                    "items": [
+                        {
+                            "item_label": "Intentional clearance loss",
+                            "ean": "LOSS-SKU",
+                            "quantity": 1,
+                            "tax_rate": 23,
+                            "price": {"value": 50.0, "currency": {"code": "EUR"}},
+                            "sum": {"value": 50.0, "currency": {"code": "EUR"}},
+                            "sum_with_tax": {"value": 61.5, "currency": {"code": "EUR"}},
+                        }
+                    ],
+                }
+            )
+
+        self.assertEqual("mapped_product_identifier", rows[0]["expense_source"])
+        self.assertEqual(80.0, rows[0]["expense_per_item"])
+        self.assertEqual(80.0, rows[0]["total_expense"])
+        self.assertEqual(-30.0, rows[0]["profit_before_ads"])
 
     def test_margin_override_brand_forces_configured_product_margin(self) -> None:
         exporter = make_exporter(project_name="roy")


### PR DESCRIPTION
## What changed

- added project-scoped `missing_cost_margin_pct` runtime configuration
- set ROY missing-cost product margin to 35%, deriving cost as 65% of net item revenue
- applied the same fallback to unresolved bundle components
- preserved VEVO's existing 0% default
- kept resolved purchase costs authoritative, including intentional negative-margin clearance sales
- updated product-cost coverage QA and `PROJECT_STATE.md`

## Why

ROY products without a configured purchase cost were previously reported at zero product margin. A conservative 35% fallback is the agreed permanent reporting rule, while known purchase costs must continue to show real profit or loss.

## Validation

- `python scripts/reporting_qa_smoke.py`
- `python -m unittest tests.test_reporting_calculation_fixes` (27 tests)
- related reporting suite (46 tests)
- CI-equivalent unit suite (116 tests)
- `python -m py_compile ...`
- `python -m json.tool projects/roy/settings.json`
- `git diff --check`