### PR TITLE
Add individual ROY picking-list printing

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -1938,6 +1938,8 @@ jobs:
           ]
           assert priority_pairs == sorted(priority_pairs, reverse=True), "Live stock alerts are not impact-sorted"
           assert "/api/operations/roy/picking-lists.pdf" in html, "Picking-list PDF link missing"
+          assert "data-print-order" in html, "Individual picking-list print action missing in live UI"
+          assert "include_printed" in html, "Individual picking-list reprint mode missing in live UI"
           assert "data-restock-enabled" in html, "Restock preference checkbox missing in live UI"
           assert "inventory-restock-preference" in html, "Restock preference action marker missing in live UI"
           assert "Raw → baseline" in html, "Smart demand comparison missing in live UI"

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,15 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY individual picking-list reprint control is implemented locally on `codex/roy-individual-picking-print` (2026-07-22):
+  - incident diagnosis for order `2677003601` confirmed that BizniWeb still exposed the order as paid and fulfillable, while the ROY operations state already marked it printed in batch `picking-20260720123200`; the default picking PDF therefore excluded it even though a preview PDF could still render it
+  - every fulfillable order row now renders its own read-only `Vytlačiť` action; already marked rows render `Vytlačiť znova`
+  - the individual action requests only that order number with `include_printed=1`, so an intentional reprint bypasses the historical print-state filter without clearing or mutating S3 operations state
+  - the existing batch PDF and explicit `Označiť vytlačené` flow remain unchanged
+  - local verification: Python compile passed; ROY operations/PDF/auth/maintenance focused suite passed (`67` tests); full suite passed (`267` tests); reporting QA, security CI, environment contract, workflow YAML, generated inline JavaScript, and `git diff --check` passed
+  - deployment is not complete yet
+  - Next exact step: complete review and broader checks, merge through PR, build the exact merge image, deploy ROY with `skip_artifact_refresh=true`, require the maintenance/Fargate localhost marker chain before App Runner UI/API verification, then prove both a new-order `Vytlačiť` link and printed-order `Vytlačiť znova` link generate a one-order PDF
+
 - ROY blocking dashboard maintenance mode is merged, deployed, and live (2026-07-22):
   - `/production/roy` now renders a server-side full-screen Slovak maintenance overlay before first paint, marks the dashboard root `inert`/`aria-hidden`, prevents pointer and keyboard use, and polls the authenticated same-origin status every 5 seconds; a 4-second request timeout and visibility/focus rechecks fail closed for already-open tabs
   - the maintenance source of truth is the separate `daily-reports/roy-sk/operations/maintenance.json` S3 object, isolated from business operations state; active leases require a versioned marker, owner, reason, phase, valid timestamps, a maximum 15-minute renewable TTL, and a 150-minute absolute lifetime

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -1211,6 +1211,8 @@ def build_roy_operations_dashboard_html(
     .badge.warn { color:var(--amber); background:var(--amber-bg); }
     .badge.bad { color:var(--red); background:var(--red-bg); }
     .badge.info { color:var(--blue); background:var(--blue-bg); }
+    .print-cell { display:grid; gap:6px; justify-items:start; min-width:132px; }
+    a.order-print-button { padding:0 8px; font-size:12px; white-space:nowrap; }
     .table-wrap { overflow:auto; }
     table { width:100%; min-width:980px; border-collapse:collapse; }
     th,td { padding:10px 12px; border-bottom:1px solid var(--line); text-align:left; vertical-align:top; font-size:13px; }
@@ -1934,11 +1936,25 @@ def build_roy_operations_dashboard_html(
       const printedAt = text(order.picking_printed_at, '');
       return `<span class="badge warn">vytlačené</span>${printedAt ? `<div class="muted">${safe(printedAt)}</div>` : ''}`;
     }
+    function individualPickingPrintLink(order) {
+      const orderNum = String(order.order_num || order.id || '').trim();
+      if (!orderNum) return '';
+      const pdfUrl = new URL(`/api/operations/${encodeURIComponent(project)}/picking-lists.pdf`, window.location.origin);
+      pdfUrl.searchParams.set('refresh', '1');
+      pdfUrl.searchParams.set('include_printed', '1');
+      pdfUrl.searchParams.set('order_num', orderNum);
+      const label = order.picking_printed ? 'Vytlačiť znova' : 'Vytlačiť';
+      const href = `${pdfUrl.pathname}${pdfUrl.search}`;
+      return `<a class="button order-print-button" data-print-order="${safe(orderNum)}" href="${safe(href)}" target="_blank" rel="noopener" aria-label="${safe(`${label} objednávku ${orderNum}`)}">${safe(label)}</a>`;
+    }
+    function pickingPrintCell(order) {
+      return `<div class="print-cell">${pickingPrintBadge(order)}${individualPickingPrintLink(order)}</div>`;
+    }
     function orderRow(order, includeDate=false) {
       return `<tr>
         <td><strong class="mono">${safe(order.order_num)}</strong>${includeDate ? `<div class="muted">${safe(order.purchase_at)}</div>` : ''}</td>
         <td><span class="badge ${order.fulfillment_reason === 'paid_online' ? 'good' : 'warn'}">${safe(order.status)}</span></td>
-        <td>${pickingPrintBadge(order)}</td>
+        <td>${pickingPrintCell(order)}</td>
         <td>${safe((order.payment || {}).title)}</td>
         <td>${safe((order.shipping || {}).title)}</td>
         <td>${safe(order.sum)}</td>

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -548,11 +548,19 @@ class RoyOperationsDashboardTests(unittest.TestCase):
                 "R-1": {"order_num": "R-1", "printed_at": "2026-05-28T10:00:00Z"},
             },
         }
+        state_before = copy.deepcopy(state)
 
         selected = select_picking_orders_for_print(orders, state, order_nums=["R-1", "R-2", "R-3"])
+        individual_reprint = select_picking_orders_for_print(
+            orders,
+            state,
+            order_nums=["R-1"],
+            include_printed=True,
+        )
 
         self.assertEqual(["R-2", "R-3"], [row["order_num"] for row in selected])
-        self.assertEqual({"R-1"}, set(state["printed_picking_orders"]))
+        self.assertEqual(["R-1"], [row["order_num"] for row in individual_reprint])
+        self.assertEqual(state_before, state)
 
     def test_operations_snapshot_marks_active_printed_orders(self) -> None:
         order_snapshot = {
@@ -584,6 +592,16 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("/api/operations/roy/picking-lists.pdf", html)
         self.assertIn("/api/operations/${encodeURIComponent(project)}/picking-lists/printed", html)
         self.assertIn("Označiť vytlačené", html)
+
+    def test_operations_dashboard_has_individual_reprint_action_for_each_order(self) -> None:
+        html = build_roy_operations_dashboard_html("roy")
+
+        self.assertIn("function individualPickingPrintLink(order)", html)
+        self.assertIn("pdfUrl.searchParams.set('include_printed', '1');", html)
+        self.assertIn("pdfUrl.searchParams.set('order_num', orderNum);", html)
+        self.assertIn('data-print-order="${safe(orderNum)}"', html)
+        self.assertIn("Vytlačiť znova", html)
+        self.assertIn("pickingPrintCell(order)", html)
 
     def test_snapshot_expands_bundle_order_items_to_pickable_components(self) -> None:
         project_settings = json.loads((ROOT_DIR / "projects" / "roy" / "settings.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## What changed

- adds a per-order `Vytlačiť` action to every fulfillable ROY order row
- shows `Vytlačiť znova` for orders already recorded as printed
- requests exactly one order with `include_printed=1`, without mutating S3 print state
- extends the production App Runner gate with feature markers
- records the incident and rollout plan in `PROJECT_STATE.md`

## Why

Order `2677003601` remained paid and fulfillable but was already present in `printed_picking_orders`, so the normal batch PDF correctly filtered it after the physical print did not complete. Warehouse staff need a safe per-order reprint path that does not clear or rewrite historical print state.

## Impact

The existing batch PDF and explicit `Označiť vytlačené` workflow are unchanged. Individual print/reprint is a read-only PDF GET scoped to one order.

## Validation

- focused ROY operations/PDF/auth/maintenance suite: 67 tests passed
- full unit suite: 267 tests passed
- reporting QA smoke passed
- security CI passed
- environment contract passed
- Python compile, workflow YAML, generated inline JavaScript, and `git diff --check` passed
- independent read-only review: no P0/P1/P2 findings
