### PR TITLE
Fix period credit-note reporting context

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4733,3 +4733,24 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - standalone ROY 30d/90d payloads do not resolve all creditnoted orders from the full-history context, omitting `0.50/0.75 EUR` of fulfillment cost; the full payload is correct and this needs a separate fix
 - Next exact step:
   - merge through PR, build the exact ECR image, regenerate the affected ROY history, verify zero row identity mismatches, and synchronize the production App Runner services/scheduled task definitions to the final image
+
+### 2026-07-16 (period credit-note context parity)
+- Root cause:
+  - the full-history exporter retained excluded/Storno orders, but the child exporters used for the standalone `7d`, `30d`, and `90d` reports received only realized orders
+  - this caused all period credit-note audits to report those orders as `order_not_found` and caused ROY to omit `0.50 EUR` of 30-day and `0.75 EUR` of 90-day retained fulfillment cost
+- Safety action:
+  - replacement VEVO rollout run `29458042558` was cancelled before localhost validation, S3 publication, scheduler promotion, or App Runner deployment
+  - candidate task `c623dcb99cc443c1a858046546709aac` (`172.31.29.81`, task definition `vevo-reporting-daily:20`) stopped with the explicit reason `Cancelled before publish: period creditnote context P1 fix required`
+  - production remained on task definition `:19`, S3 generation `20260715T220511Z`, and healthy digest `sha256:2ac61cc50ae86c9b11052c1a4b2cc9bd2d75c13f2a544c86b8a01ac3bccd7f12`
+- Fix in progress on `codex/reporting-period-creditnote-context`:
+  - each period child now receives deep-copied, range-filtered `excluded_status_orders` and `excluded_orders`
+  - credit-note audits separately receive a shared read-only full-history lookup because a credit note created in the selected period can refer to an older order
+  - carrier denominators remain explicitly period-scoped; the historical lookup cannot inflate lifecycle, CRM, fulfillment, or carrier-rate denominators
+  - regression coverage verifies the `7d`/`30d`/`90d` slices, an in-period credit note for an older order, credit-note audit resolution, CRM/lifecycle boundaries, carrier denominator isolation, and retained fulfillment cost
+- Verified so far:
+  - focused period context regression passed
+  - full suite: `179` tests passed
+  - reporting QA smoke, Python compile, and `git diff --check` passed
+  - independent re-review found no remaining P0/P1 issues and marked the change safe to merge
+- Next exact step:
+  - complete the full test/review gates, merge through PR, build one immutable image, regenerate both VEVO and ROY histories, and verify localhost markers before S3/scheduler/App Runner/UI promotion

