### PR TITLE
Describe configured missing-cost margin in QA

### DIFF
--- a/export_orders.py
+++ b/export_orders.py
@@ -2110,7 +2110,10 @@ class BizniWebExporter:
             "total_units": round(total_units, 2),
             "total_revenue": round(total_revenue, 2),
             "total_profit_before_ads": round(total_profit, 2),
-            "fallback_policy": "missing costs are treated as zero-margin instead of default 1 EUR cost",
+            "fallback_policy": (
+                f"missing costs use a configured {MISSING_COST_MARGIN_PCT:g}% margin estimate "
+                f"({100 - MISSING_COST_MARGIN_PCT:g}% of net item revenue is treated as expense)"
+            ),
             "fallback_rows": fallback_rows,
             "fallback_units": round(fallback_units, 2),
             "fallback_revenue": round(fallback_revenue, 2),

--- a/scripts/reporting_qa_smoke.py
+++ b/scripts/reporting_qa_smoke.py
@@ -268,6 +268,7 @@ def assert_product_expense_coverage(exporter: BizniWebExporter) -> None:
         )
     )
     assert risky["status"] == "critical", risky
+    assert "configured 0% margin estimate" in risky["fallback_policy"], risky
     assert risky["fallback_rows"] == 2, risky
     assert risky["fallback_revenue_share_pct"] == 60.0, risky
     assert risky["top_fallback_items"][0]["product_sku"] == "SKU-FALLBACK", risky

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -121,6 +121,29 @@ class ReportingCalculationFixTests(unittest.TestCase):
         self.assertEqual(65.0, rows[0]["total_expense"])
         self.assertEqual(35.0, rows[0]["profit_before_ads"])
 
+    def test_product_expense_qa_describes_configured_missing_cost_margin(self) -> None:
+        exporter = make_exporter(project_name="roy")
+        frame = pd.DataFrame(
+            {
+                "order_num": ["R-MISSING"],
+                "item_label": ["Unknown ROY product"],
+                "product_sku": ["UNKNOWN"],
+                "item_quantity": [1],
+                "item_total_without_tax": [100.0],
+                "profit_before_ads": [35.0],
+                "expense_per_item": [65.0],
+                "expense_source": ["missing_cost_margin_35_fallback"],
+            }
+        )
+
+        with patch("export_orders.MISSING_COST_MARGIN_PCT", 35.0):
+            qa = exporter._build_product_expense_coverage_qa(frame)
+
+        self.assertEqual(
+            "missing costs use a configured 35% margin estimate (65% of net item revenue is treated as expense)",
+            qa["fallback_policy"],
+        )
+
     def test_roy_mapped_cost_keeps_real_loss_despite_missing_cost_margin(self) -> None:
         exporter = make_exporter(project_name="roy")
         exporter.product_expenses_exact["LOSS-SKU"] = 80.0


### PR DESCRIPTION
## Summary
- describe the configured missing-cost margin accurately in product-cost QA metadata
- include the derived expense share in the policy text
- add regression coverage for ROY 35% and default 0% metadata

## Verification
- `python -m unittest discover -s tests -p test_*.py` (122 passed)
- `python scripts/reporting_qa_smoke.py`
- `python -m py_compile export_orders.py scripts/reporting_qa_smoke.py tests/test_reporting_calculation_fixes.py`
- `git diff --check`