### PR TITLE
Fix campaign attribution CPA precision

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4754,3 +4754,27 @@ eport_20260301-20260331__test2.html and decide whether the remaining legacy tabl
   - independent re-review found no remaining P0/P1 issues and marked the change safe to merge
 - Next exact step:
   - complete the full test/review gates, merge through PR, build one immutable image, regenerate both VEVO and ROY histories, and verify localhost markers before S3/scheduler/App Runner/UI promotion
+
+### 2026-07-16 (VEVO attributed CPA release gate and rollback)
+- Release blocker:
+  - immutable VEVO generation `20260716T001511Z` passed all product-accounting, credit-note, cent-identity, and period-parity audits but its 7-day payload had one critical data assertion
+  - campaign `SK-Sale-VEVO-SandBox-ABO-ACQ` reported spend `0.28 EUR`, attributed orders `0.2`, and CPA `1.21 EUR`; the displayed arithmetic requires `1.40 EUR`
+  - root cause: campaign CPA used the raw attributed-order estimate while the payload exposed the estimate rounded to one decimal place
+- Safety action:
+  - deploy run `29459459581` was cancelled as soon as the P1 was identified
+  - because publication/promotion raced immediately ahead of cancellation, S3 `latest` was restored and byte-validated against healthy generation `20260715T220511Z`
+  - scheduler `vevo-daily-report-email` was restored and verified `ENABLED`, `cron(0 1 * * ? *)`, `Europe/Bratislava`, task definition `vevo-reporting-daily:19`
+  - App Runner rollback operation `0f1d7cef5e7144e9a22d86c8f82a1c9c` completed `SUCCEEDED`; service `biznisweb-vevo-production-board` is `RUNNING` on healthy digest `sha256:2ac61cc50ae86c9b11052c1a4b2cc9bd2d75c13f2a544c86b8a01ac3bccd7f12` and `/health` returns HTTP `200`
+  - immutable generation `20260716T001511Z` remains only as audit evidence and is not the live `latest`
+- Fix prepared on `codex/reporting-attributed-cpa-rounding`:
+  - campaign attribution now serializes attributed orders to four decimals and uses that exact denominator consistently for CPA, estimated revenue, ROAS, QA, and campaign ranking
+  - a production-shaped replay of the original campaign row now reports `0.2305` attributed orders and `1.21 EUR` CPA; the deterministic unit fixture reports `0.232` and `1.21 EUR`, and both displayed calculations reconcile without the one-decimal distortion
+  - ultra-small estimates that round below `0.0001` are marked `insufficient_sample`, expose CPA as `null`/`N/A`, and raise an explicit QA warning instead of looking like free acquisition
+  - modern and legacy dashboard tables use adaptive precision; charts preserve a missing CPA as `null` instead of converting it to zero
+  - boundary regressions cover `0.249/0.251/0.500` ranking, the exact production row, and an ultra-small positive attribution
+- Verification:
+  - focused reporting/dashboard suite: `76` tests OK
+  - full unit suite: `183` tests OK
+  - reporting QA smoke, Python compile, both project settings JSON parses, and `git diff --check` passed
+- Next exact step:
+  - complete independent re-review, merge through PR, build one immutable image, then rerun the full VEVO hard gate and audit before touching ROY

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -81,6 +81,26 @@ def _maybe_num(value: Any) -> Optional[float]:
         return None
 
 
+def _format_attributed_order_estimate(value: Any, sample_status: Any = "") -> str:
+    numeric = _maybe_num(value)
+    status = str(sample_status or "").strip()
+    if status == "insufficient_sample" and (numeric is None or numeric <= 0):
+        return "&lt;0.0001"
+    if numeric is None:
+        return "N/A"
+    if 0 < numeric < 0.0001:
+        return "&lt;0.0001"
+    return f"{numeric:.4f}".rstrip("0").rstrip(".")
+
+
+def _format_attributed_cpa(value: Any, sample_status: Any = "") -> str:
+    numeric = _maybe_num(value)
+    status = str(sample_status or "").strip()
+    if numeric is None or status in {"insufficient_sample", "unavailable"}:
+        return "N/A"
+    return f"&euro;{numeric:,.2f}"
+
+
 def _json_default(value: Any) -> Any:
     if isinstance(value, (date, datetime)):
         return value.isoformat()
