### PR TITLE
Prevent reporting scheduler PassRole outages

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -229,6 +229,16 @@ jobs:
           print(settings["report_schedule"]["schedule_name"])
           PY
           )"
+          EXPECTED_SCHEDULER_ROLE_NAME="$(python - "${PROJECT}" <<'PY'
+          import json
+          import pathlib
+          import sys
+          project = sys.argv[1]
+          settings_path = pathlib.Path("projects") / project / "settings.json"
+          settings = json.loads(settings_path.read_text(encoding="utf-8"))
+          print(settings["report_schedule"]["scheduler_role_name"])
+          PY
+          )"
           CONFIGURED_AUTH_USER="$(python - "${PROJECT}" <<'PY'
           import json
           import pathlib
@@ -260,6 +270,7 @@ jobs:
             exit 1
           fi
           CURRENT_SCHEDULE_TASK_DEFINITION_ARN="${TASK_DEFINITION_ARN}"
+          CURRENT_SCHEDULE_LAST_MODIFICATION_DATE="$(python -c 'import json; print(json.load(open("schedule.json", encoding="utf-8"))["LastModificationDate"])')"
           aws ecs describe-task-definition \
             --task-definition "${TASK_DEFINITION_ARN}" \
             --region "${AWS_REGION}" > task-definition.json
@@ -935,6 +946,88 @@ jobs:
               f"inventory_rows={len(inventory.get('inventory_rows') or [])}"
           )
           PY
