### PR TITLE
Harden monthly accounting delivery

### DIFF
--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_creditnote_export tests.test_money_s3_invoice_export tests.test_creditnote_storno_guard tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_live_dashboard_s3_fallback tests.test_live_dashboard_refresh_gate tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
+          python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_creditnote_export tests.test_money_s3_invoice_export tests.test_monthly_accounting_workflow tests.test_creditnote_storno_guard tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_live_dashboard_s3_fallback tests.test_live_dashboard_refresh_gate tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/.github/workflows/build-and-push-ecr.yml
+++ b/.github/workflows/build-and-push-ecr.yml
@@ -13,6 +13,7 @@ on:
       - invoice_runner.py
       - creditnote_export.py
       - creditnote_storno_guard.py
+      - money_s3_invoice_export.py
       - monthly_creditnote_export_runner.py
       - unpaid_order_cancellation.py
       - unpaid_order_cancellation_runner.py
@@ -66,7 +67,7 @@ jobs:
 
       - name: Invoice automation regression test
         run: |
-          python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_creditnote_export tests.test_creditnote_storno_guard tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_live_dashboard_s3_fallback tests.test_live_dashboard_refresh_gate tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
+          python -m unittest tests.test_invoice_generation tests.test_unpaid_order_cancellation tests.test_creditnote_export tests.test_money_s3_invoice_export tests.test_creditnote_storno_guard tests.test_roy_picking_lists_pdf tests.test_reporting_calculation_fixes tests.test_production_board tests.test_live_dashboard_auth tests.test_live_dashboard_mobile tests.test_live_dashboard_s3_fallback tests.test_live_dashboard_refresh_gate tests.test_roy_operations_dashboard tests.test_roy_inventory_model tests.test_reporting_product_identity
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0

--- a/.github/workflows/deploy-monthly-creditnote-export.yml
+++ b/.github/workflows/deploy-monthly-creditnote-export.yml
@@ -1,10 +1,10 @@
-name: Deploy Monthly Creditnote Export
+name: Deploy Monthly Accounting Export
 
 on:
   workflow_dispatch:
     inputs:
       execute_now:
-        description: Run the export after registering the schedule
+        description: Run the host smoke and send only when send_email_now is enabled
         required: false
         default: false
         type: boolean
@@ -18,15 +18,23 @@ on:
       - main
     paths:
       - creditnote_export.py
+      - money_s3_invoice_export.py
       - monthly_creditnote_export_runner.py
       - projects/roy/settings.json
