### PR TITLE
Derive VEVO bundle costs from components

### DIFF
--- a/export_orders.py
+++ b/export_orders.py
@@ -761,12 +761,9 @@ class BizniWebExporter:
         self.excluded_status_orders = []  # Track all excluded status orders for lifecycle proxy reporting
         self._creditnote_order_nums_cache: Optional[set[str]] = None
         self._creditnote_status_change_audit_cache: Optional[Dict[str, Any]] = None
-        self.product_expenses_exact = dict(PRODUCT_EXPENSES)
-        self.product_expenses_normalized = {}
-        for key, value in PRODUCT_EXPENSES.items():
-            normalized_key = self._normalize_match_text(key)
-            if normalized_key:
-                self.product_expenses_normalized[normalized_key] = float(value)
+        self._rebuild_product_expense_indexes(PRODUCT_EXPENSES)
+        self.product_cost_bundle_rules_by_label = self._build_product_cost_bundle_rule_index()
+        self._validate_product_cost_bundle_rule_expenses()
         product_name_aliases = dict(PRODUCT_NAME_ALIASES)
         product_name_aliases_file = self.project_settings.get("product_name_aliases_file")
         if product_name_aliases_file:
@@ -2960,6 +2957,300 @@ class BizniWebExporter:
             return ""
         return "||".join(normalized_parts)
 