@@ -1088,7 +1108,7 @@ def generate_modern_dashboard(
 
     cpo_daily = _frame_rows(_to_frame((cost_per_order or {}).get("daily_cpo")), ["date", "orders", "fb_spend", "revenue", "cpo", "roas"], limit=120)
     weekly_cpo = _frame_rows(_to_frame((cost_per_order or {}).get("weekly_cpo")), ["week_start", "orders", "fb_spend", "cpo"], limit=60)
-    campaign_cpo = _frame_rows(_to_frame((cost_per_order or {}).get("campaign_attribution")), ["campaign_name", "spend", "attributed_orders_est", "estimated_orders", "cost_per_attributed_order", "estimated_cpo", "estimated_revenue", "estimated_roas", "attribution_method"], limit=12)
+    campaign_cpo = _frame_rows(_to_frame((cost_per_order or {}).get("campaign_attribution")), ["campaign_name", "spend", "attributed_orders_est", "estimated_orders", "cost_per_attributed_order", "estimated_cpo", "estimated_revenue", "estimated_roas", "attribution_method", "attribution_sample_status"], limit=12)
     hourly_orders = _frame_rows(_to_frame((cost_per_order or {}).get("hourly_orders")), ["hour", "orders", "revenue"], limit=24)
     fb_hourly_payload = _frame_rows(_to_frame(fb_hourly_stats), ["hour", "spend", "clicks", "impressions", "ctr", "cpc"], limit=24)
     fb_dow_payload = _frame_rows(_to_frame(fb_dow_stats), ["day_of_week", "total_spend", "total_clicks", "ctr", "cpc", "cpm"], limit=7)
@@ -3452,7 +3472,7 @@ def generate_modern_dashboard(
         for row in fb_campaign_rows
     ) or '<tr><td colspan="6"><span class="lang-en">No campaign data available.</span><span class="lang-sk hidden">Kampaňové dáta nie sú dostupné.</span></td></tr>'
     campaign_cpo_rows_html = "".join(
-        f"<tr><td>{escape(str(row.get('campaign_name') or '-'))}</td><td>€{_num(row.get('spend')):,.2f}</td><td>{_num(row.get('attributed_orders_est', row.get('estimated_orders'))):.1f}</td><td>€{_num(row.get('cost_per_attributed_order', row.get('estimated_cpo'))):,.2f}</td><td>€{_num(row.get('estimated_revenue')):,.2f}</td><td>{_num(row.get('estimated_roas')):.2f}x</td></tr>"
+        f"<tr><td>{escape(str(row.get('campaign_name') or '-'))}</td><td>€{_num(row.get('spend')):,.2f}</td><td>{_format_attributed_order_estimate(row.get('attributed_orders_est', row.get('estimated_orders')), row.get('attribution_sample_status'))}</td><td>{_format_attributed_cpa(row.get('cost_per_attributed_order', row.get('estimated_cpo')), row.get('attribution_sample_status'))}</td><td>€{_num(row.get('estimated_revenue')):,.2f}</td><td>{_num(row.get('estimated_roas')):.2f}x</td></tr>"
         for row in campaign_cpo
     ) or '<tr><td colspan="6"><span class="lang-en">No campaign attribution data available.</span><span class="lang-sk hidden">Atribucne data kampani nie su dostupne.</span></td></tr>'
 
@@ -6212,7 +6232,7 @@ def generate_modern_dashboard(
                     data: {{
                         labels: DATA.campaign_cpo.map(x => (x.campaign_name || 'Unknown').slice(0, 24)),
                         datasets: [
-                            {{ type: 'bar', label: 'Estimated CPO', data: DATA.campaign_cpo.map(x => Number(x.estimated_cpo || 0)), backgroundColor: 'rgba(255,138,31,.65)', borderRadius: 8, yAxisID: 'y' }},
+                            {{ type: 'bar', label: 'Estimated CPO', data: DATA.campaign_cpo.map(x => x.estimated_cpo == null ? null : Number(x.estimated_cpo)), backgroundColor: 'rgba(255,138,31,.65)', borderRadius: 8, yAxisID: 'y' }},
                             {{ type: 'line', label: 'Estimated ROAS', data: DATA.campaign_cpo.map(x => Number(x.estimated_roas || 0)), borderColor: '#1f9d66', tension: .28, borderWidth: 2.2, pointRadius: 3, yAxisID: 'y1' }},
                             {{ type: 'line', label: 'Spend', data: DATA.campaign_cpo.map(x => Number(x.spend || 0)), borderColor: '#4766ff', tension: .28, borderWidth: 2.0, pointRadius: 3, yAxisID: 'y' }},
                         ],
@@ -7806,7 +7826,7 @@ def generate_modern_dashboard(
                     type: 'bar',
                     data: {{
                         labels: DATA.campaign_cpo.map(x => (x.campaign_name || 'Unknown').slice(0, 24)),
-                        datasets: [{{ label: 'Estimated CPO', data: DATA.campaign_cpo.map(x => Number(x.estimated_cpo || 0)), backgroundColor: 'rgba(207,80,96,.68)', borderRadius: 8 }}],
+                        datasets: [{{ label: 'Estimated CPO', data: DATA.campaign_cpo.map(x => x.estimated_cpo == null ? null : Number(x.estimated_cpo)), backgroundColor: 'rgba(207,80,96,.68)', borderRadius: 8 }}],
                     }},
                     options: horizontalBarOptions(),
                 }});

--- a/export_orders.py
+++ b/export_orders.py
@@ -1903,6 +1903,7 @@ class BizniWebExporter:
 
         platform_cpa_mismatches = 0
         attributed_cpa_mismatches = 0
+        attributed_cpa_unavailable_rows = 0
         for row in campaign_rows:
             spend = self._safe_float(row.get("spend"))
             platform_conversions = self._safe_float(row.get("platform_conversions", row.get("conversions")))
@@ -1914,9 +1915,19 @@ class BizniWebExporter:
 
             attributed_orders = self._safe_float(row.get("attributed_orders_est"))
             attributed_cpa = self._safe_float(row.get("cost_per_attributed_order"))
+            attribution_sample_status = str(row.get("attribution_sample_status") or "").strip()
             if spend is not None and attributed_orders not in (None, 0):
                 expected = spend / attributed_orders
                 if attributed_cpa is None or abs(expected - attributed_cpa) > 0.05:
+                    attributed_cpa_mismatches += 1
+            elif spend is not None and spend > 0:
+                expected_unavailable = (
+                    attribution_sample_status in {"insufficient_sample", "unavailable"}
+                    and attributed_cpa is None
+                )
+                if expected_unavailable:
+                    attributed_cpa_unavailable_rows += 1
+                else:
                     attributed_cpa_mismatches += 1
 
         if platform_cpa_mismatches > 0:
@@ -1926,6 +1937,10 @@ class BizniWebExporter:
         if attributed_cpa_mismatches > 0:
             failures.append(
                 f"{attributed_cpa_mismatches} campaign row(s) have cost_per_attributed_order that does not match spend/attributed_orders_est."
+            )
+        if attributed_cpa_unavailable_rows > 0:
+            warnings.append(
+                f"{attributed_cpa_unavailable_rows} campaign row(s) have too little attributed-order evidence for a meaningful CPA."
             )
 
         attributed_orders_total = self._safe_float(attribution_summary.get("estimated_orders_total"))
@@ -1971,6 +1986,7 @@ class BizniWebExporter:
             "null_label_rate_pct": null_label_rate_pct,
             "platform_cpa_mismatches": platform_cpa_mismatches,
             "attributed_cpa_mismatches": attributed_cpa_mismatches,
+            "attributed_cpa_unavailable_rows": attributed_cpa_unavailable_rows,
             "attributed_orders_ratio": round(attributed_orders_ratio, 4) if attributed_orders_ratio is not None else None,
             "attributed_orders_tolerance_breached": bool(attributed_orders_ratio is not None and attributed_orders_ratio > 1.05),
             "label_row_total": label_row_total,
@@ -14582,12 +14598,31 @@ class BizniWebExporter:
 
                     # Weighted average (60% clicks, 40% spend as clicks are better signal)
                     estimated_orders = estimated_orders_by_clicks * 0.6 + estimated_orders_by_spend * 0.4
+                    reported_estimated_orders = round(estimated_orders, 4)
+                    if estimated_orders <= 0:
+                        attribution_sample_status = 'unavailable'
+                    elif reported_estimated_orders <= 0:
+                        attribution_sample_status = 'insufficient_sample'
+                    else:
+                        attribution_sample_status = 'estimated'
 
-                    # Calculate estimated CPO for campaign
-                    estimated_cpo = spend / estimated_orders if estimated_orders > 0 else 0
+                    # Four decimals preserve campaign ranking and small positive
+                    # estimates while keeping the serialized denominator and CPA
+                    # arithmetically consistent. Ultra-small estimates are marked
+                    # unavailable instead of appearing as zero-cost acquisition.
+                    estimated_cpo = (
+                        spend / reported_estimated_orders
+                        if reported_estimated_orders > 0
+                        else None
+                    )
 
-                    # Calculate estimated revenue share
-                    revenue_share = estimated_orders / total_orders if total_orders > 0 else 0
+                    # Keep revenue and ROAS on the same serialized attribution
+                    # basis as CPA so every value in one campaign row reconciles.
+                    revenue_share = (
+                        reported_estimated_orders / total_orders
+                        if total_orders > 0
+                        else 0
+                    )
                     estimated_revenue = total_revenue * revenue_share
 
                     # ROAS for campaign
@@ -14601,10 +14636,11 @@ class BizniWebExporter:
                         'impressions': campaign.get('impressions', 0),
                         'ctr': campaign.get('ctr', 0),
                         'cpc': campaign.get('cpc', 0),
-                        'estimated_orders': round(estimated_orders, 1),
-                        'attributed_orders_est': round(estimated_orders, 1),
-                        'estimated_cpo': round(estimated_cpo, 2),
-                        'cost_per_attributed_order': round(estimated_cpo, 2),
+                        'estimated_orders': reported_estimated_orders,
+                        'attributed_orders_est': reported_estimated_orders,
+                        'estimated_cpo': round(estimated_cpo, 2) if estimated_cpo is not None else None,
+                        'cost_per_attributed_order': round(estimated_cpo, 2) if estimated_cpo is not None else None,
+                        'attribution_sample_status': attribution_sample_status,
                         'estimated_revenue': round(estimated_revenue, 2),
                         'estimated_roas': round(estimated_roas, 2),
                         'spend_share_pct': round(spend_share * 100, 1),
@@ -14613,7 +14649,13 @@ class BizniWebExporter:
                     })
 
             # Sort by estimated CPO (best first)