+      - projects/vevo/settings.json
+      - reporting_core/**
+      - http_client.py
+      - Dockerfile
       - requirements.txt
       - .github/workflows/deploy-monthly-creditnote-export.yml
 
 env:
   AWS_REGION: eu-central-1
   ECR_REPOSITORY: vevo-reporting
-  IMAGE_TAG: latest
+  ECR_CURRENT_TAG: monthly-creditnote-export-current
+  ECR_CANDIDATE_TAG: monthly-creditnote-export-candidate
+  ALERT_TOPIC_NAME: vevo-reporting-alerts-mil-final
+  DLQ_NAME: monthly-creditnote-export-dlq
   OWNER_PROJECT: roy
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -46,6 +54,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
       - name: Deploy scheduler and run host smoke
         shell: bash
         env:
@@ -59,14 +71,101 @@ jobs:
           set -euo pipefail
 
           ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
-          IMAGE_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG}"
+          DEPLOY_IMAGE_TAG="monthly-creditnote-export-${GITHUB_SHA}"
+          IMAGE_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${DEPLOY_IMAGE_TAG}"
+          docker build -t "${IMAGE_URI}" .
+          docker push "${IMAGE_URI}"
           IMAGE_DIGEST="$(aws ecr describe-images \
             --repository-name "${ECR_REPOSITORY}" \
-            --image-ids imageTag="${IMAGE_TAG}" \
+            --image-ids imageTag="${DEPLOY_IMAGE_TAG}" \
             --region "${AWS_REGION}" \
             --query 'imageDetails[0].imageDigest' \
             --output text)"
           IMAGE_IDENTIFIER="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}@${IMAGE_DIGEST}"
+
+          protect_ecr_image_tag() {
+            local image_identifier="$1"
+            local protection_tag="$2"
+            if [[ "${image_identifier}" != *@sha256:* ]]; then
+              echo "Skipping ${protection_tag}; image is not digest-pinned: ${image_identifier}"
+              return 0
+            fi
+            local image_digest="${image_identifier##*@}"
+            local existing_digest
+            existing_digest="$(aws ecr describe-images \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-ids imageTag="${protection_tag}" \
+              --region "${AWS_REGION}" \
+              --query 'imageDetails[0].imageDigest' \
+              --output text 2>/dev/null || true)"
+            if [[ "${existing_digest}" == "${image_digest}" ]]; then
+              echo "ECR_IMAGE_PROTECTED:${protection_tag}:${image_digest}:already"
+              return 0
+            fi
+            local manifest_file
+            local manifest_response_file
+            manifest_file="$(mktemp)"
+            manifest_response_file="$(mktemp)"
+            aws ecr batch-get-image \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-ids imageDigest="${image_digest}" \
+              --region "${AWS_REGION}" \
+              --output json > "${manifest_response_file}"
+            python - "${manifest_response_file}" "${manifest_file}" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          response = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          images = response.get("images") or []
+          if not images or not images[0].get("imageManifest"):
+              raise SystemExit("ECR batch-get-image did not return an image manifest")
+          pathlib.Path(sys.argv[2]).write_text(images[0]["imageManifest"], encoding="utf-8")
+          PY
+            python -m json.tool "${manifest_file}" >/dev/null
+            local put_output
+            if ! put_output="$(aws ecr put-image \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-tag "${protection_tag}" \
+              --image-manifest "file://${manifest_file}" \
+              --region "${AWS_REGION}" 2>&1)"; then
+              if [[ "${put_output}" != *"ImageAlreadyExistsException"* ]]; then
+                echo "${put_output}" >&2
+                rm -f "${manifest_file}" "${manifest_response_file}"
+                return 1
+              fi
+              local raced_digest
+              raced_digest="$(aws ecr describe-images \
+                --repository-name "${ECR_REPOSITORY}" \
+                --image-ids imageTag="${protection_tag}" \
+                --region "${AWS_REGION}" \
+                --query 'imageDetails[0].imageDigest' \
+                --output text)"
+              rm -f "${manifest_file}" "${manifest_response_file}"
+              if [[ "${raced_digest}" != "${image_digest}" ]]; then
+                echo "${put_output}" >&2
+                echo "ECR protection tag ${protection_tag} raced to ${raced_digest}, expected ${image_digest}" >&2
+                return 1
+              fi
+              echo "ECR_IMAGE_PROTECTED:${protection_tag}:${image_digest}:already-after-race"
+              return 0
+            fi
+            rm -f "${manifest_file}" "${manifest_response_file}"
+            local protected_digest
+            protected_digest="$(aws ecr describe-images \
+              --repository-name "${ECR_REPOSITORY}" \
+              --image-ids imageTag="${protection_tag}" \
+              --region "${AWS_REGION}" \
+              --query 'imageDetails[0].imageDigest' \
+              --output text)"
+            if [[ "${protected_digest}" != "${image_digest}" ]]; then
+              echo "ECR protection tag ${protection_tag} resolved to ${protected_digest}, expected ${image_digest}" >&2
+              return 1
+            fi
+            echo "ECR_IMAGE_PROTECTED:${protection_tag}:${image_digest}:updated"
+          }
+
+          protect_ecr_image_tag "${IMAGE_IDENTIFIER}" "${ECR_CANDIDATE_TAG}"
 
           python - "${OWNER_PROJECT}" <<'PY' > creditnote-settings.env
           import json
@@ -97,6 +196,98 @@ jobs:
           PY
           # shellcheck disable=SC1091
           source creditnote-settings.env
+
+          ALERT_TOPIC_ARN="arn:aws:sns:${AWS_REGION}:${ACCOUNT_ID}:${ALERT_TOPIC_NAME}"
+          aws sns get-topic-attributes \
+            --topic-arn "${ALERT_TOPIC_ARN}" \
+            --region "${AWS_REGION}" >/dev/null
+          DLQ_URL="$(aws sqs get-queue-url \
+            --queue-name "${DLQ_NAME}" \
+            --region "${AWS_REGION}" \
+            --query QueueUrl \
+            --output text 2>/dev/null || aws sqs create-queue \
+              --queue-name "${DLQ_NAME}" \
+              --attributes MessageRetentionPeriod=1209600 \
+              --region "${AWS_REGION}" \
+              --query QueueUrl \
+              --output text)"
+          DLQ_ARN="$(aws sqs get-queue-attributes \
+            --queue-url "${DLQ_URL}" \
+            --attribute-names QueueArn \
+            --region "${AWS_REGION}" \
+            --query 'Attributes.QueueArn' \
+            --output text)"
+          SCHEDULE_ARN="arn:aws:scheduler:${AWS_REGION}:${ACCOUNT_ID}:schedule/default/${SCHEDULE_NAME}"
+          python - "${DLQ_ARN}" "${SCHEDULE_ARN}" <<'PY' > dlq-policy.json
+          import json
+          import sys
+
+          queue_arn, schedule_arn = sys.argv[1:3]
+          print(json.dumps({
+              "Version": "2012-10-17",
+              "Statement": [{
+                  "Sid": "AllowMonthlyAccountingScheduler",
+                  "Effect": "Allow",
+                  "Principal": {"Service": "scheduler.amazonaws.com"},
+                  "Action": "sqs:SendMessage",
+                  "Resource": queue_arn,
+                  "Condition": {"ArnEquals": {"aws:SourceArn": schedule_arn}},
+              }],
+          }))
+          PY
+          python - <<'PY' > dlq-attributes.json
+          import json
+          from pathlib import Path
+
+          policy = json.loads(Path("dlq-policy.json").read_text(encoding="utf-8"))
+          print(json.dumps({
+              "MessageRetentionPeriod": "1209600",
+              "Policy": json.dumps(policy, separators=(",", ":")),
+          }))
+          PY
+          aws sqs set-queue-attributes \
+            --queue-url "${DLQ_URL}" \
+            --attributes file://dlq-attributes.json \
+            --region "${AWS_REGION}"
+          aws cloudwatch put-metric-alarm \
+            --alarm-name monthly-creditnote-export-dlq-not-empty \
+            --alarm-description "Monthly accounting scheduler could not invoke its Fargate target" \
+            --namespace AWS/SQS \
+            --metric-name ApproximateNumberOfMessagesVisible \
+            --dimensions Name=QueueName,Value="${DLQ_NAME}" \
+            --statistic Maximum \
+            --period 60 \
+            --evaluation-periods 1 \
+            --datapoints-to-alarm 1 \
+            --threshold 1 \
+            --comparison-operator GreaterThanOrEqualToThreshold \
+            --treat-missing-data notBreaching \
+            --alarm-actions "${ALERT_TOPIC_ARN}" \
+            --ok-actions "${ALERT_TOPIC_ARN}" \
+            --region "${AWS_REGION}"
+
+          if aws scheduler get-schedule \
+            --name "${SCHEDULE_NAME}" \
+            --region "${AWS_REGION}" > current-monthly-schedule.json 2>/dev/null; then
+            CURRENT_MONTHLY_TASK_DEFINITION_ARN="$(python - <<'PY'
+          import json
+          schedule = json.load(open("current-monthly-schedule.json", encoding="utf-8"))
+          print(schedule["Target"]["EcsParameters"]["TaskDefinitionArn"])
+          PY
+            )"
+            aws ecs describe-task-definition \
+              --task-definition "${CURRENT_MONTHLY_TASK_DEFINITION_ARN}" \
+              --region "${AWS_REGION}" > current-monthly-task-definition.json
+            CURRENT_MONTHLY_IMAGE="$(python - <<'PY'
+          import json
+          task = json.load(open("current-monthly-task-definition.json", encoding="utf-8"))["taskDefinition"]
+          print(task["containerDefinitions"][0].get("image") or "")
+          PY
+            )"
+            if ! protect_ecr_image_tag "${CURRENT_MONTHLY_IMAGE}" "${ECR_CURRENT_TAG}"; then
+              echo "Existing monthly image could not be protected; continuing with candidate recovery: ${CURRENT_MONTHLY_IMAGE}" >&2
+            fi
+          fi
 
           aws scheduler get-schedule \
             --name "${SOURCE_REPORT_SCHEDULE_NAME}" \
@@ -268,6 +459,28 @@ jobs:
             --log-group-name "${LOG_GROUP}" \
             --retention-in-days 30 \
             --region "${AWS_REGION}"
+          aws logs put-metric-filter \
+            --log-group-name "${LOG_GROUP}" \
+            --filter-name monthly-creditnote-export-run-failed \
+            --filter-pattern '"CREDITNOTE_EXPORT_RUN_FAILED"' \
+            --metric-transformations \
+              metricName=MonthlyCreditnoteExportRunFailed,metricNamespace=BiznisWebReporting,metricValue=1,defaultValue=0 \
+            --region "${AWS_REGION}"
+          aws cloudwatch put-metric-alarm \
+            --alarm-name monthly-creditnote-export-run-failed \
+            --alarm-description "Monthly accounting export application failed before sending email" \
+            --namespace BiznisWebReporting \
+            --metric-name MonthlyCreditnoteExportRunFailed \
+            --statistic Sum \
+            --period 60 \
+            --evaluation-periods 1 \
+            --datapoints-to-alarm 1 \
+            --threshold 1 \
+            --comparison-operator GreaterThanOrEqualToThreshold \
+            --treat-missing-data notBreaching \
+            --alarm-actions "${ALERT_TOPIC_ARN}" \
+            --ok-actions "${ALERT_TOPIC_ARN}" \
+            --region "${AWS_REGION}"
 
           python - "${TASK_FAMILY}" "${IMAGE_IDENTIFIER}" "${OWNER_PROJECT}" "${CREDITNOTE_PROJECTS}" "${CREDITNOTE_EMAIL_TO}" "${LOG_GROUP}" "${AWS_REGION}" <<'PY' > task-definition-creditnote.json
           import copy
@@ -425,17 +638,22 @@ jobs:
           print(task_def.get("executionRoleArn") or "")
           PY
             )"
-            python - "${ACCOUNT_ID}" "${AWS_REGION}" "${TASK_FAMILY}" "${TASK_ROLE_ARN}" "${EXECUTION_ROLE_ARN}" <<'PY' > scheduler-role-policy.json
+            python - "${ACCOUNT_ID}" "${AWS_REGION}" "${TASK_FAMILY}" "${TASK_ROLE_ARN}" "${EXECUTION_ROLE_ARN}" "${DLQ_ARN}" <<'PY' > scheduler-role-policy.json
           import json
           import sys
 
-          account_id, region, task_family, task_role_arn, execution_role_arn = sys.argv[1:6]
+          account_id, region, task_family, task_role_arn, execution_role_arn, dlq_arn = sys.argv[1:7]
           pass_roles = [arn for arn in [task_role_arn, execution_role_arn] if arn]
           statements = [
               {
                   "Effect": "Allow",
                   "Action": "ecs:RunTask",
                   "Resource": f"arn:aws:ecs:{region}:{account_id}:task-definition/{task_family}:*",
+              },
+              {
+                  "Effect": "Allow",
+                  "Action": "sqs:SendMessage",
+                  "Resource": dlq_arn,
               }
           ]
           if pass_roles:
@@ -496,12 +714,12 @@ jobs:
             fi
           fi
 
-          python - "${REGISTERED_TASK_DEFINITION_ARN}" <<'PY' > schedule-target.json
+          python - "${REGISTERED_TASK_DEFINITION_ARN}" "${DLQ_ARN}" <<'PY' > schedule-target.json
           import copy
           import json
           import sys
 
-          task_definition_arn = sys.argv[1]
+          task_definition_arn, dlq_arn = sys.argv[1:3]
           schedule = json.load(open("source-schedule.json", encoding="utf-8"))
 
           def clean(value):
@@ -520,30 +738,17 @@ jobs:
           target = clean(copy.deepcopy(schedule["Target"]))
           target.pop("Input", None)
           target["EcsParameters"]["TaskDefinitionArn"] = task_definition_arn
+          target["DeadLetterConfig"] = {"Arn": dlq_arn}
           json.dump(target, sys.stdout)
           PY
           echo '{"Mode":"OFF"}' > flexible-time-window.json
 
-          if aws scheduler get-schedule --name "${SCHEDULE_NAME}" --region "${AWS_REGION}" > existing-schedule.json 2>/dev/null; then
-            aws scheduler update-schedule \
-              --name "${SCHEDULE_NAME}" \
-              --schedule-expression "${SCHEDULE_EXPRESSION}" \
-              --schedule-expression-timezone "${SCHEDULE_TIMEZONE}" \
-              --flexible-time-window file://flexible-time-window.json \
-              --target file://schedule-target.json \
-              --state ENABLED \
-              --region "${AWS_REGION}"
-          else
-            aws scheduler create-schedule \
-              --name "${SCHEDULE_NAME}" \
-              --schedule-expression "${SCHEDULE_EXPRESSION}" \
-              --schedule-expression-timezone "${SCHEDULE_TIMEZONE}" \
-              --flexible-time-window file://flexible-time-window.json \
-              --target file://schedule-target.json \
-              --state ENABLED \
-              --region "${AWS_REGION}"
+          SCHEDULE_EXISTS=false
+          if aws scheduler get-schedule \
+            --name "${SCHEDULE_NAME}" \
+            --region "${AWS_REGION}" > existing-schedule.json 2>/dev/null; then
+            SCHEDULE_EXISTS=true
           fi
-          aws scheduler get-schedule --name "${SCHEDULE_NAME}" --region "${AWS_REGION}" > deployed-schedule.json
 
           python - <<'PY' > network.json
           import json
@@ -565,10 +770,10 @@ jobs:
           PY
           )"
 
-          EMAIL_MODE="--dry-run-email"
+          EMAIL_MODE="dry-run"
           EXPECTED_MARKER="CREDITNOTE_EXPORT_MARKER_OK"
           if [[ "${EXECUTE_NOW}" == "true" && "${SEND_EMAIL_NOW}" == "true" ]]; then
-            EMAIL_MODE=""
+            EMAIL_MODE="send"
             EXPECTED_MARKER="CREDITNOTE_EXPORT_EMAIL_MARKER_OK"
           fi
 
@@ -577,7 +782,7 @@ jobs:
           OWNER_PROJECT="${CREDITNOTE_EXPORT_OWNER_PROJECT:-roy}"
           PROJECTS="${CREDITNOTE_EXPORT_PROJECTS:?CREDITNOTE_EXPORT_PROJECTS missing}"
           EMAIL_TO="${CREDITNOTE_EXPORT_EMAIL_TO:?CREDITNOTE_EXPORT_EMAIL_TO missing}"
-          EMAIL_MODE="${EMAIL_MODE:---dry-run-email}"
+          EMAIL_MODE="${EMAIL_MODE:-dry-run}"
           PIDS=()
           cleanup() {
             for pid in "${PIDS[@]:-}"; do
@@ -644,13 +849,16 @@ jobs:
               print(f"FARGATE_ADMIN_LOGIN_OK project={project} base_url={base_url} arf_present={bool(arf)}")
           PY
           RUN_ARGS=(--owner-project "${OWNER_PROJECT}" --projects "${PROJECTS}" --email-to "${EMAIL_TO}" --output-tag smoke)
-          if [[ -n "${EMAIL_MODE}" ]]; then
-            RUN_ARGS+=("${EMAIL_MODE}")
-          fi
+          case "${EMAIL_MODE}" in
+            dry-run) RUN_ARGS+=(--dry-run-email) ;;
+            send) ;;
+            *) echo "Unsupported EMAIL_MODE: ${EMAIL_MODE}" >&2; exit 1 ;;
+          esac
           python monthly_creditnote_export_runner.py "${RUN_ARGS[@]}" | tee /tmp/creditnote-export.log
           python - <<'PY'
           import json
           import os
+          import xml.etree.ElementTree as ET
           from pathlib import Path
 
           summary_line = ""
@@ -659,11 +867,36 @@ jobs:
                   summary_line = line.split(" ", 1)[1]
           assert summary_line, "missing creditnote export summary"
           summary = json.loads(summary_line)
-          assert summary["projects"] == [item.strip() for item in os.environ["CREDITNOTE_EXPORT_PROJECTS"].split(",") if item.strip()]
-          output_pdf = Path(summary["output_pdf"])
-          assert output_pdf.exists()
-          assert output_pdf.read_bytes()[:5] == b"%PDF-"
+          expected_projects = [
+              item.strip()
+              for item in os.environ["CREDITNOTE_EXPORT_PROJECTS"].split(",")
+              if item.strip()
+          ]
+          expected_project_keys = {project.upper() for project in expected_projects}
+          assert summary["projects"] == expected_projects
+
+          output_pdfs = summary["output_pdfs"]
+          assert set(output_pdfs) == expected_project_keys
+          for project, output_path in output_pdfs.items():
+              path = Path(output_path)
+              assert path.exists(), f"missing {project} credit-note PDF: {path}"
+              assert path.read_bytes()[:5] == b"%PDF-", f"invalid {project} credit-note PDF: {path}"
+
+          assert summary["invoice_export_skipped"] is False
+          invoice_export = summary["invoice_export"]
+          assert invoice_export["format"] == "moneys3"
+          assert invoice_export["date_field"] == "inv_date"
+          assert invoice_export["projects"] == expected_projects
+          assert set(invoice_export["output_files"]) == expected_project_keys
+          for project, output_path in invoice_export["output_files"].items():
+              path = Path(output_path)
+              assert path.exists(), f"missing {project} Money S3 export: {path}"
+              root = ET.parse(path).getroot()
+              assert root.tag.rsplit("}", 1)[-1] == "MoneyData", f"invalid {project} Money S3 XML: {path}"
+
           assert summary["email_to"] == os.environ["CREDITNOTE_EXPORT_EMAIL_TO"]
+          if not summary["email_dry_run"] and not summary["email_skipped"]:
+              assert summary["email_message_id"] not in ("", "dry-run")
           marker_name = "CREDITNOTE_EXPORT_EMAIL_MARKER_OK" if not summary["email_dry_run"] and not summary["email_skipped"] else "CREDITNOTE_EXPORT_MARKER_OK"
           marker_dir = Path("/tmp/creditnote-export-marker")
           marker_dir.mkdir(parents=True, exist_ok=True)
@@ -673,8 +906,12 @@ jobs:
               "date_from": summary["date_from"],
               "date_to": summary["date_to"],
               "exported_rows": summary["exported_rows"],
+              "invoice_export_count": invoice_export["total_invoices"],
+              "output_pdf_count": len(output_pdfs),
+              "attachment_count": len(output_pdfs) + len(invoice_export["output_files"]),
               "email_dry_run": summary["email_dry_run"],
               "email_skipped": summary["email_skipped"],
+              "email_message_id": summary["email_message_id"],
           }
           (marker_dir / "marker.json").write_text(json.dumps(marker, ensure_ascii=False, sort_keys=True), encoding="utf-8")
           PY
@@ -702,7 +939,7 @@ jobs:
                           {"name": "CREDITNOTE_EXPORT_OWNER_PROJECT", "value": os.environ["OWNER_PROJECT"]},
                           {"name": "CREDITNOTE_EXPORT_PROJECTS", "value": os.environ["CREDITNOTE_PROJECTS"]},
                           {"name": "CREDITNOTE_EXPORT_EMAIL_TO", "value": os.environ["CREDITNOTE_EMAIL_TO"]},
-                          {"name": "EMAIL_MODE", "value": os.environ.get("EMAIL_MODE", "--dry-run-email")},
+                          {"name": "EMAIL_MODE", "value": os.environ.get("EMAIL_MODE", "dry-run")},
                       ],
                   }
               ]
@@ -816,15 +1053,62 @@ jobs:
           fi
           grep -q "${EXPECTED_MARKER}" smoke-task.log
 
-          python - <<'PY'
+          if [[ "${SCHEDULE_EXISTS}" == "true" ]]; then
+            aws scheduler update-schedule \
+              --name "${SCHEDULE_NAME}" \
+              --schedule-expression "${SCHEDULE_EXPRESSION}" \
+              --schedule-expression-timezone "${SCHEDULE_TIMEZONE}" \
+              --flexible-time-window file://flexible-time-window.json \
+              --target file://schedule-target.json \
+              --state ENABLED \
+              --region "${AWS_REGION}" >/dev/null
+          else
+            aws scheduler create-schedule \
+              --name "${SCHEDULE_NAME}" \
+              --schedule-expression "${SCHEDULE_EXPRESSION}" \
+              --schedule-expression-timezone "${SCHEDULE_TIMEZONE}" \
+              --flexible-time-window file://flexible-time-window.json \
+              --target file://schedule-target.json \
+              --state ENABLED \
+              --region "${AWS_REGION}" >/dev/null
+          fi
+          aws scheduler get-schedule \
+            --name "${SCHEDULE_NAME}" \
+            --region "${AWS_REGION}" > deployed-schedule.json
+          protect_ecr_image_tag "${IMAGE_IDENTIFIER}" "${ECR_CURRENT_TAG}"
+
+          CURRENT_IMAGE_DIGEST="$(aws ecr describe-images \
+            --repository-name "${ECR_REPOSITORY}" \
+            --image-ids imageTag="${ECR_CURRENT_TAG}" \
+            --region "${AWS_REGION}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)"
+          if [[ "${CURRENT_IMAGE_DIGEST}" != "${IMAGE_DIGEST}" ]]; then
+            echo "Current monthly image tag points to ${CURRENT_IMAGE_DIGEST}, expected ${IMAGE_DIGEST}" >&2
+            exit 1
+          fi
+
+          python - "${REGISTERED_TASK_DEFINITION_ARN}" "${DLQ_ARN}" "${SCHEDULE_EXPRESSION}" "${SCHEDULE_TIMEZONE}" <<'PY'
           import json
+          import sys
+
+          expected_task_definition, expected_dlq, expected_expression, expected_timezone = sys.argv[1:5]
           schedule = json.load(open("deployed-schedule.json", encoding="utf-8"))
           target = schedule["Target"]
           assert schedule["State"] == "ENABLED"
-          assert target["EcsParameters"]["TaskDefinitionArn"]
+          assert schedule["ScheduleExpression"] == expected_expression
+          assert schedule["ScheduleExpressionTimezone"] == expected_timezone
+          assert target["EcsParameters"]["TaskDefinitionArn"] == expected_task_definition
+          assert target["DeadLetterConfig"]["Arn"] == expected_dlq
           print(
-              "DEPLOY_MONTHLY_CREDITNOTE_EXPORT_OK "
+              "DEPLOY_MONTHLY_ACCOUNTING_EXPORT_OK "
               f"schedule={schedule['Name']} "
-              f"task_definition={target['EcsParameters']['TaskDefinitionArn']}"
+              f"task_definition={target['EcsParameters']['TaskDefinitionArn']} "
+              f"dlq={target['DeadLetterConfig']['Arn']}"
           )
           PY
+
+          aws ecr batch-delete-image \
+            --repository-name "${ECR_REPOSITORY}" \
+            --image-ids imageTag="${DEPLOY_IMAGE_TAG}" \
+            --region "${AWS_REGION}" >/dev/null

--- a/money_s3_invoice_export.py
+++ b/money_s3_invoice_export.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Monthly BizniWeb Money S3 invoice export helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+from email.message import Message
+from email.parser import Parser
+from pathlib import Path
+from typing import Any, Dict, Sequence, Tuple
+
+from dotenv import load_dotenv
+
+from creditnote_export import (
+    DEFAULT_CREDITNOTE_PROJECTS,
+    ROOT_DIR,
+    _login_admin,
+    month_slug,
+    parse_biznisweb_js_object,
+    parse_date,
+    parse_project_list,
+)
+from reporting_core import sanitize_output_tag
+
+
+MONEY_S3_INVOICE_DATASET = "invoices"
+MONEY_S3_FORMAT = "moneys3"
+
+
+@dataclass(frozen=True)
+class MoneyS3InvoiceExportResult:
+    projects: Tuple[str, ...]
+    date_from: str
+    date_to: str
+    output_files: Dict[str, Path]
+    invoice_counts: Dict[str, int]
+    source_filenames: Dict[str, str]
+
+    @property
+    def total_invoices(self) -> int:
+        return sum(self.invoice_counts.values())
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "projects": list(self.projects),
+            "date_from": self.date_from,
+            "date_to": self.date_to,
+            "format": MONEY_S3_FORMAT,
+            "date_field": "inv_date",
+            "output_files": {project: str(path) for project, path in self.output_files.items()},
+            "invoice_counts": self.invoice_counts,
+            "source_filenames": self.source_filenames,
+            "total_invoices": self.total_invoices,
+        }
+
+
+def biznisweb_php_serialize(value: Any) -> str:
+    """Serialize simple values the same way BizniWeb admin mass filters do."""
+    if value is None:
+        return "N;"
+    if isinstance(value, bool):
+        return f"b:{1 if value else 0};"
+    if isinstance(value, int):
+        return f"i:{value};"
+    if isinstance(value, float):
+        return f"d:{value};"
+    if isinstance(value, str):
+        return f's:{len(value.encode("utf-8"))}:"{value}";'
+    if isinstance(value, (list, tuple)):
+        pairs = "".join(
+            biznisweb_php_serialize(index) + biznisweb_php_serialize(item)
+            for index, item in enumerate(value)
+        )
+        return f"a:{len(value)}:{{{pairs}}}"
+    if isinstance(value, dict):
+        pairs = "".join(
+            biznisweb_php_serialize(str(key)) + biznisweb_php_serialize(item)
+            for key, item in value.items()
+        )
+        return f"a:{len(value)}:{{{pairs}}}"
+    raise TypeError(f"Unsupported BizniWeb serialize type: {type(value).__name__}")
+
+
+def biznisweb_admin_date(value: date) -> str:
+    return f"{value.day}.{value.month}.{value.year}"
+
+
+def money_s3_invoice_filters(date_from: date, date_to: date) -> Dict[str, str]:
+    return {
+        "inv_date_from": biznisweb_admin_date(date_from),
+        "inv_date_to": biznisweb_admin_date(date_to),
+    }
+
+
+def build_money_s3_invoice_filename(project: str, date_from: date, date_to: date, output_tag: str = "") -> str:
+    filename = f"faktury_money_s3_{project}_{month_slug(date_from, date_to)}_issued"
+    tag = sanitize_output_tag(output_tag)
+    if tag:
+        filename = f"{filename}_{tag}"
+    return filename
+
+
+def _filename_from_content_disposition(value: str) -> str:
+    if not value:
+        return ""
+    message: Message = Parser().parsestr(f"Content-Disposition: {value}\n\n")
+    filename = message.get_param("filename", header="content-disposition")
+    return str(filename or "").strip()
+
+
+def _validate_money_s3_xml(content: bytes, project: str) -> None:
+    stripped = content.lstrip()
+    if stripped.startswith(b"<MoneyData"):
+        return
+    if stripped.startswith(b"<?xml") and b"<MoneyData" in stripped[:300]:
+        return
+    preview = stripped[:80].decode("utf-8", errors="replace")
+    raise RuntimeError(f"Money S3 invoice export for project '{project}' did not return MoneyData XML: {preview!r}")
+
+
+def download_money_s3_invoice_export(project: str, date_from: date, date_to: date) -> Tuple[bytes, str, int]:
+    base_url, session, arf = _login_admin(project)
+    mass_filter = biznisweb_php_serialize(money_s3_invoice_filters(date_from, date_to))
+    count_response = session.post(
+        f"{base_url}/erp/orders/invoices/getListJson",
+        data={"start": 0, "limit": 1, "arf": arf, "massfilter": mass_filter},
+    )
+    count_response.raise_for_status()
+    count_payload = parse_biznisweb_js_object(count_response.text)
+    try:
+        invoice_count = int(count_payload.get("total") or 0)
+    except (TypeError, ValueError):
+        invoice_count = 0
+
+    response = session.post(
+        f"{base_url}/erp/impexp/export/index/{MONEY_S3_INVOICE_DATASET}/{MONEY_S3_FORMAT}",
+        data={
+            "dataSubset": biznisweb_php_serialize({}),
+            "data": MONEY_S3_INVOICE_DATASET,
+            "massFilter": mass_filter,
+            "arf": arf,
+        },
+        allow_redirects=True,
+    )
+    response.raise_for_status()
+    _validate_money_s3_xml(response.content, project)
+    source_filename = _filename_from_content_disposition(response.headers.get("content-disposition", ""))
+    return response.content, source_filename, invoice_count
+
+
+def run_money_s3_invoice_export(
+    projects: Sequence[str] = DEFAULT_CREDITNOTE_PROJECTS,
+    date_from: date | str = "",
+    date_to: date | str = "",
+    output_dir: Path | None = None,
+    output_tag: str = "",
+) -> MoneyS3InvoiceExportResult:
+    root_env = ROOT_DIR / ".env"
+    if root_env.exists():
+        load_dotenv(dotenv_path=root_env, override=False, encoding="utf-8-sig")
+
+    resolved_projects = parse_project_list(projects)
+    if isinstance(date_from, str):
+        date_from = parse_date(date_from, "date_from")
+    if isinstance(date_to, str):
+        date_to = parse_date(date_to, "date_to")
+    if date_from > date_to:
+        raise ValueError(f"date_from ({date_from}) cannot be after date_to ({date_to})")
+
+    base_output_dir = output_dir or (ROOT_DIR / "data" / "combined_exports")
+    base_output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_files: Dict[str, Path] = {}
+    invoice_counts: Dict[str, int] = {}
+    source_filenames: Dict[str, str] = {}
+    for project in resolved_projects:
+        content, source_filename, invoice_count = download_money_s3_invoice_export(project, date_from, date_to)
+        filename = build_money_s3_invoice_filename(project, date_from, date_to, output_tag=output_tag)
+        output_path = base_output_dir / f"{filename}.xml"
+        output_path.write_bytes(content)
+        output_files[project.upper()] = output_path
+        invoice_counts[project.upper()] = invoice_count
+        source_filenames[project.upper()] = re.sub(r"[\r\n]+", " ", source_filename).strip()
+
+    return MoneyS3InvoiceExportResult(
+        projects=tuple(resolved_projects),
+        date_from=date_from.isoformat(),
+        date_to=date_to.isoformat(),
+        output_files=output_files,
+        invoice_counts=invoice_counts,
+        source_filenames=source_filenames,
+    )

--- a/monthly_creditnote_export_runner.py
+++ b/monthly_creditnote_export_runner.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from dataclasses import dataclass
 from datetime import datetime
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
@@ -24,11 +25,79 @@ from creditnote_export import (
     previous_calendar_month,
     run_monthly_creditnote_export,
 )
+from money_s3_invoice_export import MoneyS3InvoiceExportResult, run_money_s3_invoice_export
 from reporting_core import load_project_settings, put_metric, resolve_reporting_defaults
 
 
 DEFAULT_OWNER_PROJECT = os.getenv("CREDITNOTE_EXPORT_OWNER_PROJECT", "roy").strip() or "roy"
 DEFAULT_RECIPIENT = "mil.terem@gmail.com"
+MAX_SES_RAW_MESSAGE_BYTES = 9_500_000
+
+
+@dataclass(frozen=True)
+class MonthlyAccountingExportResult:
+    creditnote_results: Tuple[CreditnoteExportResult, ...]
+    invoice_result: MoneyS3InvoiceExportResult | None
+
+    def __post_init__(self) -> None:
+        if not self.creditnote_results:
+            raise ValueError("At least one credit-note export is required")
+        windows = {(result.date_from, result.date_to) for result in self.creditnote_results}
+        if len(windows) != 1:
+            raise ValueError("Credit-note exports must use one shared date window")
+        projects = tuple(result.projects[0] for result in self.creditnote_results)
+        if len(projects) != len(set(projects)):
+            raise ValueError("Credit-note exports contain duplicate projects")
+        if self.invoice_result is not None:
+            if self.invoice_result.projects != projects:
+                raise ValueError("Money S3 invoice projects do not match credit-note projects")
+            if (self.invoice_result.date_from, self.invoice_result.date_to) != next(iter(windows)):
+                raise ValueError("Money S3 invoices do not match the credit-note date window")
+
+    @property
+    def projects(self) -> Tuple[str, ...]:
+        return tuple(result.projects[0] for result in self.creditnote_results)
+
+    @property
+    def date_from(self) -> str:
+        return self.creditnote_results[0].date_from
+
+    @property
+    def date_to(self) -> str:
+        return self.creditnote_results[0].date_to
+
+    @property
+    def exported_rows(self) -> int:
+        return sum(result.exported_rows for result in self.creditnote_results)
+
+    @property
+    def project_counts(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for result in self.creditnote_results:
+            counts.update(result.project_counts)
+        return counts
+
+    @property
+    def output_pdfs(self) -> Dict[str, Path]:
+        return {
+            result.projects[0].upper(): result.output_pdf
+            for result in self.creditnote_results
+        }
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "projects": list(self.projects),
+            "date_from": self.date_from,
+            "date_to": self.date_to,
+            "exported_rows": self.exported_rows,
+            "project_counts": self.project_counts,
+            "output_pdfs": {project: str(path) for project, path in self.output_pdfs.items()},
+            "creditnote_exports": {
+                result.projects[0].upper(): result.as_dict()
+                for result in self.creditnote_results
+            },
+            "invoice_export": self.invoice_result.as_dict() if self.invoice_result else None,
+        }
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -39,11 +108,11 @@ def _env_bool(name: str, default: bool = False) -> bool:
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Export monthly BizniWeb credit notes and email one PDF")
+    parser = argparse.ArgumentParser(description="Export monthly BizniWeb credit notes and Money S3 invoices")
     parser.add_argument(
         "--projects",
         default=os.getenv("CREDITNOTE_EXPORT_PROJECTS", "roy,vevo"),
-        help="Comma-separated project slugs to include in one PDF.",
+        help="Comma-separated project slugs. Each project gets a separate credit-note PDF.",
     )
     parser.add_argument(
         "--owner-project",
@@ -113,6 +182,12 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         default=_env_bool("CREDITNOTE_EXPORT_SKIP_METRICS", False),
         help="Generate files but do not publish CloudWatch metrics.",
     )
+    parser.add_argument(
+        "--skip-invoice-export",
+        action="store_true",
+        default=_env_bool("CREDITNOTE_EXPORT_SKIP_INVOICE_EXPORT", False),
+        help="Skip Money S3 invoice XML files. The scheduled accounting run exports them by default.",
+    )
     return parser.parse_args(argv)
 
 
@@ -139,11 +214,26 @@ def resolve_creditnote_export_window(
     return start.isoformat(), end.isoformat()
 
 
-def build_creditnote_email_subject(result: CreditnoteExportResult, override: str = "") -> str:
+AccountingExportInput = CreditnoteExportResult | MonthlyAccountingExportResult
+
+
+def _creditnote_results(result: AccountingExportInput) -> Tuple[CreditnoteExportResult, ...]:
+    if isinstance(result, MonthlyAccountingExportResult):
+        return result.creditnote_results
+    return (result,)
+
+
+def _invoice_result(result: AccountingExportInput) -> MoneyS3InvoiceExportResult | None:
+    if isinstance(result, MonthlyAccountingExportResult):
+        return result.invoice_result
+    return None
+
+
+def build_creditnote_email_subject(result: AccountingExportInput, override: str = "") -> str:
     if override.strip():
         return override.strip()
     projects = "+".join(project.upper() for project in result.projects)
-    return f"Dobropisy {projects} {result.date_from[:7]}"
+    return f"Uctovne doklady {projects} {result.date_from[:7]}"
 
 
 def _format_amount(value: Any) -> str:
@@ -162,26 +252,41 @@ def _format_rate(value: Any) -> str:
         return "-"
 
 
-def build_creditnote_email_body(result: CreditnoteExportResult) -> str:
+def build_creditnote_email_body(result: AccountingExportInput) -> str:
+    creditnote_results = _creditnote_results(result)
+    invoice_result = _invoice_result(result)
     lines = [
         "Dobry den,",
         "",
         "v prilohe posielam mesacny PDF export dobropisov z BizniWebu.",
         f"Obdobie vytvorenia dobropisov: {result.date_from} az {result.date_to}.",
+        f"Faktury su filtrovane podla datumu vystavenia: {result.date_from} az {result.date_to}.",
         f"E-shopy: {', '.join(project.upper() for project in result.projects)}.",
         f"Pocet dobropisov: {result.exported_rows}.",
         "",
         "Dobropisovana suma spolu:",
+        "Dobropisy PDF:",
     ]
-    if result.total_rows:
-        for row in result.total_rows:
-            lines.append(
-                f"- {row.get('Mena') or '-'}: "
-                f"{int(row.get('Pocet') or 0)} ks, "
-                f"s DPH {_format_amount(row.get('Suma_s_DPH'))}"
+    if invoice_result is not None:
+        lines.insert(3, "V prilohe je aj export faktur vo formate Money S3.")
+    for creditnote_result in creditnote_results:
+        project = creditnote_result.projects[0].upper()
+        if creditnote_result.total_rows:
+            totals = ", ".join(
+                f"{row.get('Mena') or '-'} {_format_amount(row.get('Suma_s_DPH'))} s DPH"
+                for row in creditnote_result.total_rows
             )
+        else:
+            totals = "bez dobropisov"
+        lines.append(f"- {project}: {creditnote_result.exported_rows} ks, {totals}")
+
+    lines.extend(["", "Faktury Money S3:"])
+    if invoice_result is None:
+        lines.append("- Export faktur bol pre tento beh vypnuty.")
     else:
-        lines.append("- Bez dobropisov v zadanom obdobi.")
+        for project in invoice_result.projects:
+            project_key = project.upper()
+            lines.append(f"- {project_key}: {int(invoice_result.invoice_counts.get(project_key) or 0)} faktur")
 
     lines.extend(
         [
@@ -189,17 +294,24 @@ def build_creditnote_email_body(result: CreditnoteExportResult) -> str:
             "Kontrola vylucenia z reporting revenue:",
         ]
     )
-    audit = result.reporting_exclusion_summary or {}
-    audit_errors = audit.get("audit_errors") or {}
-    if audit_errors:
-        lines.append("- Audit nie je kompletne dostupny: " + "; ".join(f"{k}: {v}" for k, v in audit_errors.items()))
-    else:
-        lines.append(
-            f"- V realized revenue ostava {int(audit.get('included_in_revenue') or 0)} "
-            f"z {int(audit.get('checked_orders') or 0)} dobropisovanych objednavok."
+    for creditnote_result in creditnote_results:
+        project = creditnote_result.projects[0].upper()
+        audit = creditnote_result.reporting_exclusion_summary or {}
+        audit_errors = audit.get("audit_errors") or {}
+        if audit_errors:
+            lines.append(
+                f"- {project}: audit nie je kompletne dostupny: "
+                + "; ".join(f"{key}: {value}" for key, value in audit_errors.items())
+            )
+            continue
+        line = (
+            f"- {project}: v realized revenue ostava {int(audit.get('included_in_revenue') or 0)} "
+            f"z {int(audit.get('checked_orders') or 0)} dobropisovanych objednavok"
         )
-        if int(audit.get("order_not_found") or 0):
-            lines.append(f"- Nenajdene povodne objednavky v auditovanom okne: {int(audit.get('order_not_found') or 0)}.")
+        missing = int(audit.get("order_not_found") or 0)
+        if missing:
+            line += f", nenajdene povodne objednavky: {missing}"
+        lines.append(line + ".")
 
     lines.extend(
         [
@@ -208,7 +320,9 @@ def build_creditnote_email_body(result: CreditnoteExportResult) -> str:
         ]
     )
     carrier_rows = [
-        row for row in (result.carrier_rows or [])
+        row
+        for creditnote_result in creditnote_results
+        for row in (creditnote_result.carrier_rows or [])
         if int(row.get("Dobropisovane objednavky") or 0) > 0
     ]
     if carrier_rows:
@@ -230,8 +344,13 @@ def build_creditnote_email_body(result: CreditnoteExportResult) -> str:
             "Sumar:",
         ]
     )
-    if result.summary_rows:
-        for row in result.summary_rows:
+    summary_rows = [
+        row
+        for creditnote_result in creditnote_results
+        for row in creditnote_result.summary_rows
+    ]
+    if summary_rows:
+        for row in summary_rows:
             lines.append(
                 f"- {row.get('Eshop')} {row.get('Mena') or '-'}: "
                 f"{int(row.get('Pocet') or 0)} ks, "
@@ -249,7 +368,7 @@ def build_creditnote_email_body(result: CreditnoteExportResult) -> str:
 
 
 def send_creditnote_email_ses(
-    result: CreditnoteExportResult,
+    result: AccountingExportInput,
     subject: str,
     body_text: str,
     email_from: str,
@@ -262,8 +381,18 @@ def send_creditnote_email_ses(
         raise ValueError("CREDITNOTE_EXPORT_EMAIL_FROM or REPORT_EMAIL_FROM is required")
     if not destinations:
         raise ValueError("CREDITNOTE_EXPORT_EMAIL_TO has no valid recipients")
-    if not result.output_pdf.exists():
-        raise FileNotFoundError(f"Missing creditnote PDF: {result.output_pdf}")
+
+    creditnote_results = _creditnote_results(result)
+    invoice_result = _invoice_result(result)
+    for creditnote_result in creditnote_results:
+        if not creditnote_result.output_pdf.exists():
+            raise FileNotFoundError(f"Missing creditnote PDF: {creditnote_result.output_pdf}")
+    if invoice_result is not None:
+        for project in invoice_result.projects:
+            project_key = project.upper()
+            path = invoice_result.output_files.get(project_key)
+            if path is None or not path.exists():
+                raise FileNotFoundError(f"Missing Money S3 invoice export for project: {project_key}")
 
     msg = MIMEMultipart("mixed")
     msg["Subject"] = subject
@@ -274,10 +403,20 @@ def send_creditnote_email_ses(
     msg["Reply-To"] = source
     msg.attach(MIMEText(body_text, "plain", "utf-8"))
 
-    with result.output_pdf.open("rb") as fh:
-        part = MIMEApplication(fh.read(), _subtype="pdf", Name=result.output_pdf.name)
-    part["Content-Disposition"] = f'attachment; filename="{result.output_pdf.name}"'
-    msg.attach(part)
+    for creditnote_result in creditnote_results:
+        path = creditnote_result.output_pdf
+        with path.open("rb") as fh:
+            part = MIMEApplication(fh.read(), _subtype="pdf", Name=path.name)
+        part["Content-Disposition"] = f'attachment; filename="{path.name}"'
+        msg.attach(part)
+
+    if invoice_result is not None:
+        for project in invoice_result.projects:
+            path = invoice_result.output_files[project.upper()]
+            with path.open("rb") as fh:
+                part = MIMEApplication(fh.read(), _subtype="xml", Name=path.name)
+            part["Content-Disposition"] = f'attachment; filename="{path.name}"'
+            msg.attach(part)
 
     try:
         import boto3  # type: ignore
@@ -288,10 +427,16 @@ def send_creditnote_email_ses(
     region = os.getenv("AWS_REGION", "eu-central-1").strip()
     configuration_set = os.getenv("SES_CONFIGURATION_SET", reporting_defaults.get("ses_configuration_set", "")).strip()
     ses = boto3.client("ses", region_name=region)
+    raw_message = msg.as_bytes()
+    if len(raw_message) > MAX_SES_RAW_MESSAGE_BYTES:
+        raise RuntimeError(
+            f"Accounting email is too large for the configured SES safety limit: "
+            f"{len(raw_message)} > {MAX_SES_RAW_MESSAGE_BYTES} bytes"
+        )
     send_args: Dict[str, Any] = {
         "Source": source,
         "Destinations": destinations,
-        "RawMessage": {"Data": msg.as_string()},
+        "RawMessage": {"Data": raw_message},
     }
     if configuration_set:
         send_args["ConfigurationSetName"] = configuration_set
@@ -308,6 +453,7 @@ def run_creditnote_export_runner(args: argparse.Namespace) -> Dict[str, Any]:
     reporting_defaults = resolve_reporting_defaults(owner_project, project_settings)
     projects = parse_project_list(args.projects)
     skip_metrics = bool(getattr(args, "skip_metrics", False))
+    skip_invoice_export = bool(getattr(args, "skip_invoice_export", False))
     date_from, date_to = resolve_creditnote_export_window(
         timezone_name=args.timezone,
         reference_date=args.reference_date,
@@ -316,37 +462,69 @@ def run_creditnote_export_runner(args: argparse.Namespace) -> Dict[str, Any]:
     )
     output_dir = Path(args.output_dir) if str(args.output_dir or "").strip() else None
     print(
-        "Running monthly creditnote export "
+        "Running monthly accounting export "
         f"projects={','.join(projects)} window={date_from}..{date_to} "
-        f"skip_email={args.skip_email} dry_run_email={args.dry_run_email}"
+        f"skip_email={args.skip_email} dry_run_email={args.dry_run_email} "
+        f"skip_invoice_export={skip_invoice_export}"
     )
 
+    creditnote_results: List[CreditnoteExportResult] = []
     try:
-        result = run_monthly_creditnote_export(
-            projects=projects,
-            date_from=date_from,
-            date_to=date_to,
-            output_dir=output_dir,
-            output_tag=args.output_tag,
-        )
+        for project in projects:
+            creditnote_results.append(
+                run_monthly_creditnote_export(
+                    projects=(project,),
+                    date_from=date_from,
+                    date_to=date_to,
+                    output_dir=output_dir,
+                    output_tag=args.output_tag,
+                )
+            )
     except Exception:
         if not skip_metrics:
             put_metric("CreditnoteExportRunFailed", 1, owner_project, reporting_defaults)
         raise
 
-    total_gross_credit = sum(abs(float(row.get("Suma_s_DPH") or 0.0)) for row in result.total_rows)
+    invoice_result: MoneyS3InvoiceExportResult | None = None
+    if skip_invoice_export:
+        print("Money S3 invoice export skipped by flag.")
+    else:
+        try:
+            invoice_result = run_money_s3_invoice_export(
+                projects=projects,
+                date_from=date_from,
+                date_to=date_to,
+                output_dir=output_dir,
+                output_tag=args.output_tag,
+            )
+        except Exception:
+            if not skip_metrics:
+                put_metric("InvoiceMoneyS3ExportRunFailed", 1, owner_project, reporting_defaults)
+            raise
+
+    result = MonthlyAccountingExportResult(
+        creditnote_results=tuple(creditnote_results),
+        invoice_result=invoice_result,
+    )
+    total_gross_credit = sum(
+        abs(float(row.get("Suma_s_DPH") or 0.0))
+        for creditnote_result in creditnote_results
+        for row in creditnote_result.total_rows
+    )
+    revenue_included_orders = sum(
+        int((creditnote_result.reporting_exclusion_summary or {}).get("included_in_revenue") or 0)
+        for creditnote_result in creditnote_results
+    )
     if skip_metrics:
-        print("Creditnote export CloudWatch metrics skipped by flag.")
+        print("Monthly accounting export CloudWatch metrics skipped by flag.")
     else:
         put_metric("CreditnoteExportRows", result.exported_rows, owner_project, reporting_defaults)
         put_metric("CreditnoteExportGrossAmount", round(total_gross_credit, 2), owner_project, reporting_defaults)
-        put_metric(
-            "CreditnoteExportRevenueIncludedOrders",
-            int((result.reporting_exclusion_summary or {}).get("included_in_revenue") or 0),
-            owner_project,
-            reporting_defaults,
-        )
+        put_metric("CreditnoteExportRevenueIncludedOrders", revenue_included_orders, owner_project, reporting_defaults)
         put_metric("CreditnoteExportRunSucceeded", 1, owner_project, reporting_defaults)
+        if invoice_result is not None:
+            put_metric("InvoiceMoneyS3ExportRows", invoice_result.total_invoices, owner_project, reporting_defaults)
+            put_metric("InvoiceMoneyS3ExportRunSucceeded", 1, owner_project, reporting_defaults)
 
     subject = build_creditnote_email_subject(result, args.email_subject)
     body_text = build_creditnote_email_body(result)
@@ -355,18 +533,24 @@ def run_creditnote_export_runner(args: argparse.Namespace) -> Dict[str, Any]:
         print("Creditnote export email skipped by flag.")
     elif args.dry_run_email:
         message_id = "dry-run"
-        print("Creditnote export email dry-run; SES send skipped.")
+        print("Monthly accounting email dry-run; SES send skipped.")
     else:
-        message_id = send_creditnote_email_ses(
-            result=result,
-            subject=subject,
-            body_text=body_text,
-            email_from=args.email_from,
-            email_to=args.email_to,
-            reporting_defaults=reporting_defaults,
-        )
-        put_metric("CreditnoteExportEmailSent", 1, owner_project, reporting_defaults)
-        print(f"SES creditnote export sent. MessageId={message_id}")
+        try:
+            message_id = send_creditnote_email_ses(
+                result=result,
+                subject=subject,
+                body_text=body_text,
+                email_from=args.email_from,
+                email_to=args.email_to,
+                reporting_defaults=reporting_defaults,
+            )
+        except Exception:
+            if not skip_metrics:
+                put_metric("CreditnoteExportEmailFailed", 1, owner_project, reporting_defaults)
+            raise
+        if not skip_metrics:
+            put_metric("CreditnoteExportEmailSent", 1, owner_project, reporting_defaults)
+        print(f"SES monthly accounting export sent. MessageId={message_id}")
 
     summary = result.as_dict()
     summary.update(
@@ -377,6 +561,7 @@ def run_creditnote_export_runner(args: argparse.Namespace) -> Dict[str, Any]:
             "email_to": args.email_to,
             "metrics_skipped": skip_metrics,
             "subject": subject,
+            "invoice_export_skipped": skip_invoice_export,
         }
     )
     print("CREDITNOTE_EXPORT_SUMMARY " + json.dumps(summary, ensure_ascii=False, sort_keys=True))
@@ -385,7 +570,12 @@ def run_creditnote_export_runner(args: argparse.Namespace) -> Dict[str, Any]:
 
 def main() -> None:
     load_dotenv(encoding="utf-8-sig")
-    run_creditnote_export_runner(parse_args())
+    try:
+        run_creditnote_export_runner(parse_args())
+    except Exception as exc:
+        message = " ".join(str(exc).splitlines())
+        print(f"CREDITNOTE_EXPORT_RUN_FAILED type={type(exc).__name__} message={message}", flush=True)
+        raise
 
 
 if __name__ == "__main__":

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -115,7 +115,10 @@
       "roy",
       "vevo"
     ],
-    "email_to": "mil.terem@gmail.com"
+    "email_to": "mil.terem@gmail.com",
+    "creditnote_pdf_mode": "per_project",
+    "invoice_format": "moneys3",
+    "invoice_date_field": "inv_date"
   },
   "creditnote_storno_guard": {
     "enabled": true,

--- a/tests/test_creditnote_export.py
+++ b/tests/test_creditnote_export.py
@@ -3,6 +3,8 @@ import os
 import tempfile
 import unittest
 from datetime import date
+from email import policy
+from email.parser import BytesParser
 from pathlib import Path
 from unittest.mock import patch
 
@@ -16,10 +18,13 @@ from creditnote_export import (
 )
 from daily_report_runner import _build_creditnote_summary
 from monthly_creditnote_export_runner import (
+    MonthlyAccountingExportResult,
     build_creditnote_email_body,
     resolve_creditnote_export_window,
     run_creditnote_export_runner,
+    send_creditnote_email_ses,
 )
+from money_s3_invoice_export import MoneyS3InvoiceExportResult
 from reporting_core import resolve_biznisweb_api_url, resolve_project_env_value
 from reporting_core.runtime import load_project_runtime
 
@@ -180,6 +185,63 @@ class CreditnoteExportTests(unittest.TestCase):
             self.assertIn("Dobropisovana suma spolu", body)
             self.assertIn("VEVO €", body)
 
+    @patch("boto3.client")
+    def test_email_attaches_two_pdfs_and_two_money_s3_files(self, boto_client_mock) -> None:
+        boto_client_mock.return_value.send_raw_email.return_value = {"MessageId": "test-message-id"}
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            creditnote_results = tuple(
+                write_creditnote_pdf(
+                    export_rows=[],
+                    fetch_totals={project: {"reported_total": 0, "fetched_rows": 0, "exported_rows": 0}},
+                    output_pdf=root / f"dobropisy_{project}.pdf",
+                    date_from=date(2026, 5, 1),
+                    date_to=date(2026, 5, 31),
+                    projects=(project,),
+                )
+                for project in ("roy", "vevo")
+            )
+            invoice_paths = {
+                "ROY": root / "faktury_money_s3_roy.xml",
+                "VEVO": root / "faktury_money_s3_vevo.xml",
+            }
+            for path in invoice_paths.values():
+                path.write_bytes(b"<MoneyData />")
+            result = MonthlyAccountingExportResult(
+                creditnote_results=creditnote_results,
+                invoice_result=MoneyS3InvoiceExportResult(
+                    projects=("roy", "vevo"),
+                    date_from="2026-05-01",
+                    date_to="2026-05-31",
+                    output_files=invoice_paths,
+                    invoice_counts={"ROY": 1, "VEVO": 1},
+                    source_filenames={"ROY": "roy.xml", "VEVO": "vevo.xml"},
+                ),
+            )
+
+            message_id = send_creditnote_email_ses(
+                result=result,
+                subject="Uctovne doklady",
+                body_text=build_creditnote_email_body(result),
+                email_from="reports@example.test",
+                email_to="mil.terem@gmail.com",
+                reporting_defaults={},
+            )
+
+            self.assertEqual("test-message-id", message_id)
+            raw_message = boto_client_mock.return_value.send_raw_email.call_args.kwargs["RawMessage"]["Data"]
+            message = BytesParser(policy=policy.default).parsebytes(raw_message)
+            filenames = sorted(part.get_filename() for part in message.iter_attachments())
+            self.assertEqual(
+                [
+                    "dobropisy_roy.pdf",
+                    "dobropisy_vevo.pdf",
+                    "faktury_money_s3_roy.xml",
+                    "faktury_money_s3_vevo.xml",
+                ],
+                filenames,
+            )
+
     def test_reporting_audit_flags_creditnoted_orders_still_in_revenue_by_carrier(self) -> None:
         export_rows = [
             {
@@ -332,18 +394,39 @@ class CreditnoteExportTests(unittest.TestCase):
         self.assertEqual(("roy", "vevo"), parse_project_list(" ROY, vevo ,,"))
 
     @patch("monthly_creditnote_export_runner.put_metric")
+    @patch("monthly_creditnote_export_runner.run_money_s3_invoice_export")
     @patch("monthly_creditnote_export_runner.run_monthly_creditnote_export")
-    def test_runner_skip_email_uses_previous_month(self, export_mock, put_metric_mock) -> None:
+    def test_runner_skip_email_uses_previous_month(self, export_mock, invoice_mock, put_metric_mock) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            result = write_creditnote_pdf(
+            roy_result = write_creditnote_pdf(
                 export_rows=[],
                 fetch_totals={"roy": {"reported_total": 0, "fetched_rows": 0, "exported_rows": 0}},
-                output_pdf=Path(tmp) / "dobropisy.pdf",
+                output_pdf=Path(tmp) / "dobropisy_roy.pdf",
                 date_from=date(2026, 5, 1),
                 date_to=date(2026, 5, 31),
-                projects=("roy", "vevo"),
+                projects=("roy",),
             )
-            export_mock.return_value = result
+            vevo_result = write_creditnote_pdf(
+                export_rows=[],
+                fetch_totals={"vevo": {"reported_total": 0, "fetched_rows": 0, "exported_rows": 0}},
+                output_pdf=Path(tmp) / "dobropisy_vevo.pdf",
+                date_from=date(2026, 5, 1),
+                date_to=date(2026, 5, 31),
+                projects=("vevo",),
+            )
+            export_mock.side_effect = [roy_result, vevo_result]
+            roy_xml = Path(tmp) / "faktury_roy.xml"
+            vevo_xml = Path(tmp) / "faktury_vevo.xml"
+            roy_xml.write_bytes(b"<MoneyData />")
+            vevo_xml.write_bytes(b"<MoneyData />")
+            invoice_mock.return_value = MoneyS3InvoiceExportResult(
+                projects=("roy", "vevo"),
+                date_from="2026-05-01",
+                date_to="2026-05-31",
+                output_files={"ROY": roy_xml, "VEVO": vevo_xml},
+                invoice_counts={"ROY": 10, "VEVO": 20},
+                source_filenames={"ROY": "roy.xml", "VEVO": "vevo.xml"},
+            )
 
             args = type(
                 "Args",
@@ -362,15 +445,21 @@ class CreditnoteExportTests(unittest.TestCase):
                     "email_to": "mil.terem@gmail.com",
                     "skip_email": True,
                     "dry_run_email": False,
+                    "skip_invoice_export": False,
                 },
             )()
 
             summary = run_creditnote_export_runner(args)
 
-            export_mock.assert_called_once()
-            _, kwargs = export_mock.call_args
-            self.assertEqual("2026-05-01", kwargs["date_from"])
-            self.assertEqual("2026-05-31", kwargs["date_to"])
+            self.assertEqual(2, export_mock.call_count)
+            self.assertEqual(("roy",), export_mock.call_args_list[0].kwargs["projects"])
+            self.assertEqual(("vevo",), export_mock.call_args_list[1].kwargs["projects"])
+            self.assertEqual("2026-05-01", export_mock.call_args_list[0].kwargs["date_from"])
+            self.assertEqual("2026-05-31", export_mock.call_args_list[0].kwargs["date_to"])
+            invoice_mock.assert_called_once()
+            self.assertEqual({"ROY", "VEVO"}, set(summary["output_pdfs"]))
+            self.assertEqual(30, summary["invoice_export"]["total_invoices"])
+            self.assertFalse(summary["invoice_export_skipped"])
             self.assertTrue(summary["email_skipped"])
             self.assertGreaterEqual(put_metric_mock.call_count, 2)
 
@@ -385,6 +474,9 @@ class CreditnoteExportTests(unittest.TestCase):
         self.assertEqual("monthly-creditnote-export", raw["task_family"])
         self.assertEqual(["roy", "vevo"], raw["projects"])
         self.assertEqual("mil.terem@gmail.com", raw["email_to"])
+        self.assertEqual("per_project", raw["creditnote_pdf_mode"])
+        self.assertEqual("moneys3", raw["invoice_format"])
+        self.assertEqual("inv_date", raw["invoice_date_field"])
 
 
 if __name__ == "__main__":

--- a/tests/test_money_s3_invoice_export.py
+++ b/tests/test_money_s3_invoice_export.py
@@ -1,0 +1,57 @@
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+from money_s3_invoice_export import (
+    _validate_money_s3_xml,
+    biznisweb_php_serialize,
+    money_s3_invoice_filters,
+    run_money_s3_invoice_export,
+)
+
+
+class MoneyS3InvoiceExportTests(unittest.TestCase):
+    def test_money_s3_filter_uses_invoice_issue_dates(self) -> None:
+        filters = money_s3_invoice_filters(date(2026, 5, 1), date(2026, 5, 31))
+
+        self.assertEqual(
+            {"inv_date_from": "1.5.2026", "inv_date_to": "31.5.2026"},
+            filters,
+        )
+        self.assertEqual(
+            'a:2:{s:13:"inv_date_from";s:8:"1.5.2026";s:11:"inv_date_to";s:9:"31.5.2026";}',
+            biznisweb_php_serialize(filters),
+        )
+
+    def test_money_s3_validation_rejects_non_xml_response(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "did not return MoneyData XML"):
+            _validate_money_s3_xml(b"<html>login</html>", "roy")
+
+    @patch("money_s3_invoice_export.download_money_s3_invoice_export")
+    def test_export_writes_one_xml_per_project(self, download_mock) -> None:
+        download_mock.side_effect = [
+            (b"<MoneyData><ROY /></MoneyData>", "roy.xml", 12),
+            (b"<?xml version='1.0'?><MoneyData><VEVO /></MoneyData>", "vevo.xml", 15),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_money_s3_invoice_export(
+                projects=("roy", "vevo"),
+                date_from="2026-05-01",
+                date_to="2026-05-31",
+                output_dir=Path(tmp),
+                output_tag="test",
+            )
+
+            self.assertEqual({"ROY": 12, "VEVO": 15}, result.invoice_counts)
+            self.assertEqual(27, result.total_invoices)
+            self.assertEqual({"ROY", "VEVO"}, set(result.output_files))
+            for project, path in result.output_files.items():
+                self.assertTrue(path.exists(), project)
+                self.assertIn(f"faktury_money_s3_{project.lower()}_2026-05_issued_test.xml", path.name)
+                self.assertIn(b"<MoneyData", path.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_monthly_accounting_workflow.py
+++ b/tests/test_monthly_accounting_workflow.py
@@ -1,0 +1,50 @@
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT_DIR / ".github" / "workflows" / "deploy-monthly-creditnote-export.yml"
+
+
+class MonthlyAccountingWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_builds_and_pins_the_exact_commit_image(self) -> None:
+        self.assertIn('DEPLOY_IMAGE_TAG="monthly-creditnote-export-${GITHUB_SHA}"', self.workflow)
+        self.assertIn('docker build -t "${IMAGE_URI}" .', self.workflow)
+        self.assertIn('docker push "${IMAGE_URI}"', self.workflow)
+        self.assertIn('IMAGE_IDENTIFIER="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}@${IMAGE_DIGEST}"', self.workflow)
+        self.assertNotIn('imageTag="latest"', self.workflow)
+
+    def test_promotes_scheduler_only_after_the_host_marker(self) -> None:
+        marker_gate = self.workflow.index('grep -q "${EXPECTED_MARKER}" smoke-task.log')
+        schedule_update = self.workflow.index("aws scheduler update-schedule", marker_gate)
+        current_tag = self.workflow.index(
+            'protect_ecr_image_tag "${IMAGE_IDENTIFIER}" "${ECR_CURRENT_TAG}"',
+            marker_gate,
+        )
+        self.assertLess(marker_gate, schedule_update)
+        self.assertLess(schedule_update, current_tag)
+
+    def test_validates_all_four_accounting_attachments(self) -> None:
+        self.assertIn('output_pdfs = summary["output_pdfs"]', self.workflow)
+        self.assertIn('invoice_export = summary["invoice_export"]', self.workflow)
+        self.assertIn('root.tag.rsplit("}", 1)[-1] == "MoneyData"', self.workflow)
+        self.assertIn('"attachment_count": len(output_pdfs) + len(invoice_export["output_files"])', self.workflow)
+
+    def test_real_smoke_uses_explicit_send_mode(self) -> None:
+        self.assertIn('EMAIL_MODE="send"', self.workflow)
+        self.assertIn('dry-run) RUN_ARGS+=(--dry-run-email)', self.workflow)
+        self.assertIn('send) ;;', self.workflow)
+
+    def test_scheduler_has_dlq_and_failure_alarms(self) -> None:
+        self.assertIn('target["DeadLetterConfig"] = {"Arn": dlq_arn}', self.workflow)
+        self.assertIn("monthly-creditnote-export-dlq-not-empty", self.workflow)
+        self.assertIn("monthly-creditnote-export-run-failed", self.workflow)
+        self.assertIn('assert target["DeadLetterConfig"]["Arn"] == expected_dlq', self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## What
- generate one credit-note PDF per shop for ROY and VEVO
- export invoices for the same previous-calendar-month window as Money S3 XML using invoice issue date (`inv_date`)
- send all four files in one SES email to the configured accounting recipient
- build and pin the exact monthly image, promote the scheduler only after a Fargate localhost marker, and add DLQ/application failure alarms

## Why
The 2026-07-14 task referenced an ECR digest that had become untagged and was deleted by the seven-day lifecycle policy. The task never reached application logging or SES. The production runner also still generated only one combined credit-note PDF and had no Money S3 invoice export because the earlier feature branch was never merged.

## Impact
The enabled `monthly-creditnote-export` schedule remains `cron(0 6 14 * ? *)` in `Europe/Bratislava`. Each run exports the complete previous calendar month and sends two PDF credit-note files plus two Money S3 XML invoice files. A failed smoke cannot replace the current scheduler target.

## Checks
- `python -m unittest tests.test_money_s3_invoice_export tests.test_creditnote_export tests.test_monthly_accounting_workflow` (24 tests)
- CI regression command (183 tests)
- `python scripts/reporting_qa_smoke.py`
- JSON, YAML, Python compile, `git diff --check`
- extracted workflow shell passed `bash -n`