+            aws scheduler get-schedule \
+              --name "${REPORT_SCHEDULE_NAME}" \
+              --region "${AWS_REGION}" > schedule-runtime-current.json
+            aws iam get-role \
+              --role-name "${EXPECTED_SCHEDULER_ROLE_NAME}" \
+              --output json > reporting-scheduler-role.json
+            python scripts/reporting_scheduler_passrole.py \
+              --schedule-json schedule-runtime-current.json \
+              --task-definition-json task-definition.json \
+              --scheduler-role-json reporting-scheduler-role.json \
+              --project-task-role-arn "${PROJECT_TASK_ROLE_ARN}" \
+              --account-id "${ACCOUNT_ID}" \
+              --expected-scheduler-role-name "${EXPECTED_SCHEDULER_ROLE_NAME}" \
+              --policy-output reporting-scheduler-passrole-policy.json \
+              --metadata-output reporting-scheduler-passrole-metadata.json
+            SCHEDULER_ROLE_NAME="$(python -c 'import json; print(json.load(open("reporting-scheduler-passrole-metadata.json", encoding="utf-8"))["scheduler_role_name"])')"
+            SCHEDULER_ROLE_ARN="$(python -c 'import json; print(json.load(open("reporting-scheduler-passrole-metadata.json", encoding="utf-8"))["scheduler_role_arn"])')"
+            PROJECT_EXECUTION_ROLE_ARN="$(python -c 'import json; print(json.load(open("reporting-scheduler-passrole-metadata.json", encoding="utf-8"))["execution_role_arn"])')"
+            SCHEDULER_PASSROLE_POLICY_NAME="ReportingSchedulePassRole-${PROJECT}"
+            aws iam put-role-policy \
+              --role-name "${SCHEDULER_ROLE_NAME}" \
+              --policy-name "${SCHEDULER_PASSROLE_POLICY_NAME}" \
+              --policy-document file://reporting-scheduler-passrole-policy.json
+            aws iam get-role-policy \
+              --role-name "${SCHEDULER_ROLE_NAME}" \
+              --policy-name "${SCHEDULER_PASSROLE_POLICY_NAME}" \
+              --query PolicyDocument \
+              --output json > reporting-scheduler-passrole-installed.json
+            python - <<'PY'
+          import json
+
+          desired = json.load(open("reporting-scheduler-passrole-policy.json", encoding="utf-8"))
+          installed = json.load(open("reporting-scheduler-passrole-installed.json", encoding="utf-8"))
+          if installed != desired:
+              raise SystemExit("Installed reporting scheduler PassRole policy does not match the desired policy")
+          PY
+            PASSROLE_SIMULATION_READY=false
+            for _ in $(seq 1 12); do
+              if aws iam simulate-principal-policy \
+                --policy-source-arn "${SCHEDULER_ROLE_ARN}" \
+                --action-names iam:PassRole \
+                --resource-arns "${PROJECT_TASK_ROLE_ARN}" "${PROJECT_EXECUTION_ROLE_ARN}" \
+                --context-entries ContextKeyName=iam:PassedToService,ContextKeyValues=ecs-tasks.amazonaws.com,ContextKeyType=string \
+                --output json > reporting-scheduler-passrole-simulation.json \
+                && python - <<'PY'
+          import json
+
+          results = json.load(open("reporting-scheduler-passrole-simulation.json", encoding="utf-8")).get("EvaluationResults") or []
+          if len(results) != 2 or any(result.get("EvalDecision") != "allowed" for result in results):
+              raise SystemExit(1)
+          PY
+              then
+                PASSROLE_SIMULATION_READY=true
+                break
+              fi
+              sleep 5
+            done
+            if [[ "${PASSROLE_SIMULATION_READY}" != "true" ]]; then
+              cat reporting-scheduler-passrole-simulation.json >&2 || true
+              echo "Scheduler PassRole policy did not become effective in time." >&2
+              exit 1
+            fi
+            aws scheduler get-schedule \
+              --name "${REPORT_SCHEDULE_NAME}" \
+              --region "${AWS_REGION}" > schedule-passrole-verified.json
+            PASSROLE_VERIFIED_TASK_DEFINITION_ARN="$(python -c 'import json; schedule = json.load(open("schedule-passrole-verified.json", encoding="utf-8")); print(schedule["Target"]["EcsParameters"]["TaskDefinitionArn"])')"
+            PASSROLE_VERIFIED_SCHEDULER_ROLE_ARN="$(python -c 'import json; schedule = json.load(open("schedule-passrole-verified.json", encoding="utf-8")); print(schedule["Target"]["RoleArn"])')"
+            PASSROLE_VERIFIED_LAST_MODIFICATION_DATE="$(python -c 'import json; print(json.load(open("schedule-passrole-verified.json", encoding="utf-8"))["LastModificationDate"])')"
+            if [[ "${PASSROLE_VERIFIED_TASK_DEFINITION_ARN}" != "${CURRENT_SCHEDULE_TASK_DEFINITION_ARN}" ]]; then
+              echo "Schedule ${REPORT_SCHEDULE_NAME} drifted from ${CURRENT_SCHEDULE_TASK_DEFINITION_ARN} to ${PASSROLE_VERIFIED_TASK_DEFINITION_ARN} while repairing PassRole; refusing to continue." >&2
+              exit 1
+            fi
+            if [[ "${PASSROLE_VERIFIED_SCHEDULER_ROLE_ARN}" != "${SCHEDULER_ROLE_ARN}" ]]; then
+              echo "Schedule ${REPORT_SCHEDULE_NAME} role drifted from ${SCHEDULER_ROLE_ARN} to ${PASSROLE_VERIFIED_SCHEDULER_ROLE_ARN} while repairing PassRole; refusing to continue." >&2
+              exit 1
+            fi
+            if [[ "${PASSROLE_VERIFIED_LAST_MODIFICATION_DATE}" != "${CURRENT_SCHEDULE_LAST_MODIFICATION_DATE}" ]]; then
+              echo "Schedule ${REPORT_SCHEDULE_NAME} changed during PassRole repair (${CURRENT_SCHEDULE_LAST_MODIFICATION_DATE} -> ${PASSROLE_VERIFIED_LAST_MODIFICATION_DATE}); refusing to continue." >&2
+              exit 1
+            fi
+            echo "REPORTING_SCHEDULER_PASSROLE_READY:${REPORT_SCHEDULE_NAME}:${SCHEDULER_ROLE_NAME}:${PROJECT_TASK_ROLE_ARN}"
+
             if [[ "${SKIP_ARTIFACT_REFRESH:-false}" == "true" && "${NEEDS_REPORT_TASK_UPDATE}" == "true" ]]; then
               echo "REPORT_SCHEDULE_PROMOTION_SKIPPED:${REPORT_SCHEDULE_NAME}:${TASK_DEFINITION_ARN}:skip_artifact_refresh=true"
             elif [[ "${NEEDS_REPORT_TASK_UPDATE}" == "true" ]]; then
@@ -942,8 +1035,18 @@ jobs:
                 --name "${REPORT_SCHEDULE_NAME}" \
                 --region "${AWS_REGION}" > schedule-promotion-current.json
               PROMOTION_SOURCE_TASK_DEFINITION_ARN="$(python -c 'import json; schedule = json.load(open("schedule-promotion-current.json", encoding="utf-8")); print(schedule["Target"]["EcsParameters"]["TaskDefinitionArn"])')"