-            campaign_attribution.sort(key=lambda x: x['estimated_cpo'] if x['estimated_cpo'] > 0 else float('inf'))
+            campaign_attribution.sort(
+                key=lambda row: (
+                    row['estimated_cpo']
+                    if row.get('estimated_cpo') is not None and row['estimated_cpo'] > 0
+                    else float('inf')
+                )
+            )
             result['campaign_attribution'] = campaign_attribution
             estimated_orders_total = sum(row['estimated_orders'] for row in campaign_attribution)
             result['campaign_attribution_summary'] = {

--- a/html_report_generator.py
+++ b/html_report_generator.py
@@ -2687,7 +2687,27 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                     <tbody>"""
 
             for camp in campaign_attribution:
-                cpo_color = '#48bb78' if camp['estimated_cpo'] < fb_cpo else '#f56565'
+                estimated_orders_value = camp.get('estimated_orders')
+                attribution_sample_status = str(camp.get('attribution_sample_status') or '').strip()
+                if (
+                    attribution_sample_status == 'insufficient_sample'
+                    and (estimated_orders_value is None or estimated_orders_value <= 0)
+                ):
+                    estimated_orders_label = '&lt;0.0001'
+                elif estimated_orders_value is None:
+                    estimated_orders_label = 'N/A'
+                elif 0 < estimated_orders_value < 0.0001:
+                    estimated_orders_label = '&lt;0.0001'
+                else:
+                    estimated_orders_label = f"{estimated_orders_value:.4f}".rstrip('0').rstrip('.')
+
+                estimated_cpo_value = camp.get('estimated_cpo')
+                if estimated_cpo_value is None or attribution_sample_status in {'insufficient_sample', 'unavailable'}:
+                    cpo_color = '#718096'
+                    estimated_cpo_label = 'N/A'
+                else:
+                    cpo_color = '#48bb78' if estimated_cpo_value < fb_cpo else '#f56565'
+                    estimated_cpo_label = f"&#8364;{estimated_cpo_value:.2f}"
                 roas_color = '#48bb78' if camp['estimated_roas'] > 1 else '#f56565'
 
                 html_content += f"""
@@ -2697,8 +2717,8 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                             <td class="number">{camp['clicks']:,}</td>
                             <td class="number">{camp['ctr']:.2f}%</td>
                             <td class="number">&#8364;{camp['cpc']:.2f}</td>
-                            <td class="number">{camp['estimated_orders']:.1f}</td>
-                            <td class="number" style="color: {cpo_color}; font-weight: bold;">&#8364;{camp['estimated_cpo']:.2f}</td>
+                            <td class="number">{estimated_orders_label}</td>
+                            <td class="number" style="color: {cpo_color}; font-weight: bold;">{estimated_cpo_label}</td>
                             <td class="number">&#8364;{camp['estimated_revenue']:,.2f}</td>
                             <td class="number" style="color: {roas_color}; font-weight: bold;">{camp['estimated_roas']:.2f}x</td>
                             <td class="number">{camp['click_share_pct']:.1f}%</td>
@@ -8758,8 +8778,8 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                     datasets: [{{
                         label: 'Est. CPO (&#8364;)',
                         data: {json.dumps(camp_cpos)},
-                        backgroundColor: {json.dumps(camp_cpos)}.map(v => v < avgCpo ? 'rgba(72, 187, 120, 0.7)' : 'rgba(245, 101, 101, 0.7)'),
-                        borderColor: {json.dumps(camp_cpos)}.map(v => v < avgCpo ? '#48bb78' : '#f56565'),
+                        backgroundColor: {json.dumps(camp_cpos)}.map(v => v == null ? 'rgba(113, 128, 150, 0.5)' : (v < avgCpo ? 'rgba(72, 187, 120, 0.7)' : 'rgba(245, 101, 101, 0.7)')),
+                        borderColor: {json.dumps(camp_cpos)}.map(v => v == null ? '#718096' : (v < avgCpo ? '#48bb78' : '#f56565')),
                         borderWidth: 1,
                         borderRadius: 5
                     }}]
@@ -8774,6 +8794,7 @@ def generate_html_report(date_agg: pd.DataFrame, date_product_agg: pd.DataFrame,
                         tooltip: {{
                             callbacks: {{
                                 label: function(context) {{
+                                    if (context.parsed.x == null) return 'Est. CPO: N/A';
                                     return 'Est. CPO: &#8364;' + context.parsed.x.toFixed(2);
                                 }}
                             }}

--- a/tests/test_dashboard_modern.py
+++ b/tests/test_dashboard_modern.py
@@ -5,6 +5,8 @@ import pandas as pd
 
 from dashboard_modern import (
     _build_fb_daily_payload,
+    _format_attributed_cpa,
+    _format_attributed_order_estimate,
     _frame_rows,
     extract_embedded_dashboard_payload,
     generate_modern_dashboard,
@@ -12,6 +14,12 @@ from dashboard_modern import (
 
 
 class DashboardModernTests(unittest.TestCase):
+    def test_attributed_campaign_values_use_adaptive_precision(self) -> None:
+        self.assertEqual("0.232", _format_attributed_order_estimate(0.232, "estimated"))
+        self.assertEqual("&lt;0.0001", _format_attributed_order_estimate(0, "insufficient_sample"))
+        self.assertEqual("&euro;1.21", _format_attributed_cpa(1.21, "estimated"))
+        self.assertEqual("N/A", _format_attributed_cpa(None, "insufficient_sample"))
+
     def test_fb_daily_payload_zero_fills_missing_report_dates(self) -> None:
         payload = _build_fb_daily_payload(
             datetime(2026, 5, 1),

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -1381,6 +1381,127 @@ class ReportingCalculationFixTests(unittest.TestCase):
         )
         self.assertEqual(0, qa["shell_parity_failures"])
 
+    def test_campaign_attributed_cpa_uses_reported_order_estimate(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        frame = pd.DataFrame(
+            [
+                {
+                    "purchase_date": "2026-07-15 10:00:00",
+                    "order_num": "V-CPA-1",
+                    "item_total_without_tax": 100.0,
+                    "fb_ads_daily_spend": 1.0,
+                    "google_ads_daily_spend": 0.0,
+                }
+            ]
+        )
+        campaigns = [
+            {
+                "campaign_name": "SK-Sale-VEVO-SandBox-ABO-ACQ",
+                "campaign_id": "target",
+                "spend": 0.28,
+                "clicks": 0.2,
+            },
+            {
+                "campaign_name": "Other campaign",
+                "campaign_id": "other",
+                "spend": 0.72,
+                "clicks": 0.8,
+            },
+        ]
+
+        result = exporter.analyze_cost_per_order(frame, fb_campaigns=campaigns)
+        target = next(
+            row
+            for row in result["campaign_attribution"]
+            if row["campaign_id"] == "target"
+        )
+
+        self.assertEqual(0.232, target["attributed_orders_est"])
+        self.assertEqual(1.21, target["cost_per_attributed_order"])
+        self.assertEqual(
+            round(target["spend"] / target["attributed_orders_est"], 2),
+            target["cost_per_attributed_order"],
+        )
+
+        qa = exporter._build_data_assertions_qa(
+            financial_metrics={"total_orders": 1},
+            consistency_checks={},
+            refunds_analysis={},
+            day_of_week_analysis=pd.DataFrame(),
+            advanced_dtc_metrics={},
+            country_analysis=pd.DataFrame(),
+            geo_profitability={},
+            cost_per_order=result,
+        )
+        self.assertEqual(0, qa["attributed_cpa_mismatches"])
+
+    def test_campaign_attribution_preserves_ranking_near_rounding_boundaries(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        frame = pd.DataFrame(
+            [
+                {
+                    "purchase_date": "2026-07-15 10:00:00",
+                    "order_num": "V-CPA-BOUNDARY",
+                    "item_total_without_tax": 100.0,
+                    "fb_ads_daily_spend": 1.0,
+                    "google_ads_daily_spend": 0.0,
+                }
+            ]
+        )
+        campaigns = [
+            {"campaign_name": "A", "campaign_id": "a", "spend": 0.249, "clicks": 0.249},
+            {"campaign_name": "B", "campaign_id": "b", "spend": 0.251, "clicks": 0.251},
+            {"campaign_name": "C", "campaign_id": "c", "spend": 0.5, "clicks": 0.5},
+        ]
+
+        result = exporter.analyze_cost_per_order(frame, fb_campaigns=campaigns)
+        rows = result["campaign_attribution"]
+
+        self.assertEqual(["a", "b", "c"], [row["campaign_id"] for row in rows])
+        self.assertEqual([0.249, 0.251, 0.5], [row["attributed_orders_est"] for row in rows])
+        self.assertEqual([1.0, 1.0, 1.0], [row["cost_per_attributed_order"] for row in rows])
+        self.assertEqual(100.0, sum(row["estimated_revenue"] for row in rows))
+
+    def test_tiny_positive_attribution_never_looks_like_free_acquisition(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        frame = pd.DataFrame(
+            [
+                {
+                    "purchase_date": "2026-07-15 10:00:00",
+                    "order_num": "V-CPA-TINY",
+                    "item_total_without_tax": 100.0,
+                    "fb_ads_daily_spend": 1.0,
+                    "google_ads_daily_spend": 0.0,
+                }
+            ]
+        )
+        campaigns = [
+            {"campaign_name": "Tiny", "campaign_id": "tiny", "spend": 0.00001, "clicks": 0.00001},
+            {"campaign_name": "Other", "campaign_id": "other", "spend": 0.99999, "clicks": 0.99999},
+        ]
+
+        result = exporter.analyze_cost_per_order(frame, fb_campaigns=campaigns)
+        tiny = next(row for row in result["campaign_attribution"] if row["campaign_id"] == "tiny")
+
+        self.assertEqual(0, tiny["attributed_orders_est"])
+        self.assertIsNone(tiny["cost_per_attributed_order"])
+        self.assertEqual("insufficient_sample", tiny["attribution_sample_status"])
+        self.assertEqual(0, tiny["estimated_revenue"])
+        self.assertEqual(0, tiny["estimated_roas"])
+
+        qa = exporter._build_data_assertions_qa(
+            financial_metrics={"total_orders": 1},
+            consistency_checks={},
+            refunds_analysis={},
+            day_of_week_analysis=pd.DataFrame(),
+            advanced_dtc_metrics={},
+            country_analysis=pd.DataFrame(),
+            geo_profitability={},
+            cost_per_order=result,
+        )
+        self.assertEqual(0, qa["attributed_cpa_mismatches"])
+        self.assertEqual(1, qa["attributed_cpa_unavailable_rows"])
+
     def test_weekly_cac_includes_blended_spend_on_days_without_orders(self) -> None:
         exporter = make_exporter(project_name="vevo")
         frame = pd.DataFrame(


### PR DESCRIPTION
## Summary
- keep campaign attributed orders, CPA, estimated revenue and ROAS on one four-decimal basis
- show ultra-small samples as `<0.0001` with CPA `N/A` instead of false zero-cost acquisition
- preserve null CPA in modern and legacy dashboard charts and add regression coverage
- record the blocked VEVO generation and verified rollback in PROJECT_STATE.md

## Verification
- `python -m unittest discover -s tests` (183 tests)
- `python -m unittest tests.test_reporting_calculation_fixes tests.test_dashboard_modern` (76 tests)
- `python scripts/reporting_qa_smoke.py`
- Python compile, VEVO/ROY settings JSON, `git diff --check`
- independent review: no P0/P1