### PR TITLE
Harden live dashboard Unicode authentication

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4701,3 +4701,17 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - the production Facebook access token appeared in a local ignored `.env` line in tool output during a read-only audit; it was not committed or added to any project artifact, but it must be treated as compromised and rotated in Meta plus the production secret store
 - Next exact step:
   - rotate the production Facebook access token, update the managed production secret without committing it, then verify the Facebook connection and monitor the next scheduled `roy-daily-report-email` run on task definition `:48`
+
+### 2026-07-16 (live dashboard Unicode Basic Auth hardening)
+- Verification false alarm and real robustness bug:
+  - a read-only PowerShell verification pipeline corrupted the ASCII SSM password into a non-ASCII request value; those malformed requests returned HTTP `502`
+  - direct secret loading via boto3 confirmed ROY production stayed healthy: authenticated board/API/PDF routes returned HTTP `200`
+  - the malformed request still exposed a real server bug: string-based `hmac.compare_digest` raises `TypeError` for non-ASCII input instead of rejecting invalid authentication with HTTP `401`
+- Fix in progress:
+  - compare UTF-8 encoded credential bytes in constant time and reject unencodable values safely
+  - add regression tests for valid UTF-8 credentials and malformed non-ASCII input against ASCII production credentials
+- Verified before deploy:
+  - production traceback identifies the failure at `live_dashboard_server.py:66`
+  - reporting artifacts, scheduler, App Runner service, and correctly authenticated live routes remain healthy
+- Next exact step:
+  - pass the focused/full test gates, merge through PR, rebuild the exact image, deploy both App Runner services without refreshing artifacts, then verify malformed auth returns `401` and valid protected live UI/API routes return `200`

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -63,7 +63,15 @@ def is_authorized_basic_header(header: Optional[str], credentials: Optional[Tupl
     user, separator, password = decoded.partition(":")
     if not separator:
         return False
-    return hmac.compare_digest(user, expected_user) and hmac.compare_digest(password, expected_password)
+    try:
+        user_matches = hmac.compare_digest(user.encode("utf-8"), expected_user.encode("utf-8"))
+        password_matches = hmac.compare_digest(
+            password.encode("utf-8"),
+            expected_password.encode("utf-8"),
+        )
+    except UnicodeEncodeError:
+        return False
+    return user_matches and password_matches
 
 
 def available_projects() -> List[str]:

--- a/tests/test_live_dashboard_auth.py
+++ b/tests/test_live_dashboard_auth.py
@@ -29,6 +29,20 @@ class LiveDashboardAuthTests(unittest.TestCase):
 
     @patch.dict(
         os.environ,
+        {"LIVE_DASHBOARD_AUTH_USER": "roy21", "LIVE_DASHBOARD_AUTH_PASSWORD": "tajne-heslo-žľš"},
+        clear=True,
+    )
+    def test_basic_auth_accepts_utf8_credentials(self) -> None:
+        credentials = live_dashboard_auth_credentials()
+        self.assertTrue(
+            is_authorized_basic_header(basic_header("roy21", "tajne-heslo-žľš"), credentials)
+        )
+        self.assertFalse(
+            is_authorized_basic_header(basic_header("roy21", "tajne-heslo-zls"), credentials)
+        )
+
+    @patch.dict(
+        os.environ,
         {"LIVE_DASHBOARD_AUTH_USER": "vevo", "LIVE_DASHBOARD_AUTH_PASSWORD": "secret"},
         clear=True,
     )
@@ -38,6 +52,7 @@ class LiveDashboardAuthTests(unittest.TestCase):
         self.assertFalse(is_authorized_basic_header("Bearer token", credentials))
         self.assertFalse(is_authorized_basic_header("Basic not-base64", credentials))
         self.assertFalse(is_authorized_basic_header(basic_header("vevo", "wrong"), credentials))
+        self.assertFalse(is_authorized_basic_header(basic_header("vevo", "wröng"), credentials))
         self.assertFalse(is_authorized_basic_header(basic_header("other", "secret"), credentials))
 
     @patch.dict(os.environ, {"LIVE_DASHBOARD_AUTH_USER": "vevo"}, clear=True)


### PR DESCRIPTION
## Summary
- compare Basic Auth credentials as UTF-8 bytes so `hmac.compare_digest` supports Unicode safely
- reject malformed/non-ASCII wrong credentials with `401` instead of crashing the request handler with `502`
- add regression coverage for valid UTF-8 credentials and a non-ASCII invalid password against ASCII production credentials
- document the PowerShell verification false alarm and the actual robustness issue in PROJECT_STATE.md

## Production evidence
A read-only verifier corrupted the ASCII SSM password through a PowerShell native pipeline. Correct boto3-loaded credentials confirmed ROY production stayed healthy (board/API/PDF HTTP 200), but the malformed request exposed a real `TypeError` at `live_dashboard_server.py:66`.

## Validation
- focused auth tests: 5 passed
- full suite: 177 passed
- reporting QA smoke passed
- Python compile and `git diff --check` passed