### PR TITLE
Enforce exported reporting cent identity

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4715,3 +4715,21 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - reporting artifacts, scheduler, App Runner service, and correctly authenticated live routes remain healthy
 - Next exact step:
   - pass the focused/full test gates, merge through PR, rebuild the exact image, deploy both App Runner services without refreshing artifacts, then verify malformed auth returns `401` and valid protected live UI/API routes return `200`
+
+### 2026-07-16 (item-level exported cent identity)
+- Audit finding:
+  - ROY immutable generation `20260715T224903Z` had `23` legacy 35% fallback rows where independently rounded `profit_before_ads` differed from exported revenue minus exported cost by `0.01 EUR`
+  - the net item/product-profit overstatement was `0.03 EUR`; company profit was unaffected because company aggregation recomputes profit from summed revenue and costs
+  - VEVO immutable generation `20260715T220511Z` had `0` mismatches across `13,094` item rows, but shared code was susceptible to the same half-cent edge case
+- Fix:
+  - every exported item profit now equals cent-rounded exported revenue minus cent-rounded exported cost
+  - non-authoritative ROI intentionally stays on its established raw-value basis, so the correction does not create unrelated ROI churn
+  - regression and QA smoke fixtures cover both `missing_cost_margin_35_fallback` and `margin_35_override`
+- Local verification:
+  - focused cent-identity and authoritative-margin tests passed
+  - full suite: `178` tests passed
+  - reporting QA smoke, Python compile, and `git diff --check` passed
+- Known separate reporting issue:
+  - standalone ROY 30d/90d payloads do not resolve all creditnoted orders from the full-history context, omitting `0.50/0.75 EUR` of fulfillment cost; the full payload is correct and this needs a separate fix
+- Next exact step:
+  - merge through PR, build the exact ECR image, regenerate the affected ROY history, verify zero row identity mismatches, and synchronize the production App Runner services/scheduled task definitions to the final image

--- a/export_orders.py
+++ b/export_orders.py
@@ -5956,18 +5956,28 @@ class BizniWebExporter:
                                 item_quantity,
                             )
                 total_expense = expense_per_item * item_quantity
+                reported_revenue = round(item_total_without_tax, 2)
                 reported_total_expense = round(total_expense, 2)
+                reported_item_profit_before_ads = round(
+                    reported_revenue - reported_total_expense,
+                    2,
+                )
                 
                 # Calculate profit and ROI (Note: FB ads will be added at aggregation level)
                 # At item level, we only have product expense
                 if authoritative_margin_applied:
-                    # Keep the exported accounting identity exact after cent rounding.
-                    item_profit_before_ads = round(item_total_without_tax, 2) - reported_total_expense
+                    roi_profit_before_ads = reported_item_profit_before_ads
                     roi_expense = reported_total_expense
                 else:
-                    item_profit_before_ads = item_total_without_tax - total_expense
+                    # Preserve the established raw-basis ROI while the exported accounting
+                    # values use one exact cent identity for every expense source.
+                    roi_profit_before_ads = item_total_without_tax - total_expense
                     roi_expense = total_expense
-                item_roi_before_ads = (item_profit_before_ads / roi_expense * 100) if roi_expense > 0 else 0
+                item_roi_before_ads = (
+                    roi_profit_before_ads / roi_expense * 100
+                    if roi_expense > 0
+                    else 0
+                )
                 
                 row = base_data.copy()
                 row.update({
@@ -5989,7 +5999,7 @@ class BizniWebExporter:
                     'item_line_sum_original': item_line_net_original,
                     'item_line_sum_with_tax_original': item_line_gross_original,
                     'item_total_with_tax': round(item_total_with_tax, 2),  # In EUR
-                    'item_total_without_tax': round(item_total_without_tax, 2),  # In EUR
+                    'item_total_without_tax': reported_revenue,  # In EUR
                     'item_tax_amount': round(item_tax_amount, 2),  # In EUR
                     'item_recycle_fee': recycle_fee.get('value'),
                     'expense_per_item': expense_per_item,
@@ -5997,7 +6007,7 @@ class BizniWebExporter:
                     'purchase_cost_reference_per_item': purchase_cost_reference_per_item,
                     'purchase_cost_reference_source': purchase_cost_reference_source,
                     'total_expense': reported_total_expense,
-                    'profit_before_ads': round(item_profit_before_ads, 2),
+                    'profit_before_ads': reported_item_profit_before_ads,
                     'roi_before_ads': round(item_roi_before_ads, 2),
                 })
                 item_rows.append(row)

--- a/scripts/reporting_qa_smoke.py
+++ b/scripts/reporting_qa_smoke.py
@@ -7,6 +7,7 @@ import pathlib
 import re
 import sys
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pandas as pd
 
@@ -443,6 +444,57 @@ def assert_authoritative_margin_policy_source_of_truth() -> None:
         )
 
 