--- a/creditnote_export.py
+++ b/creditnote_export.py
@@ -871,6 +871,9 @@ def build_creditnote_reporting_audit(
         project_key = project.upper()
         included_orders = context.get("included_orders") or []
         all_orders = context.get("all_orders") or []
+        carrier_denominator_orders = context.get("carrier_denominator_orders")
+        if carrier_denominator_orders is None:
+            carrier_denominator_orders = all_orders
         included_order_sets[project_key] = {
             normalize_order_num(order.get("order_num"))
             for order in included_orders
@@ -880,7 +883,7 @@ def build_creditnote_reporting_audit(
         decision_maps[project_key] = dict(context.get("creditnote_order_decisions") or {})
         status_audits[project_key] = context.get("status_change_audit") or {}
         shipped_statuses_by_project[project_key] = tuple(context.get("shipped_statuses") or creditnote_shipped_statuses())
-        for order in all_orders:
+        for order in carrier_denominator_orders:
             order_num = normalize_order_num(order.get("order_num"))
             if not order_num:
                 continue

--- a/export_orders.py
+++ b/export_orders.py
@@ -760,6 +760,7 @@ class BizniWebExporter:
         self.unknown_currencies = set()
         self.excluded_orders = []  # Track orders with failed/excluded statuses for segmentation
         self.excluded_status_orders = []  # Track all excluded status orders for lifecycle proxy reporting
+        self.creditnote_audit_context_orders: Tuple[Dict[str, Any], ...] = ()
         self._creditnote_order_nums_cache: Optional[set[str]] = None
         self._creditnote_status_change_audit_cache: Optional[Dict[str, Any]] = None
         self._rebuild_product_expense_indexes(PRODUCT_EXPENSES)
@@ -1310,6 +1311,9 @@ class BizniWebExporter:
         main_report_path = self.output_path(f"report_{date_from.strftime('%Y%m%d')}-{date_to.strftime('%Y%m%d')}.html")
         bundle_root = Path("_periods") / main_report_path.stem
 
+        creditnote_audit_context_orders = (
+            tuple(orders or []) + tuple(self.excluded_status_orders or [])
+        )
         for spec in specs:
             if spec['key'] == 'full':
                 spec['report_path'] = main_report_path
@@ -1333,12 +1337,36 @@ class BizniWebExporter:
             if spec['key'] == 'full':
                 continue
             filtered_orders = self._filter_orders_by_range(orders, spec['date_from'], spec['date_to'])
+            child_exporter = spec['exporter']
+            # Period exporters receive only realized orders as their main input. Keep
+            # the matching excluded-order context as well so credit-note fulfillment,
+            # CRM, and lifecycle metrics reconcile with the same slice of the
+            # full-history report.
+            child_exporter.excluded_status_orders = copy.deepcopy(
+                self._filter_orders_by_range(
+                    self.excluded_status_orders,
+                    spec['date_from'],
+                    spec['date_to'],
+                )
+            )
+            child_exporter.excluded_orders = copy.deepcopy(
+                self._filter_orders_by_range(
+                    self.excluded_orders,
+                    spec['date_from'],
+                    spec['date_to'],
+                )
+            )
+            # Credit notes are selected by their creation date and can reference an
+            # order purchased before the selected report period. Share a read-only
+            # full-history lookup for the audit only; the range-filtered lists above
+            # remain the source for lifecycle, CRM, and fulfillment-cost metrics.
+            child_exporter.creditnote_audit_context_orders = creditnote_audit_context_orders
             switcher_payload = self._build_period_switcher_payload(
                 current_key=spec['key'],
                 current_path=spec['report_path'],
                 specs=specs,
             )
-            spec['exporter'].export_to_csv(
+            child_exporter.export_to_csv(
                 filtered_orders,
                 spec['date_from'],
                 spec['date_to'],
@@ -5258,7 +5286,12 @@ class BizniWebExporter:
         except (TypeError, ValueError):
             return None
 
-    def _build_creditnote_reporting_context(self, orders: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _build_creditnote_reporting_context(
+        self,
+        orders: List[Dict[str, Any]],
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+    ) -> Dict[str, Any]:
         included_by_num = {
             str((order or {}).get("order_num") or "").strip(): order
             for order in orders or []
@@ -5266,12 +5299,26 @@ class BizniWebExporter:
         }
         all_order_map: Dict[str, Dict[str, Any]] = {}
         decision_map: Dict[str, Dict[str, Any]] = {}
-        for order in [*(orders or []), *(self.excluded_status_orders or [])]:
+        audit_context_orders = self.creditnote_audit_context_orders or (
+            tuple(orders or []) + tuple(self.excluded_status_orders or [])
+        )
+        for order in audit_context_orders:
             order_num = str((order or {}).get("order_num") or "").strip()
             if not order_num or order_num in all_order_map:
                 continue
             all_order_map[order_num] = order
-            include, reason = self._realized_revenue_decision(order)
+            purchase_dt = self._order_purchase_datetime(order)
+            outside_period = bool(
+                date_from is not None
+                and date_to is not None
+                and purchase_dt is not None
+                and not (date_from.date() <= purchase_dt.date() <= date_to.date())
+            )
+            if outside_period:
+                include = False
+                reason = "Original order is outside the report purchase-date window"
+            else:
+                include, reason = self._realized_revenue_decision(order)
             decision_map[order_num] = {"included": bool(include), "reason": reason}
         for order_num, order in included_by_num.items():
             all_order_map.setdefault(order_num, order)
@@ -5282,6 +5329,10 @@ class BizniWebExporter:
             "error": "",
             "included_orders": list(included_by_num.values()),
             "all_orders": list(all_order_map.values()),
+            "carrier_denominator_orders": [
+                *(orders or []),
+                *(self.excluded_status_orders or []),
+            ],
             "creditnote_order_decisions": decision_map,
             "creditnote_order_errors": {},
             "status_change_audit": self._creditnote_status_change_audit(),
@@ -5306,7 +5357,7 @@ class BizniWebExporter:
             date_from.date(),
             date_to.date(),
         )
-        context = self._build_creditnote_reporting_context(orders)
+        context = self._build_creditnote_reporting_context(orders, date_from, date_to)
         enriched_rows, carrier_rows, audit = build_creditnote_reporting_audit(
             creditnote_rows,
             {self.project_name: context},

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -90,6 +90,146 @@ def analytics_item_row(
 
 
 class ReportingCalculationFixTests(unittest.TestCase):
+    def test_period_bundle_carries_range_filtered_excluded_order_context(self) -> None:
+        exporter = BizniWebExporter(
+            api_url="https://example.com/api/graphql",
+            api_token="token",
+            project_name="vevo",
+            output_tag="unit",
+            enable_period_bundle=True,
+        )
+        date_from = datetime(2026, 1, 1)
+        date_to = datetime(2026, 6, 30)
+        packeta = price_element("shipping", "Packeta - vydajne miesto", "9")
+        orders = [
+            {
+                "order_num": "OK-7D",
+                "pur_date": "2026-06-29 10:00:00",
+                "status": {"name": "odoslana"},
+                "price_elements": [packeta],
+            },
+            {"order_num": "OK-30D", "pur_date": "2026-06-10 10:00:00"},
+            {"order_num": "OK-90D", "pur_date": "2026-05-01 10:00:00"},
+        ]
+        exporter.excluded_status_orders = [
+            {"order_num": "RETURN-7D", "pur_date": "2026-06-29 11:00:00", "status": {"name": "Storno"}},
+            {"order_num": "RETURN-30D", "pur_date": "2026-06-10 11:00:00", "status": {"name": "Storno"}},
+            {"order_num": "RETURN-90D", "pur_date": "2026-05-01 11:00:00", "status": {"name": "Storno"}},
+            {
+                "order_num": "RETURN-OLD",
+                "pur_date": "2026-02-01 11:00:00",
+                "status": {"name": "Storno"},
+                "price_elements": [packeta],
+            },
+        ]
+        exporter.excluded_orders = [
+            {"order_num": "FAILED-7D", "pur_date": "2026-06-29 12:00:00"},
+            {"order_num": "FAILED-30D", "pur_date": "2026-06-10 12:00:00"},
+            {"order_num": "FAILED-90D", "pur_date": "2026-05-01 12:00:00"},
+            {"order_num": "FAILED-OLD", "pur_date": "2026-02-01 12:00:00"},
+        ]
+
+        with patch.object(BizniWebExporter, "export_to_csv", autospec=True) as export_mock:
+            exporter._build_period_switcher_bundle(orders, date_from, date_to)
+
+        children = {
+            Path(call.args[0].artifact_subdir).name: call.args[0]
+            for call in export_mock.call_args_list
+        }
+        expected = {
+            "7d": (["RETURN-7D"], ["FAILED-7D"]),
+            "30d": (["RETURN-7D", "RETURN-30D"], ["FAILED-7D", "FAILED-30D"]),
+            "90d": (
+                ["RETURN-7D", "RETURN-30D", "RETURN-90D"],
+                ["FAILED-7D", "FAILED-30D", "FAILED-90D"],
+            ),
+        }
+        self.assertEqual(set(expected), set(children))
+        for key, (status_order_nums, excluded_order_nums) in expected.items():
+            child = children[key]
+            self.assertEqual(status_order_nums, [row["order_num"] for row in child.excluded_status_orders])
+            self.assertEqual(excluded_order_nums, [row["order_num"] for row in child.excluded_orders])
+            child._creditnote_status_change_audit_cache = {"project": "vevo", "orders": []}
+
+        self.assertIsNot(
+            children["7d"].excluded_status_orders[0],
+            exporter.excluded_status_orders[0],
+        )
+
+        child_7d = children["7d"]
+        child_7d._creditnote_status_change_audit_cache = {
+            "project": "vevo",
+            "orders": [{"order_num": "RETURN-OLD", "previous_status": "odoslana"}],
+        }
+        creditnote_rows = [
+            {
+                "number": "CN-PERIOD-1",
+                "creditnote_id": "1",
+                "created": "2026-06-30 08:00:00",
+                "order_num": "RETURN-OLD",
+                "price": "10 EUR",
+                "taxed_price": "12.30 EUR",
+            }
+        ]
+        with patch("creditnote_export.fetch_project_creditnotes", return_value=(creditnote_rows, 1)):
+            metrics = child_7d.analyze_creditnote_reporting_metrics(
+                [orders[0]],
+                datetime(2026, 6, 24),
+                date_to,
+                pd.DataFrame([{"unique_orders": 1}]),
+            )
+        self.assertEqual(0, metrics["summary"]["order_not_found"])
+        self.assertEqual(1, metrics["summary"]["revenue_excluded_orders"])
+        audit_row = metrics["revenue_audit_rows"][0]
+        self.assertEqual("excluded", audit_row["Reporting revenue"])
+        self.assertEqual(
+            "Original order is outside the report purchase-date window",
+            audit_row["Reporting revenue reason"],
+        )
+        self.assertNotIn(
+            "RETURN-OLD",
+            [row["order_num"] for row in child_7d.excluded_status_orders],
+        )
+        packeta_carrier = next(
+            row for row in metrics["carrier_rows"] if row["carrier"] == "Packeta"
+        )
+        self.assertEqual(1, packeta_carrier["realized_orders"])
+        self.assertEqual(1, packeta_carrier["creditnoted_orders"])
+
+        child_7d.excluded_status_orders = []
+        with patch("creditnote_export.fetch_project_creditnotes", return_value=(creditnote_rows, 1)):
+            empty_period_metrics = child_7d.analyze_creditnote_reporting_metrics(
+                [],
+                datetime(2026, 6, 24),
+                date_to,
+                pd.DataFrame(),
+            )
+        empty_period_packeta = next(
+            row for row in empty_period_metrics["carrier_rows"] if row["carrier"] == "Packeta"
+        )
+        self.assertEqual(0, empty_period_packeta["realized_orders"])
+        self.assertIsNone(empty_period_packeta["creditnote_rate_pct"])
+
+        child_30d = children["30d"]
+        child_30d.project_settings["creditnote_fulfillment_costs"] = {
+            "enabled": True,
+            "shipping_cost_per_order": 0.2,
+        }
+        child_30d._creditnote_order_nums_cache = {"RETURN-30D", "RETURN-OLD"}
+        child_30d._creditnote_status_change_audit_cache = {
+            "project": "vevo",
+            "orders": [
+                {"order_num": "RETURN-30D", "previous_status": "odoslana"},
+                {"order_num": "RETURN-OLD", "previous_status": "odoslana"},
+            ],
+        }
+        fulfillment = child_30d._build_creditnote_fulfillment_costs_by_date(
+            datetime(2026, 6, 1),
+            date_to,
+        )
+        self.assertEqual(1, int(fulfillment["creditnote_fulfillment_orders"].sum()))
+        self.assertEqual(0.5, float(fulfillment["creditnote_fulfillment_cost"].sum()))
+
     def test_unknown_currency_is_not_treated_as_eur(self) -> None:
         exporter = make_exporter()
         with self.assertRaises(ValueError):


### PR DESCRIPTION
﻿## Summary
- carry range-filtered excluded orders into 7d/30d/90d exporters for CRM, lifecycle, and fulfillment parity
- resolve creditnotes created in-period against a separate read-only full-history order lookup
- keep carrier denominators strictly period-scoped, including empty periods
- document the cancelled pre-publish rollout and safe replacement path

## Verification
- `python -m unittest discover -s tests` (179 tests)
- `python scripts/reporting_qa_smoke.py`
- focused cross-period creditnote, fulfillment, and carrier-denominator regression
- Python compile and `git diff --check`
- independent review: no P0/P1 findings