+    def _rebuild_product_expense_indexes(self, expenses: Dict[Any, Any]) -> None:
+        """Build exact and normalized cost indexes while retaining ambiguity metadata."""
+        self.product_expenses_exact = {}
+        self.product_expenses_normalized = {}
+        self.product_expenses_normalized_costs: Dict[str, set[float]] = {}
+        for raw_key, raw_value in dict(expenses or {}).items():
+            key = str(raw_key or "").strip()
+            if not key:
+                continue
+            value = float(raw_value)
+            self.product_expenses_exact[key] = value
+            normalized_key = self._normalize_match_text(key)
+            if not normalized_key:
+                continue
+            self.product_expenses_normalized[normalized_key] = value
+            self.product_expenses_normalized_costs.setdefault(normalized_key, set()).add(value)
+
+    def _build_product_cost_bundle_rule_index(self) -> Dict[str, Dict[str, Any]]:
+        """Validate exact-label mixed-bundle rules and index them by their raw shop label."""
+        raw_rules = self.project_settings.get("product_cost_bundle_rules") or []
+        if not isinstance(raw_rules, list):
+            raise ValueError("product_cost_bundle_rules must be a list")
+
+        rules_by_label: Dict[str, Dict[str, Any]] = {}
+        seen_rule_keys = set()
+        for rule_index, raw_rule in enumerate(raw_rules):
+            if not isinstance(raw_rule, dict):
+                raise ValueError(f"product_cost_bundle_rules[{rule_index}] must be an object")
+            rule_key = str(raw_rule.get("key") or "").strip()
+            if not rule_key:
+                raise ValueError(f"product_cost_bundle_rules[{rule_index}] requires a non-empty key")
+            if rule_key in seen_rule_keys:
+                raise ValueError(f"Duplicate product_cost_bundle_rules key {rule_key!r}")
+            seen_rule_keys.add(rule_key)
+
+            exact_labels = raw_rule.get("exact_labels") or []
+            components = raw_rule.get("components") or []
+            shared_component_identifiers = raw_rule.get("shared_component_identifiers") or []
+            if not isinstance(exact_labels, list) or not exact_labels:
+                raise ValueError(f"product_cost_bundle_rules[{rule_key}] requires exact_labels")
+            if not isinstance(components, list) or not components:
+                raise ValueError(f"product_cost_bundle_rules[{rule_key}] requires components")
+            if not isinstance(shared_component_identifiers, list):
+                raise ValueError(
+                    f"product_cost_bundle_rules[{rule_key}].shared_component_identifiers must be a list"
+                )
+
+            normalized_shared_identifiers = {
+                self._normalize_product_identifier(identifier)
+                for identifier in shared_component_identifiers
+                if self._normalize_product_identifier(identifier)
+            }
+
+            validated_components: List[Dict[str, Any]] = []
+            for component_index, component in enumerate(components):
+                if not isinstance(component, dict):
+                    raise ValueError(
+                        f"product_cost_bundle_rules[{rule_key}].components[{component_index}] must be an object"
+                    )
+                expense_key = str(component.get("expense_key") or "").strip()
+                if not expense_key:
+                    raise ValueError(
+                        f"product_cost_bundle_rules[{rule_key}].components[{component_index}] requires expense_key"
+                    )
+                raw_quantity = component.get("quantity", 1)
+                try:
+                    quantity = float(raw_quantity)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"product_cost_bundle_rules[{rule_key}].components[{component_index}] has invalid quantity"
+                    ) from exc
+                if quantity <= 0 or not quantity.is_integer():
+                    raise ValueError(
+                        f"product_cost_bundle_rules[{rule_key}].components[{component_index}] quantity "
+                        "must be a positive integer"
+                    )
+                validated_components.append(
+                    {
+                        "expense_key": expense_key,
+                        "quantity": int(quantity),
+                    }
+                )
+
+            indexed_rule = {
+                "key": rule_key,
+                "components": validated_components,
+                "shared_component_identifiers": normalized_shared_identifiers,
+            }
+            for raw_label in exact_labels:
+                label = str(raw_label or "").strip()
+                if not label:
+                    raise ValueError(f"product_cost_bundle_rules[{rule_key}] contains an empty exact label")
+                if label in rules_by_label:
+                    previous_key = rules_by_label[label]["key"]
+                    raise ValueError(
+                        f"Bundle label {label!r} is configured by both {previous_key!r} and {rule_key!r}"
+                    )
+                rules_by_label[label] = indexed_rule
+        return rules_by_label
+
+    def _validate_product_cost_bundle_rule_expenses(self) -> None:
+        """Fail at startup when a configured component key cannot be safely priced."""
+        if not self.product_cost_bundle_rules_by_label:
+            return
+
+        validation_expenses = self.product_expenses_exact
+        product_expenses_file = str(self.project_settings.get("product_expenses_file") or "").strip()
+        if product_expenses_file:
+            product_expenses_path = project_dir(self.project_name) / product_expenses_file
+            if product_expenses_path.exists():
+                raw_expenses = json.loads(product_expenses_path.read_text(encoding="utf-8")) or {}
+                if not isinstance(raw_expenses, dict):
+                    raise ValueError(f"Product expense map {product_expenses_path} must be an object")
+                validation_expenses = {
+                    str(key).strip(): float(value)
+                    for key, value in raw_expenses.items()
+                    if str(key).strip()
+                }
+
+        rules_by_key = {
+            str(rule["key"]): rule
+            for rule in self.product_cost_bundle_rules_by_label.values()
+        }
+        for rule_key, rule in rules_by_key.items():
+            for component in rule.get("components") or []:
+                expense_key = str(component.get("expense_key") or "")
+                if expense_key not in validation_expenses:
+                    raise ValueError(
+                        f"product_cost_bundle_rules[{rule_key}] references missing expense key {expense_key!r}"
+                    )
+                component_cost = float(validation_expenses[expense_key])
+                if not np.isfinite(component_cost) or component_cost < 0:
+                    raise ValueError(
+                        f"product_cost_bundle_rules[{rule_key}] references invalid expense {expense_key!r}"
+                    )
+
+    def _lookup_unique_normalized_expense(self, candidate: Any) -> Optional[float]:
+        normalized_candidate = self._normalize_match_text(candidate)
+        if not normalized_candidate:
+            return None
+        values = self.product_expenses_normalized_costs.get(normalized_candidate) or set()
+        if len(values) != 1:
+            return None
+        return float(next(iter(values)))
+
+    def _resolve_explicit_bundle_expense(
+        self,
+        product_sku: str,
+        item_label: str,
+        import_code: Any = None,
+        warehouse_number: Any = None,
+        ean: Any = None,
+        shared_component_identifiers: Optional[set[str]] = None,
+    ) -> Tuple[Optional[float], Optional[str]]:
+        """Resolve only bundle-scoped mappings, excluding ambiguous shared component identifiers."""
+        title_candidate = str(item_label or "").strip()
+        if not title_candidate:
+            return None, None
+        product_sku_candidate = str(product_sku or "").strip()
+        import_code_candidate = self._normalize_product_identifier(import_code)
+        ean_candidate = self._normalize_product_identifier(ean)
+        warehouse_number_candidate = str(warehouse_number or "").strip()
+        legacy_title_sku_candidate = self.get_product_sku("", title_candidate)
+
+        exact_candidates = [
+            (self._compose_expense_key(title_candidate, warehouse_number_candidate), "mapped_compound_key"),
+            (self._compose_expense_key(title_candidate, import_code_candidate), "mapped_compound_key"),
+            (self._compose_expense_key(title_candidate, ean_candidate), "mapped_compound_key"),
+            (self._compose_expense_key(title_candidate, product_sku_candidate), "mapped_compound_key"),
+            (self._compose_expense_key(title_candidate, legacy_title_sku_candidate), "mapped_compound_key"),
+            (title_candidate, "mapped_item_label"),
+            (legacy_title_sku_candidate, "mapped_legacy_title_hash"),
+        ]
+        shared_identifiers = set(shared_component_identifiers or set())
+        standalone_identifier_candidates = [
+            (warehouse_number_candidate, "mapped_product_identifier"),
+            (import_code_candidate, "mapped_product_identifier"),
+            (ean_candidate, "mapped_product_identifier"),
+            (product_sku_candidate, "mapped_product_sku"),
+        ]
+        exact_candidates.extend(
+            (candidate, source)
+            for candidate, source in standalone_identifier_candidates
+            if candidate and self._normalize_product_identifier(candidate) not in shared_identifiers
+        )
+
+        seen_candidates = set()
+        for candidate, source in exact_candidates:
+            if not candidate or candidate in seen_candidates:
+                continue
+            seen_candidates.add(candidate)
+            if candidate in self.product_expenses_exact:
+                return float(self.product_expenses_exact[candidate]), source
+
+        for candidate, source in exact_candidates:
+            if not candidate:
+                continue
+            resolved = self._lookup_unique_normalized_expense(candidate)
+            if resolved is not None:
+                return resolved, f"{source}_normalized"
+        return None, None
+
+    def _bundle_rule_uses_shared_input_identifier(
+        self,
+        rule: Dict[str, Any],
+        product_sku: Any,
+        import_code: Any = None,
+        warehouse_number: Any = None,
+        ean: Any = None,
+    ) -> bool:
+        shared_identifiers = set(rule.get("shared_component_identifiers") or set())
+        if not shared_identifiers:
+            return False
+        input_identifiers = {
+            self._normalize_product_identifier(identifier)
+            for identifier in (product_sku, import_code, warehouse_number, ean)
+            if self._normalize_product_identifier(identifier)
+        }
+        return bool(shared_identifiers.intersection(input_identifiers))
+
+    @classmethod
+    def _parse_homogeneous_bundle_label(cls, item_label: Any) -> Optional[Tuple[int, str]]:
+        label = str(item_label or "").strip()
+        match = re.match(r"^\s*(\d{1,3})\s*[x×]\s+(.+?)\s*$", label, flags=re.IGNORECASE)
+        if not match:
+            return None
+        multiplier = int(match.group(1))
+        base_label = match.group(2).strip()
+        if multiplier < 2 or not base_label or "+" in base_label:
+            return None
+        if re.search(r"(?:^|\s)\d{1,3}\s*[x×]\s+", base_label, flags=re.IGNORECASE):
+            return None
+        base_tokens = set(cls._normalize_match_text(base_label).split())
+        if base_tokens.intersection({"darcek", "gift", "gratis", "zdarma"}):
+            return None
+        return multiplier, base_label
+
+    def _resolve_label_only_expense(self, item_label: str) -> Tuple[Optional[float], Optional[str]]:
+        """Resolve a base unit by label without inheriting identifiers from its bundle parent."""
+        title_candidate = str(item_label or "").strip()
+        if not title_candidate:
+            return None, None
+        if title_candidate in self.product_expenses_exact:
+            return float(self.product_expenses_exact[title_candidate]), "mapped_item_label"
+
+        legacy_title_sku_candidate = self.get_product_sku("", title_candidate)
+        if legacy_title_sku_candidate in self.product_expenses_exact:
+            return (
+                float(self.product_expenses_exact[legacy_title_sku_candidate]),
+                "mapped_legacy_title_hash",
+            )
+
+        normalized_title_expense = self._lookup_unique_normalized_expense(title_candidate)
+        if normalized_title_expense is not None:
+            return normalized_title_expense, "mapped_item_label_normalized"
+
+        normalized_legacy_expense = self._lookup_unique_normalized_expense(legacy_title_sku_candidate)
+        if normalized_legacy_expense is not None:
+            return normalized_legacy_expense, "mapped_legacy_title_hash_normalized"
+        return None, None
+
+    def _resolve_configured_bundle_expense(
+        self,
+        rule: Dict[str, Any],
+    ) -> Tuple[float, str]:
+        total_expense = 0.0
+        rule_key = str(rule.get("key") or "unknown")
+        for component in rule.get("components") or []:
+            expense_key = str(component.get("expense_key") or "")
+            if expense_key not in self.product_expenses_exact:
+                raise ValueError(
+                    f"product_cost_bundle_rules[{rule_key}] references missing expense key {expense_key!r}"
+                )
+            component_cost = float(self.product_expenses_exact[expense_key])
+            if not np.isfinite(component_cost) or component_cost < 0:
+                raise ValueError(
+                    f"product_cost_bundle_rules[{rule_key}] references invalid expense {expense_key!r}"
+                )
+            total_expense += component_cost * int(component.get("quantity") or 0)
+        return round(total_expense, 6), f"bundle_components_configured:{rule_key}"
+
+    def _resolve_inferred_homogeneous_bundle_expense(
+        self,
+        bundle: Tuple[int, str],
+    ) -> Tuple[Optional[float], Optional[str]]:
+        multiplier, base_label = bundle
+        base_expense, base_source = self._resolve_label_only_expense(base_label)
+        if base_expense is None:
+            return None, None
+        return (
+            round(float(base_expense) * multiplier, 6),
+            f"bundle_components_inferred:x{multiplier}:{base_source or 'unknown'}",
+        )
+
     def _resolve_product_expense(
         self,
         product_sku: str,
@@ -2974,6 +3265,31 @@ class BizniWebExporter:
         warehouse_number_candidate = str(warehouse_number or "").strip()
         title_candidate = str(item_label or "").strip()
         legacy_title_sku_candidate = self.get_product_sku("", title_candidate)
+
+        configured_bundle_rule = self.product_cost_bundle_rules_by_label.get(title_candidate)
+        homogeneous_bundle = self._parse_homogeneous_bundle_label(title_candidate)
+        if configured_bundle_rule is not None or homogeneous_bundle is not None:
+            shared_component_identifiers = set(
+                (configured_bundle_rule or {}).get("shared_component_identifiers") or set()
+            )
+            explicit_bundle_expense = self._resolve_explicit_bundle_expense(
+                product_sku,
+                title_candidate,
+                import_code=import_code,
+                warehouse_number=warehouse_number,
+                ean=ean,
+                shared_component_identifiers=shared_component_identifiers,
+            )
+            if explicit_bundle_expense[0] is not None:
+                return explicit_bundle_expense
+            if configured_bundle_rule is not None and self._bundle_rule_uses_shared_input_identifier(
+                configured_bundle_rule,
+                product_sku,
+                import_code=import_code,
+                warehouse_number=warehouse_number,
+                ean=ean,
+            ):
+                return self._resolve_configured_bundle_expense(configured_bundle_rule)
 
         exact_compound_candidates = [
             (self._compose_expense_key(title_candidate, warehouse_number_candidate), "mapped_compound_key"),
@@ -3036,6 +3352,15 @@ class BizniWebExporter:
         for candidate, source in normalized_candidates:
             if candidate and candidate in self.product_expenses_normalized:
                 return float(self.product_expenses_normalized[candidate]), source
+
+        if configured_bundle_rule is not None:
+            return self._resolve_configured_bundle_expense(configured_bundle_rule)
+        if homogeneous_bundle is not None:
+            inferred_bundle_expense = self._resolve_inferred_homogeneous_bundle_expense(
+                homogeneous_bundle
+            )
+            if inferred_bundle_expense[0] is not None:
+                return inferred_bundle_expense
 
         return None, None
 

--- a/export_orders.py
+++ b/export_orders.py
@@ -2981,27 +2981,27 @@ class BizniWebExporter:
             raise ValueError("product_cost_bundle_rules must be a list")
 
         rules_by_label: Dict[str, Dict[str, Any]] = {}
-        seen_rule_keys = set()
+        seen_rule_ids = set()
         for rule_index, raw_rule in enumerate(raw_rules):
             if not isinstance(raw_rule, dict):
                 raise ValueError(f"product_cost_bundle_rules[{rule_index}] must be an object")
-            rule_key = str(raw_rule.get("key") or "").strip()
-            if not rule_key:
-                raise ValueError(f"product_cost_bundle_rules[{rule_index}] requires a non-empty key")
-            if rule_key in seen_rule_keys:
-                raise ValueError(f"Duplicate product_cost_bundle_rules key {rule_key!r}")
-            seen_rule_keys.add(rule_key)
+            rule_id = str(raw_rule.get("rule_id") or "").strip()
+            if not rule_id:
+                raise ValueError(f"product_cost_bundle_rules[{rule_index}] requires a non-empty rule_id")
+            if rule_id in seen_rule_ids:
+                raise ValueError(f"Duplicate product_cost_bundle_rules rule_id {rule_id!r}")
+            seen_rule_ids.add(rule_id)
 
             exact_labels = raw_rule.get("exact_labels") or []
             components = raw_rule.get("components") or []
             shared_component_identifiers = raw_rule.get("shared_component_identifiers") or []
             if not isinstance(exact_labels, list) or not exact_labels:
-                raise ValueError(f"product_cost_bundle_rules[{rule_key}] requires exact_labels")
+                raise ValueError(f"product_cost_bundle_rules[{rule_id}] requires exact_labels")
             if not isinstance(components, list) or not components:
-                raise ValueError(f"product_cost_bundle_rules[{rule_key}] requires components")
+                raise ValueError(f"product_cost_bundle_rules[{rule_id}] requires components")
             if not isinstance(shared_component_identifiers, list):
                 raise ValueError(
-                    f"product_cost_bundle_rules[{rule_key}].shared_component_identifiers must be a list"
+                    f"product_cost_bundle_rules[{rule_id}].shared_component_identifiers must be a list"
                 )
 
             normalized_shared_identifiers = {
@@ -3014,23 +3014,23 @@ class BizniWebExporter:
             for component_index, component in enumerate(components):
                 if not isinstance(component, dict):
                     raise ValueError(
-                        f"product_cost_bundle_rules[{rule_key}].components[{component_index}] must be an object"
+                        f"product_cost_bundle_rules[{rule_id}].components[{component_index}] must be an object"
                     )
                 expense_key = str(component.get("expense_key") or "").strip()
                 if not expense_key:
                     raise ValueError(
-                        f"product_cost_bundle_rules[{rule_key}].components[{component_index}] requires expense_key"
+                        f"product_cost_bundle_rules[{rule_id}].components[{component_index}] requires expense_key"
                     )
                 raw_quantity = component.get("quantity", 1)
                 try:
                     quantity = float(raw_quantity)
                 except (TypeError, ValueError) as exc:
                     raise ValueError(
-                        f"product_cost_bundle_rules[{rule_key}].components[{component_index}] has invalid quantity"
+                        f"product_cost_bundle_rules[{rule_id}].components[{component_index}] has invalid quantity"
                     ) from exc
                 if quantity <= 0 or not quantity.is_integer():
                     raise ValueError(
-                        f"product_cost_bundle_rules[{rule_key}].components[{component_index}] quantity "
+                        f"product_cost_bundle_rules[{rule_id}].components[{component_index}] quantity "
                         "must be a positive integer"
                     )
                 validated_components.append(
@@ -3041,18 +3041,18 @@ class BizniWebExporter:
                 )
 
             indexed_rule = {
-                "key": rule_key,
+                "rule_id": rule_id,
                 "components": validated_components,
                 "shared_component_identifiers": normalized_shared_identifiers,
             }
             for raw_label in exact_labels:
                 label = str(raw_label or "").strip()
                 if not label:
-                    raise ValueError(f"product_cost_bundle_rules[{rule_key}] contains an empty exact label")
+                    raise ValueError(f"product_cost_bundle_rules[{rule_id}] contains an empty exact label")
                 if label in rules_by_label:
-                    previous_key = rules_by_label[label]["key"]
+                    previous_rule_id = rules_by_label[label]["rule_id"]
                     raise ValueError(
-                        f"Bundle label {label!r} is configured by both {previous_key!r} and {rule_key!r}"
+                        f"Bundle label {label!r} is configured by both {previous_rule_id!r} and {rule_id!r}"
                     )
                 rules_by_label[label] = indexed_rule
         return rules_by_label
@@ -3076,21 +3076,21 @@ class BizniWebExporter:
                     if str(key).strip()
                 }
 
-        rules_by_key = {
-            str(rule["key"]): rule
+        rules_by_id = {
+            str(rule["rule_id"]): rule
             for rule in self.product_cost_bundle_rules_by_label.values()
         }
-        for rule_key, rule in rules_by_key.items():
+        for rule_id, rule in rules_by_id.items():
             for component in rule.get("components") or []:
                 expense_key = str(component.get("expense_key") or "")
                 if expense_key not in validation_expenses:
                     raise ValueError(
-                        f"product_cost_bundle_rules[{rule_key}] references missing expense key {expense_key!r}"
+                        f"product_cost_bundle_rules[{rule_id}] references missing expense key {expense_key!r}"
                     )
                 component_cost = float(validation_expenses[expense_key])
                 if not np.isfinite(component_cost) or component_cost < 0:
                     raise ValueError(
-                        f"product_cost_bundle_rules[{rule_key}] references invalid expense {expense_key!r}"
+                        f"product_cost_bundle_rules[{rule_id}] references invalid expense {expense_key!r}"
                     )
 
     def _lookup_unique_normalized_expense(self, candidate: Any) -> Optional[float]:
@@ -3223,20 +3223,20 @@ class BizniWebExporter:
         rule: Dict[str, Any],
     ) -> Tuple[float, str]:
         total_expense = 0.0
-        rule_key = str(rule.get("key") or "unknown")
+        rule_id = str(rule.get("rule_id") or "unknown")
         for component in rule.get("components") or []:
             expense_key = str(component.get("expense_key") or "")
             if expense_key not in self.product_expenses_exact:
                 raise ValueError(
-                    f"product_cost_bundle_rules[{rule_key}] references missing expense key {expense_key!r}"
+                    f"product_cost_bundle_rules[{rule_id}] references missing expense key {expense_key!r}"
                 )
             component_cost = float(self.product_expenses_exact[expense_key])
             if not np.isfinite(component_cost) or component_cost < 0:
                 raise ValueError(
-                    f"product_cost_bundle_rules[{rule_key}] references invalid expense {expense_key!r}"
+                    f"product_cost_bundle_rules[{rule_id}] references invalid expense {expense_key!r}"
                 )
             total_expense += component_cost * int(component.get("quantity") or 0)
-        return round(total_expense, 6), f"bundle_components_configured:{rule_key}"
+        return round(total_expense, 6), f"bundle_components_configured:{rule_id}"
 
     def _resolve_inferred_homogeneous_bundle_expense(
         self,

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -236,6 +236,62 @@
       }
     ]
   },