+              PROMOTION_SOURCE_SCHEDULER_ROLE_ARN="$(python -c 'import json; schedule = json.load(open("schedule-promotion-current.json", encoding="utf-8")); print(schedule["Target"]["RoleArn"])')"
+              PROMOTION_SOURCE_LAST_MODIFICATION_DATE="$(python -c 'import json; print(json.load(open("schedule-promotion-current.json", encoding="utf-8"))["LastModificationDate"])')"
               if [[ "${PROMOTION_SOURCE_TASK_DEFINITION_ARN}" != "${CURRENT_SCHEDULE_TASK_DEFINITION_ARN}" ]]; then
                 echo "Schedule ${REPORT_SCHEDULE_NAME} drifted from ${CURRENT_SCHEDULE_TASK_DEFINITION_ARN} to ${PROMOTION_SOURCE_TASK_DEFINITION_ARN}; refusing to overwrite concurrent infrastructure changes." >&2
+                exit 1
+              fi
+              if [[ "${PROMOTION_SOURCE_SCHEDULER_ROLE_ARN}" != "${SCHEDULER_ROLE_ARN}" ]]; then
+                echo "Schedule ${REPORT_SCHEDULE_NAME} role drifted from ${SCHEDULER_ROLE_ARN} to ${PROMOTION_SOURCE_SCHEDULER_ROLE_ARN}; refusing to promote with stale PassRole permissions." >&2
+                exit 1
+              fi
+              if [[ "${PROMOTION_SOURCE_LAST_MODIFICATION_DATE}" != "${CURRENT_SCHEDULE_LAST_MODIFICATION_DATE}" ]]; then
+                echo "Schedule ${REPORT_SCHEDULE_NAME} changed during deployment (${CURRENT_SCHEDULE_LAST_MODIFICATION_DATE} -> ${PROMOTION_SOURCE_LAST_MODIFICATION_DATE}); refusing to overwrite concurrent infrastructure changes." >&2
                 exit 1
               fi
               mv schedule-promotion-current.json schedule.json

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -6,6 +6,7 @@
   "report_from_date": "2025-09-24",
   "report_schedule": {
     "schedule_name": "roy-daily-report-email",
+    "scheduler_role_name": "vevo-reporting-scheduler-role",
     "schedule_expression": "cron(30 1 * * ? *)",
     "timezone": "Europe/Bratislava",
     "task_family": "roy-reporting-daily"

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -7,6 +7,7 @@
   "report_from_date": "2025-05-03",
   "report_schedule": {
     "schedule_name": "vevo-daily-report-email",
+    "scheduler_role_name": "vevo-reporting-scheduler-role",
     "schedule_expression": "cron(0 1 * * ? *)",
     "timezone": "Europe/Bratislava",
     "task_family": "vevo-reporting-daily"

--- a/scripts/reporting_scheduler_passrole.py
+++ b/scripts/reporting_scheduler_passrole.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Build the least-privilege PassRole policy for a reporting schedule.
+
+EventBridge Scheduler calls ECS with its own IAM role.  Whenever a reporting
+task definition moves to a project-specific task role, the scheduler role must
+be allowed to pass both that task role and the ECS execution role.  This helper
+validates the AWS documents and emits an exact, account-local policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+
+ROLE_ARN_RE = re.compile(
+    r"^arn:(?P<partition>aws(?:-us-gov|-cn)?):iam::"
+    r"(?P<account>\d{12}):role/(?P<path>[A-Za-z0-9+=,.@_/-]+)$"
+)
+ROLE_NAME_RE = re.compile(r"^[A-Za-z0-9+=,.@_-]{1,64}$")
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def validate_role_arn(role_arn: str, account_id: str) -> Tuple[str, str]:
+    """Return ``(partition, role_name)`` for an exact local IAM role ARN."""
+
+    match = ROLE_ARN_RE.fullmatch(str(role_arn or ""))
+    if not match:
+        raise ValueError(f"Invalid IAM role ARN: {role_arn!r}")
+    if match.group("account") != account_id:
+        raise ValueError(
+            f"IAM role {role_arn!r} is not in expected account {account_id}"
+        )
+    role_path = match.group("path")
+    if "*" in role_path or role_path.endswith("/"):
+        raise ValueError(f"IAM role ARN must identify one exact role: {role_arn!r}")
+    return match.group("partition"), role_path.rsplit("/", 1)[-1]
+
+
+def build_passrole_documents(
+    schedule: Dict[str, Any],
+    task_definition_document: Dict[str, Any],
+    scheduler_role_document: Dict[str, Any],
+    project_task_role_arn: str,
+    account_id: str,
+    expected_scheduler_role_name: str,
+) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    """Build the policy and metadata used by the deployment workflow."""
+
+    target = schedule.get("Target")
+    if not isinstance(target, dict):
+        raise ValueError("Schedule document is missing Target")
+    scheduler_role_arn = str(target.get("RoleArn") or "")
+    scheduler_partition, scheduler_role_name = validate_role_arn(
+        scheduler_role_arn, account_id
+    )
+    if not ROLE_NAME_RE.fullmatch(expected_scheduler_role_name):
+        raise ValueError(
+            f"Invalid expected scheduler role name: {expected_scheduler_role_name!r}"
+        )
+    expected_scheduler_role_arn = (
+        f"arn:{scheduler_partition}:iam::{account_id}:role/"
+        f"{expected_scheduler_role_name}"
+    )
+    if scheduler_role_arn != expected_scheduler_role_arn:
+        raise ValueError(
+            "Schedule uses an unexpected scheduler role: "
+            f"{scheduler_role_arn!r} != {expected_scheduler_role_arn!r}"
+        )
+    role = scheduler_role_document.get("Role", scheduler_role_document)
+    if not isinstance(role, dict) or role.get("Arn") != scheduler_role_arn:
+        raise ValueError("Scheduler role document does not match Schedule.Target.RoleArn")
+    trust = role.get("AssumeRolePolicyDocument")
+    statements = trust.get("Statement") if isinstance(trust, dict) else None
+    if not isinstance(statements, list) or len(statements) != 1:
+        raise ValueError("Scheduler role must have one exact trust statement")
+    trust_statement = statements[0]
+    if not isinstance(trust_statement, dict):
+        raise ValueError("Scheduler role trust statement is invalid")
+    if (
+        trust_statement.get("Effect") != "Allow"
+        or trust_statement.get("Action") != "sts:AssumeRole"
+        or trust_statement.get("Principal")
+        != {"Service": "scheduler.amazonaws.com"}
+        or trust_statement.get("Condition") not in (None, {})
+    ):
+        raise ValueError(
+            "Scheduler role trust must allow only scheduler.amazonaws.com to assume it"
+        )
+
+    raw_task_definition = task_definition_document.get(
+        "taskDefinition", task_definition_document
+    )
+    if not isinstance(raw_task_definition, dict):
+        raise ValueError("Task-definition document is invalid")
+    actual_task_role_arn = str(raw_task_definition.get("taskRoleArn") or "")
+    execution_role_arn = str(raw_task_definition.get("executionRoleArn") or "")
+    task_partition, _ = validate_role_arn(actual_task_role_arn, account_id)
+    execution_partition, _ = validate_role_arn(execution_role_arn, account_id)
+    validate_role_arn(project_task_role_arn, account_id)
+
+    if actual_task_role_arn != project_task_role_arn:
+        raise ValueError(
+            "Candidate task definition does not use the expected project task role: "
+            f"{actual_task_role_arn!r} != {project_task_role_arn!r}"
+        )
+    if len({scheduler_partition, task_partition, execution_partition}) != 1:
+        raise ValueError("Scheduler, task, and execution roles use different partitions")
+
+    resources = list(dict.fromkeys([project_task_role_arn, execution_role_arn]))
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "PassReportingTaskRolesToEcs",
+                "Effect": "Allow",
+                "Action": "iam:PassRole",
+                "Resource": resources,
+                "Condition": {
+                    "StringEquals": {
+                        "iam:PassedToService": "ecs-tasks.amazonaws.com"
+                    }
+                },
+            }
+        ],
+    }
+    metadata = {
+        "scheduler_role_arn": scheduler_role_arn,
+        "scheduler_role_name": scheduler_role_name,
+        "task_role_arn": project_task_role_arn,
+        "execution_role_arn": execution_role_arn,
+    }
+    return policy, metadata
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--schedule-json", type=Path, required=True)
+    parser.add_argument("--task-definition-json", type=Path, required=True)
+    parser.add_argument("--scheduler-role-json", type=Path, required=True)
+    parser.add_argument("--project-task-role-arn", required=True)
+    parser.add_argument("--account-id", required=True)
+    parser.add_argument("--expected-scheduler-role-name", required=True)
+    parser.add_argument("--policy-output", type=Path, required=True)
+    parser.add_argument("--metadata-output", type=Path, required=True)
+    args = parser.parse_args()
+
+    policy, metadata = build_passrole_documents(
+        schedule=_load_json(args.schedule_json),
+        task_definition_document=_load_json(args.task_definition_json),
+        scheduler_role_document=_load_json(args.scheduler_role_json),
+        project_task_role_arn=args.project_task_role_arn,
+        account_id=args.account_id,
+        expected_scheduler_role_name=args.expected_scheduler_role_name,
+    )
+    args.policy_output.write_text(
+        json.dumps(policy, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    args.metadata_output.write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_live_dashboard_refresh_gate.py
+++ b/tests/test_live_dashboard_refresh_gate.py
@@ -39,6 +39,35 @@ class LiveDashboardRefreshGateTests(unittest.TestCase):
 
         self.assertIn("- scripts/live_dashboard_refresh_gate.sh", workflow)
 
+    def test_deploy_repairs_scheduler_passrole_before_schedule_promotion(self) -> None:
+        workflow = (
+            ROOT_DIR / ".github" / "workflows" / "deploy-live-dashboard-apprunner.yml"
+        ).read_text(encoding="utf-8")
+
+        helper_call = "python scripts/reporting_scheduler_passrole.py"
+        policy_ready = "REPORTING_SCHEDULER_PASSROLE_READY:"
+        schedule_update = 'aws scheduler update-schedule "${UPDATE_SCHEDULE_ARGS[@]}"'
+        self.assertIn(helper_call, workflow)
+        self.assertIn('"ReportingSchedulePassRole-${PROJECT}"', workflow)
+        self.assertIn("aws iam put-role-policy", workflow)
+        self.assertIn("aws iam get-role-policy", workflow)
+        self.assertIn("aws iam simulate-principal-policy", workflow)
+        self.assertIn("role drifted from", workflow)
+        self.assertIn("changed during deployment", workflow)
+        unconditional_verify = "schedule-passrole-verified.json"
+        conditional_promotion = 'if [[ "${SKIP_ARTIFACT_REFRESH:-false}"'
+        self.assertIn(unconditional_verify, workflow)
+        self.assertLess(
+            workflow.index(unconditional_verify), workflow.index(policy_ready)
+        )
+        policy_ready_index = workflow.index(policy_ready)
+        self.assertLess(
+            policy_ready_index,
+            workflow.index(conditional_promotion, policy_ready_index),
+        )
+        self.assertLess(workflow.index(helper_call), workflow.index(policy_ready))
+        self.assertLess(workflow.index(policy_ready), workflow.index(schedule_update))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reporting_scheduler_passrole.py
+++ b/tests/test_reporting_scheduler_passrole.py
@@ -1,0 +1,154 @@
+import json
+import unittest
+
+from scripts.reporting_scheduler_passrole import (
+    build_passrole_documents,
+    validate_role_arn,
+)
+
+
+ACCOUNT_ID = "919341186960"
+SCHEDULER_ROLE_ARN = (
+    f"arn:aws:iam::{ACCOUNT_ID}:role/vevo-reporting-scheduler-role"
+)
+TASK_ROLE_ARN = (
+    f"arn:aws:iam::{ACCOUNT_ID}:role/BiznisWebReportingTaskRole-vevo"
+)
+EXECUTION_ROLE_ARN = f"arn:aws:iam::{ACCOUNT_ID}:role/ecsTaskExecutionRole"
+SCHEDULER_ROLE_DOCUMENT = {
+    "Role": {
+        "Arn": SCHEDULER_ROLE_ARN,
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "scheduler.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        },
+    }
+}
+
+
+class ReportingSchedulerPassRoleTests(unittest.TestCase):
+    def test_builds_exact_account_local_ecs_passrole_policy(self) -> None:
+        schedule = {"Target": {"RoleArn": SCHEDULER_ROLE_ARN}}
+        task_definition = {
+            "taskDefinition": {
+                "taskRoleArn": TASK_ROLE_ARN,
+                "executionRoleArn": EXECUTION_ROLE_ARN,
+            }
+        }
+
+        policy, metadata = build_passrole_documents(
+            schedule,
+            task_definition,
+            SCHEDULER_ROLE_DOCUMENT,
+            TASK_ROLE_ARN,
+            ACCOUNT_ID,
+            "vevo-reporting-scheduler-role",
+        )
+
+        statement = policy["Statement"][0]
+        self.assertEqual(statement["Action"], "iam:PassRole")
+        self.assertEqual(
+            statement["Resource"], [TASK_ROLE_ARN, EXECUTION_ROLE_ARN]
+        )
+        self.assertEqual(
+            statement["Condition"]["StringEquals"]["iam:PassedToService"],
+            "ecs-tasks.amazonaws.com",
+        )
+        self.assertEqual(
+            metadata["scheduler_role_name"], "vevo-reporting-scheduler-role"
+        )
+
+    def test_rejects_task_definition_role_mismatch(self) -> None:
+        schedule = {"Target": {"RoleArn": SCHEDULER_ROLE_ARN}}
+        task_definition = {
+            "taskDefinition": {
+                "taskRoleArn": f"arn:aws:iam::{ACCOUNT_ID}:role/unexpected",
+                "executionRoleArn": EXECUTION_ROLE_ARN,
+            }
+        }
+
+        with self.assertRaisesRegex(ValueError, "does not use the expected"):
+            build_passrole_documents(
+                schedule,
+                task_definition,
+                SCHEDULER_ROLE_DOCUMENT,
+                TASK_ROLE_ARN,
+                ACCOUNT_ID,
+                "vevo-reporting-scheduler-role",
+            )
+
+    def test_rejects_unexpected_same_account_scheduler_role(self) -> None:
+        unexpected_arn = f"arn:aws:iam::{ACCOUNT_ID}:role/unexpected-scheduler"
+        schedule = {"Target": {"RoleArn": unexpected_arn}}
+        scheduler_role = {
+            "Role": {
+                "Arn": unexpected_arn,
+                "AssumeRolePolicyDocument": SCHEDULER_ROLE_DOCUMENT["Role"][
+                    "AssumeRolePolicyDocument"
+                ],
+            }
+        }
+        task_definition = {
+            "taskDefinition": {
+                "taskRoleArn": TASK_ROLE_ARN,
+                "executionRoleArn": EXECUTION_ROLE_ARN,
+            }
+        }
+
+        with self.assertRaisesRegex(ValueError, "unexpected scheduler role"):
+            build_passrole_documents(
+                schedule,
+                task_definition,
+                scheduler_role,
+                TASK_ROLE_ARN,
+                ACCOUNT_ID,
+                "vevo-reporting-scheduler-role",
+            )
+
+    def test_rejects_broadened_scheduler_trust(self) -> None:
+        schedule = {"Target": {"RoleArn": SCHEDULER_ROLE_ARN}}
+        task_definition = {
+            "taskDefinition": {
+                "taskRoleArn": TASK_ROLE_ARN,
+                "executionRoleArn": EXECUTION_ROLE_ARN,
+            }
+        }
+        scheduler_role = json.loads(json.dumps(SCHEDULER_ROLE_DOCUMENT))
+        scheduler_role["Role"]["AssumeRolePolicyDocument"]["Statement"].append(
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": f"arn:aws:iam::{ACCOUNT_ID}:root"},
+                "Action": "sts:AssumeRole",
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "one exact trust statement"):
+            build_passrole_documents(
+                schedule,
+                task_definition,
+                scheduler_role,
+                TASK_ROLE_ARN,
+                ACCOUNT_ID,
+                "vevo-reporting-scheduler-role",
+            )
+
+    def test_rejects_cross_account_and_wildcard_role_arns(self) -> None:
+        with self.assertRaisesRegex(ValueError, "expected account"):
+            validate_role_arn(
+                "arn:aws:iam::111111111111:role/cross-account", ACCOUNT_ID
+            )
+        with self.assertRaisesRegex(ValueError, "Invalid IAM role ARN"):
+            validate_role_arn(
+                f"arn:aws:iam::{ACCOUNT_ID}:role/BiznisWebReportingTaskRole-*",
+                ACCOUNT_ID,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome
- repairs the reporting scheduler's least-privilege `iam:PassRole` policy before any schedule promotion
- allowlists the configured scheduler role and validates its exact Scheduler trust policy
- verifies effective authorization with IAM simulation and fails closed on concurrent schedule drift
- records the scheduler role name in each project config and adds regression coverage

## Incident
The 2026-07-16 VEVO run at 01:00 Europe/Bratislava failed before ECS task creation because `vevo-reporting-scheduler-role` could not pass `BiznisWebReportingTaskRole-vevo`.

## Verification
- 189 unit tests passed
- focused scheduler/workflow tests passed
- workflow YAML and normalized Bash syntax passed
- Python compile and `git diff --check` passed
- helper validated against the live VEVO schedule, TD22, and IAM trust document
- independent review found no remaining P0/P1 issue