+def assert_exported_row_cent_identity() -> None:
+    exporter = make_exporter()
+    with patch("export_orders.MISSING_COST_MARGIN_PCT", 35.0), patch(
+        "export_orders.MARGIN_OVERRIDE_SKUS", {"CENT-LEGACY": 35.0}
+    ), patch("export_orders.MARGIN_OVERRIDE_BRANDS", {}), patch(
+        "export_orders.MARGIN_OVERRIDE_LABEL_PATTERNS", {}
+    ):
+        rows = exporter.flatten_order(
+            {
+                "id": "1",
+                "order_num": "QA-CENT-IDENTITY",
+                "pur_date": "2026-07-14 10:00:00",
+                "sum": {"value": 12.20, "currency": {"code": "EUR"}},
+                "customer": {"email": "qa@example.com"},
+                "items": [
+                    {
+                        "item_label": "Unknown cent product",
+                        "ean": "MISSING-CENT",
+                        "quantity": 1,
+                        "tax_rate": 0,
+                        "price": {"value": 6.10, "currency": {"code": "EUR"}},
+                        "sum": {"value": 6.10, "currency": {"code": "EUR"}},
+                        "sum_with_tax": {"value": 6.10, "currency": {"code": "EUR"}},
+                    },
+                    {
+                        "item_label": "Legacy cent override",
+                        "ean": "",
+                        "import_code": "CENT-LEGACY",
+                        "quantity": 1,
+                        "tax_rate": 0,
+                        "price": {"value": 6.10, "currency": {"code": "EUR"}},
+                        "sum": {"value": 6.10, "currency": {"code": "EUR"}},
+                        "sum_with_tax": {"value": 6.10, "currency": {"code": "EUR"}},
+                    },
+                ],
+            }
+        )
+    assert len(rows) == 2, rows
+    for row in rows:
+        expected_profit = round(
+            float(row["item_total_without_tax"]) - float(row["total_expense"]),
+            2,
+        )
+        assert math.isclose(
+            float(row["profit_before_ads"]),
+            expected_profit,
+            rel_tol=0.0,
+            abs_tol=0.0,
+        ), row
+
+
 def assert_daily_runner_fixed_overhead_not_double_subtracted() -> None:
     row_by_date = {
         datetime(2026, 4, 1).date(): {
@@ -497,6 +549,7 @@ def main() -> int:
     assert_daily_profit_loss_payload_and_ui()
     assert_roy_fixed_cost_source_of_truth()
     assert_authoritative_margin_policy_source_of_truth()
+    assert_exported_row_cent_identity()
     assert_daily_runner_fixed_overhead_not_double_subtracted()
     print("reporting_qa_smoke.py: OK")
     return 0

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -689,6 +689,57 @@ class ReportingCalculationFixTests(unittest.TestCase):
         self.assertEqual(65.0, rows[0]["total_expense"])
         self.assertEqual(35.0, rows[0]["profit_before_ads"])
 
+    def test_legacy_35_percent_rows_keep_exported_cent_identity(self) -> None:
+        exporter = make_exporter(project_name="roy")
+        base_item = {
+            "quantity": 1,
+            "tax_rate": 0,
+            "price": {"value": 6.10, "currency": {"code": "EUR"}},
+            "sum": {"value": 6.10, "currency": {"code": "EUR"}},
+            "sum_with_tax": {"value": 6.10, "currency": {"code": "EUR"}},
+        }
+
+        with patch("export_orders.MISSING_COST_MARGIN_PCT", 35.0), patch(
+            "export_orders.MARGIN_OVERRIDE_SKUS", {"CENT-LEGACY": 35.0}
+        ), patch("export_orders.MARGIN_OVERRIDE_BRANDS", {}), patch(
+            "export_orders.MARGIN_OVERRIDE_LABEL_PATTERNS", {}
+        ):
+            rows = exporter.flatten_order(
+                {
+                    "id": "1",
+                    "order_num": "R-CENT-IDENTITY",
+                    "pur_date": "2026-07-14 10:00:00",
+                    "sum": {"value": 12.20, "currency": {"code": "EUR"}},
+                    "customer": {"email": "a@example.com"},
+                    "items": [
+                        {
+                            **base_item,
+                            "item_label": "Unknown cent product",
+                            "ean": "MISSING-CENT",
+                        },
+                        {
+                            **base_item,
+                            "item_label": "Legacy cent override",
+                            "ean": "",
+                            "import_code": "CENT-LEGACY",
+                        },
+                    ],
+                }
+            )
+
+        self.assertEqual(
+            ["missing_cost_margin_35_fallback", "margin_35_override"],
+            [row["expense_source"] for row in rows],
+        )
+        self.assertEqual([3.96, 3.96], [row["total_expense"] for row in rows])
+        self.assertEqual([2.14, 2.14], [row["profit_before_ads"] for row in rows])
+        self.assertEqual([53.85, 53.85], [row["roi_before_ads"] for row in rows])
+        for row in rows:
+            self.assertEqual(
+                round(row["item_total_without_tax"] - row["total_expense"], 2),
+                row["profit_before_ads"],
+            )
+
     def test_mapped_purchase_cost_wins_over_legacy_overrides(self) -> None:
         exporter = make_exporter(project_name="roy")
         exporter.product_expenses_exact.update(


### PR DESCRIPTION
## Summary
- derive every exported `profit_before_ads` from the already cent-rounded exported revenue and cost
- preserve the established raw-basis ROI for non-authoritative rows
- add regressions and reporting smoke coverage for missing-cost and legacy 35% margin half-cent cases
- document the production audit and the separate ROY period creditnote-context issue

## Production finding
ROY generation `20260715T224903Z` contained 23 legacy 35% rows with one-cent row identity mismatches. They netted to EUR +0.03 of item/product profit. Company profit was unaffected because company aggregation recomputes profit from summed revenue and costs. VEVO had zero current mismatches but shared the susceptible code path.

## Validation
- focused cent-identity + authoritative policy tests passed
- full suite: 178 tests passed
- reporting QA smoke passed
- Python compile and diff check passed