+  "product_cost_bundle_rules": [
+    {
+      "key": "ylang_absolute_perfume_gel_1_1",
+      "exact_labels": [
+        "Combo Parfum do prania Ylang Absolute 500ml + Prací gél Ylang Absolute 1L"
+      ],
+      "shared_component_identifiers": [
+        "8594201618000"
+      ],
+      "components": [
+        {
+          "expense_key": "Parfum do prania Vevo Natural No.07 Ylang Absolute (500ml)",
+          "quantity": 1
+        },
+        {
+          "expense_key": "8594201618000",
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "key": "ylang_absolute_perfume_gel_1_3",
+      "exact_labels": [
+        "Combo 1x Parfum do prania Ylang Absolute 500ml + 3x Prací gél Ylang Absolute 1L"
+      ],
+      "shared_component_identifiers": [
+        "8594201618000"
+      ],
+      "components": [
+        {
+          "expense_key": "Parfum do prania Vevo Natural No.07 Ylang Absolute (500ml)",
+          "quantity": 1
+        },
+        {
+          "expense_key": "8594201618000",
+          "quantity": 3
+        }
+      ]
+    },
+    {
+      "key": "wool_balls_royal_cotton_dryer_fragrance_1_1",
+      "exact_labels": [
+        "Vlnené gule + Vevo Premium No.06 Royal Cotton 10ml"
+      ],
+      "components": [
+        {
+          "expense_key": "Prírodné vlnené gule do sušičky 3 ks",
+          "quantity": 1
+        },
+        {
+          "expense_key": "Parfum do sušičky Vevo Premium No.06 Royal Cotton 10ml",
+          "quantity": 1
+        }
+      ]
+    }
+  ],
   "product_expenses_file": "product_expenses.json",
   "currency_rates_to_eur": {
     "EUR": 1.0,

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -238,7 +238,7 @@
   },
   "product_cost_bundle_rules": [
     {
-      "key": "ylang_absolute_perfume_gel_1_1",
+      "rule_id": "ylang_absolute_perfume_gel_1_1",
       "exact_labels": [
         "Combo Parfum do prania Ylang Absolute 500ml + Prací gél Ylang Absolute 1L"
       ],
@@ -257,7 +257,7 @@
       ]
     },
     {
-      "key": "ylang_absolute_perfume_gel_1_3",
+      "rule_id": "ylang_absolute_perfume_gel_1_3",
       "exact_labels": [
         "Combo 1x Parfum do prania Ylang Absolute 500ml + 3x Prací gél Ylang Absolute 1L"
       ],
@@ -276,7 +276,7 @@
       ]
     },
     {
-      "key": "wool_balls_royal_cotton_dryer_fragrance_1_1",
+      "rule_id": "wool_balls_royal_cotton_dryer_fragrance_1_1",
       "exact_labels": [
         "Vlnené gule + Vevo Premium No.06 Royal Cotton 10ml"
       ],

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -358,6 +358,15 @@ class ReportingCalculationFixTests(unittest.TestCase):
             rows[0]["expense_source"],
         )
 
+    def test_vevo_bundle_rules_use_explicit_non_secret_rule_ids(self) -> None:
+        settings_path = Path(__file__).resolve().parents[1] / "projects" / "vevo" / "settings.json"
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        rules = settings.get("product_cost_bundle_rules") or []
+
+        self.assertTrue(rules)
+        self.assertTrue(all(str(rule.get("rule_id") or "").strip() for rule in rules))
+        self.assertTrue(all("key" not in rule for rule in rules))
+
     def test_homogeneous_bundle_parser_is_narrow_and_keeps_explicit_bundle_cost_precedence(self) -> None:
         exporter = make_exporter(project_name="vevo")
         exporter._rebuild_product_expense_indexes(

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -321,6 +321,217 @@ class ReportingCalculationFixTests(unittest.TestCase):
         self.assertEqual(0.0, qa["fallback_recent_30d_revenue"])
         self.assertEqual(0.0, qa["fallback_recent_30d_revenue_share_pct"])
 
+    def test_homogeneous_bundle_uses_known_single_product_cost_for_every_bundle_unit(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        exporter._rebuild_product_expense_indexes(
+            {
+                "Parfum do prania Vevo Natural No.07 Ylang Absolute (500ml)": 6.14,
+            }
+        )
+
+        rows = exporter.flatten_order(
+            {
+                "id": "1",
+                "order_num": "V-YLANG-2X",
+                "pur_date": "2026-07-14 10:00:00",
+                "sum": {"value": 97.37, "currency": {"code": "EUR"}},
+                "customer": {"email": "a@example.com"},
+                "items": [
+                    {
+                        "item_label": "2x Parfum do prania Vevo Natural No.07 Ylang Absolute 500ml",
+                        "ean": "",
+                        "quantity": 2,
+                        "tax_rate": 20,
+                        "price": {"value": 40.57, "currency": {"code": "EUR"}},
+                        "sum": {"value": 81.14, "currency": {"code": "EUR"}},
+                        "sum_with_tax": {"value": 97.37, "currency": {"code": "EUR"}},
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(12.28, rows[0]["expense_per_item"])
+        self.assertEqual(24.56, rows[0]["total_expense"])
+        self.assertEqual(56.58, rows[0]["profit_before_ads"])
+        self.assertEqual(
+            "bundle_components_inferred:x2:mapped_item_label_normalized",
+            rows[0]["expense_source"],
+        )
+
+    def test_homogeneous_bundle_parser_is_narrow_and_keeps_explicit_bundle_cost_precedence(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        exporter._rebuild_product_expense_indexes(
+            {
+                "Base Product": 4.25,
+                "2x Base Product": 7.5,
+                "Free Product": 0.0,
+            }
+        )
+
+        explicit_cost, explicit_source = exporter._resolve_product_expense("", "2x Base Product")
+        self.assertEqual(7.5, explicit_cost)
+        self.assertEqual("mapped_item_label", explicit_source)
+
+        for label in ("2 x Base Product", "2× Base Product", "3X Base Product"):
+            cost, source = exporter._resolve_product_expense("", label)
+            expected_multiplier = 3 if label.startswith("3") else 2
+            self.assertEqual(4.25 * expected_multiplier, cost)
+            self.assertTrue(
+                str(source).startswith(f"bundle_components_inferred:x{expected_multiplier}:")
+            )
+
+        normalized_explicit_cost, normalized_explicit_source = exporter._resolve_product_expense(
+            "", "2X Base Product"
+        )
+        self.assertEqual(7.5, normalized_explicit_cost)
+        self.assertEqual("mapped_item_label_normalized", normalized_explicit_source)
+
+        zero_cost, zero_source = exporter._resolve_product_expense("", "3x Free Product")
+        self.assertEqual(0.0, zero_cost)
+        self.assertTrue(str(zero_source).startswith("bundle_components_inferred:x3:"))
+
+        unsafe_labels = (
+            "2x Base Product + Other Product",
+            "2x Base Product 3x Other Product",
+            "2x Base Product zdarma",
+            "3x200ml Base Product",
+            "Walther 2x20",
+        )
+        for label in unsafe_labels:
+            self.assertEqual((None, None), exporter._resolve_product_expense("", label))
+
+    def test_homogeneous_bundle_does_not_infer_from_ambiguous_normalized_cost(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        exporter._rebuild_product_expense_indexes(
+            {
+                "Base (Product)": 4.0,
+                "Base Product": 5.0,
+            }
+        )
+
+        self.assertEqual(
+            (None, None),
+            exporter._resolve_product_expense("", "2x Base-Product"),
+        )
+
+    def test_known_bundle_identifier_wins_over_inferred_or_configured_components(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        exporter._rebuild_product_expense_indexes(
+            {
+                "Base Product": 4.0,
+                "BUNDLE-EAN": 7.0,
+                "BUNDLE-SKU": 9.0,
+                "BUNDLE-IMPORT": 10.0,
+            }
+        )
+
+        homogeneous_cost, homogeneous_source = exporter._resolve_product_expense(
+            "BUNDLE-EAN",
+            "2x Base Product",
+            ean="BUNDLE-EAN",
+        )
+        self.assertEqual(7.0, homogeneous_cost)
+        self.assertEqual("mapped_product_identifier", homogeneous_source)
+
+        configured_cost, configured_source = exporter._resolve_product_expense(
+            "BUNDLE-SKU",
+            "Vlnené gule + Vevo Premium No.06 Royal Cotton 10ml",
+        )
+        self.assertEqual(9.0, configured_cost)
+        self.assertEqual("mapped_product_sku", configured_source)
+
+        combo_cost, combo_source = exporter._resolve_product_expense(
+            "BUNDLE-IMPORT",
+            "Combo Parfum do prania Ylang Absolute 500ml + Prací gél Ylang Absolute 1L",
+            import_code="BUNDLE-IMPORT",
+            ean="8594201618000",
+        )
+        self.assertEqual(10.0, combo_cost)
+        self.assertEqual("mapped_product_identifier", combo_source)
+
+    def test_configured_mixed_bundle_costs_override_shared_component_ean(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        exporter._rebuild_product_expense_indexes(
+            {
+                "Parfum do prania Vevo Natural No.07 Ylang Absolute (500ml)": 6.14,
+                "8594201618000": 2.43,
+                "Prírodné vlnené gule do sušičky 3 ks": 1.60,
+                "Parfum do sušičky Vevo Premium No.06 Royal Cotton 10ml": 0.50,
+            }
+        )
+
+        cases = (
+            (
+                "Combo Parfum do prania Ylang Absolute 500ml + Prací gél Ylang Absolute 1L",
+                "8594201618000",
+                8.57,
+                "bundle_components_configured:ylang_absolute_perfume_gel_1_1",
+            ),
+            (
+                "Combo 1x Parfum do prania Ylang Absolute 500ml + 3x Prací gél Ylang Absolute 1L",
+                "8594201618000",
+                13.43,
+                "bundle_components_configured:ylang_absolute_perfume_gel_1_3",
+            ),
+            (
+                "Vlnené gule + Vevo Premium No.06 Royal Cotton 10ml",
+                "H-C0FBC1FB",
+                2.10,
+                "bundle_components_configured:wool_balls_royal_cotton_dryer_fragrance_1_1",
+            ),
+        )
+        for label, identifier, expected_cost, expected_source in cases:
+            cost, source = exporter._resolve_product_expense(
+                identifier,
+                label,
+                ean=identifier if identifier.isdigit() else "",
+            )
+            self.assertAlmostEqual(expected_cost, cost, places=2)
+            self.assertEqual(expected_source, source)
+
+    def test_configured_bundle_rule_fails_closed_when_component_cost_is_missing(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        exporter._rebuild_product_expense_indexes({"8594201618000": 2.43})
+
+        with self.assertRaisesRegex(ValueError, "references missing expense key"):
+            exporter._resolve_product_expense(
+                "8594201618000",
+                "Combo Parfum do prania Ylang Absolute 500ml + Prací gél Ylang Absolute 1L",
+                ean="8594201618000",
+            )
+
+    def test_bundle_cost_sources_are_not_reported_as_missing_purchase_costs(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        frame = pd.DataFrame(
+            [
+                {
+                    "order_num": "V-BUNDLE-A",
+                    "item_label": "2x Base Product",
+                    "product_sku": "BUNDLE-A",
+                    "item_quantity": 1,
+                    "item_total_without_tax": 20.0,
+                    "profit_before_ads": 12.0,
+                    "expense_per_item": 8.0,
+                    "expense_source": "bundle_components_inferred:x2:mapped_item_label",
+                },
+                {
+                    "order_num": "V-BUNDLE-B",
+                    "item_label": "Base Product + Other Product",
+                    "product_sku": "BUNDLE-B",
+                    "item_quantity": 1,
+                    "item_total_without_tax": 30.0,
+                    "profit_before_ads": 18.0,
+                    "expense_per_item": 12.0,
+                    "expense_source": "bundle_components_configured:test_rule",
+                },
+            ]
+        )
+
+        qa = exporter._build_product_expense_coverage_qa(frame)
+
+        self.assertEqual(0, qa["fallback_rows"])
+        self.assertEqual(0, qa["missing_cost_product_entry_count"])
+
     def test_roy_mapped_cost_keeps_real_loss_despite_missing_cost_margin(self) -> None:
         exporter = make_exporter(project_name="roy")
         exporter.product_expenses_exact["LOSS-SKU"] = 80.0


### PR DESCRIPTION
## What changed
- derive homogeneous leading-multiplier bundle costs (for example `2x Product`) from a unique known base-product purchase cost
- configure exact component composition for the two Ylang perfume/gel combos and the wool-balls/Royal-Cotton bundle
- preserve direct bundle title, compound, SKU, EAN, import-code, and warehouse-cost precedence; bypass only explicitly declared shared component identifiers
- fail closed on duplicate rules, missing component costs, invalid quantities, and non-finite or negative configured costs

## Why
VEVO bundle rows could fall back to the 35% estimate or inherit only one component's EAN cost. The 2x Ylang bundle should cost `2 x EUR 6.14`, while the mixed combos must include both perfume and gel components.

## Expected reporting impact
- full company profit: `EUR 17,531.00 -> EUR 17,504.90` (`-EUR 26.10`)
- full missing-cost revenue: `EUR 523.47 -> EUR 409.97` (`0.44% -> 0.35%`)
- full missing-cost products: `13 -> 11`

## Validation
- `python -m unittest discover -s tests -p test_*.py` (`167` tests passed)
- `python scripts/reporting_qa_smoke.py`
- Python compile, VEVO JSON parse, and `git diff --check`
- independent accounting-impact validation against production generation `20260715T174819Z`
- independent code review with no remaining blockers