### PR TITLE
Reconcile paid Stripe-expired orders

### DIFF
--- a/.github/workflows/deploy-unpaid-order-cancellation.yml
+++ b/.github/workflows/deploy-unpaid-order-cancellation.yml
@@ -73,6 +73,8 @@ jobs:
           if not raw.get("enabled"):
               raise SystemExit(f"unpaid_order_cancellation is disabled for project={project}")
           required = ["schedule_name", "schedule_expression", "task_family", "target_status_name"]
+          if raw.get("recovery_enabled"):
+              required.append("recovery_target_status_name")
           missing = [key for key in required if not str(raw.get(key) or "").strip()]
           if missing:
               raise SystemExit(f"Missing unpaid_order_cancellation settings: {missing}")
@@ -88,6 +90,9 @@ jobs:
           emit("TASK_FAMILY", raw["task_family"])
           emit("TARGET_STATUS_NAME", raw["target_status_name"])
           emit("TARGET_STATUS_ID", raw.get("target_status_id") or "")
+          emit("RECOVERY_ENABLED", str(bool(raw.get("recovery_enabled"))).lower())
+          emit("RECOVERY_TARGET_STATUS_NAME", raw.get("recovery_target_status_name") or "")
+          emit("RECOVERY_TARGET_STATUS_ID", raw.get("recovery_target_status_id") or "")
           PY
           # shellcheck disable=SC1091
           source unpaid-settings.env
@@ -320,6 +325,9 @@ jobs:
           PROJECT="${REPORT_PROJECT:?REPORT_PROJECT missing}"
           TARGET_STATUS_NAME="${TARGET_STATUS_NAME:?TARGET_STATUS_NAME missing}"
           TARGET_STATUS_ID="${TARGET_STATUS_ID:-}"
+          RECOVERY_ENABLED="${RECOVERY_ENABLED:-false}"
+          RECOVERY_TARGET_STATUS_NAME="${RECOVERY_TARGET_STATUS_NAME:-}"
+          RECOVERY_TARGET_STATUS_ID="${RECOVERY_TARGET_STATUS_ID:-}"
           EXECUTE_NOW="${EXECUTE_NOW:-false}"
           PIDS=()
           cleanup() {
@@ -348,11 +356,18 @@ jobs:
           assert summary["enabled"] is True
           assert summary["dry_run"] is (not execute_now)
           assert summary["target_status_name"] == os.environ["TARGET_STATUS_NAME"]
+          recovery_enabled = os.environ.get("RECOVERY_ENABLED", "false").lower() == "true"
+          assert summary["recovery_enabled"] is recovery_enabled
+          if recovery_enabled:
+              assert summary["recovery_target_status_name"] == os.environ["RECOVERY_TARGET_STATUS_NAME"]
           if execute_now:
               assert int(summary["failed_orders"]) == 0
           expected_id = os.environ.get("TARGET_STATUS_ID") or ""
           if expected_id:
               assert int(summary["target_status_id"]) == int(expected_id)
+          expected_recovery_id = os.environ.get("RECOVERY_TARGET_STATUS_ID") or ""
+          if expected_recovery_id:
+              assert int(summary["recovery_target_status_id"]) == int(expected_recovery_id)
           marker_name = "UNPAID_CANCELLATION_EXECUTE_MARKER_OK" if execute_now else "UNPAID_CANCELLATION_MARKER_OK"
           marker_dir = Path("/tmp/unpaid-cancellation-marker")
           marker_dir.mkdir(parents=True, exist_ok=True)
@@ -363,6 +378,9 @@ jobs:
               "orders_scanned": summary["total_orders_scanned"],
               "eligible_orders": summary["eligible_orders"],
               "updated_orders": summary["updated_orders"],
+              "recovery_candidates": summary["recovery_candidates"],
+              "recovered_orders": summary["recovered_orders"],
+              "recovery_target_status_id": summary["recovery_target_status_id"],
               "target_status_id": summary["target_status_id"],
               "dry_run": summary["dry_run"],
           }
@@ -377,7 +395,8 @@ jobs:
           echo "UNPAID_CANCELLATION_MARKER_END"
           SH
           )"
-          export CONTAINER_NAME PROJECT SMOKE_SCRIPT TARGET_STATUS_NAME TARGET_STATUS_ID EXECUTE_NOW
+          export CONTAINER_NAME PROJECT SMOKE_SCRIPT TARGET_STATUS_NAME TARGET_STATUS_ID RECOVERY_ENABLED
+          export RECOVERY_TARGET_STATUS_NAME RECOVERY_TARGET_STATUS_ID EXECUTE_NOW
           python - <<'PY' > smoke-overrides.json
           import json
           import os
@@ -390,6 +409,15 @@ jobs:
                           {"name": "REPORT_PROJECT", "value": os.environ["PROJECT"]},
                           {"name": "TARGET_STATUS_NAME", "value": os.environ["TARGET_STATUS_NAME"]},
                           {"name": "TARGET_STATUS_ID", "value": os.environ.get("TARGET_STATUS_ID", "")},
+                          {"name": "RECOVERY_ENABLED", "value": os.environ.get("RECOVERY_ENABLED", "false")},
+                          {
+                              "name": "RECOVERY_TARGET_STATUS_NAME",
+                              "value": os.environ.get("RECOVERY_TARGET_STATUS_NAME", ""),
+                          },
+                          {
+                              "name": "RECOVERY_TARGET_STATUS_ID",
+                              "value": os.environ.get("RECOVERY_TARGET_STATUS_ID", ""),
+                          },
                           {"name": "EXECUTE_NOW", "value": os.environ.get("EXECUTE_NOW", "false")},
                       ],
                   }

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-07-22
+Last updated: 2026-08-10
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,17 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- ROY unpaid-order Stripe-expiry reconciliation is implemented and locally verified on branch `codex/stripe-expired-reconciliation` (2026-08-10; deployment pending):
+  - root cause: Stripe can overwrite an already fulfilled order back to `Stripe - expired` after an operator has matched an alternative bank transfer, issued the final invoice, and moved the order through the paid/sent states; the existing cancellation job inspected only the current status/payment and could later cancel that genuinely paid order
+  - every prospective cancellation now loads the current order detail before planning and again immediately before mutation; any final invoice is a hard cancellation stop, so the job fails safe if invoice evidence appears between the scan and write
+  - recovery is deliberately narrow: current status must be `Stripe - expired`, a final invoice must predate the current last-change timestamp, and payment resolution must be evidenced by either the invoice API `paid=true` flag or the configured bank-transfer payment identity; eligible orders are restored to `Odoslaná` (`status_id=4`) instead of cancelled
+  - the cancellation scan now queries only configured candidate/recovery status IDs through BizniWeb's official status filter, avoiding the previous broad all-status scan; `Čaká na vybavenie` is an explicit ROY candidate so stale bank-transfer orders can be cancelled while COD remains excluded by the payment guard
+  - CloudWatch and Fargate smoke summaries now include recovery candidates, successful/failed recoveries, pre-mutation rechecks, and the resolved recovery target status
+  - live API work was read-only: order `2677002988` is currently `Odoslaná` after the operator's manual 2026-08-10 correction and is therefore outside the candidate set; its final invoice exists but BizniWeb exposes `paid=false`, which is why bank-transfer identity is an intentional second recovery proof; order `2677003434` is still `Čaká na vybavenie`, bank transfer, older than 14 days, and has no final invoice, so it is eligible for cancellation
+  - the final read-only dry-run completed without API errors: `51` candidate-status rows scanned across `29` pages, `35` cancellation candidates, `0` recovery candidates because `2677002988` was already manually restored, and all `35` cancellation candidates had zero final invoices
+  - local verification passed: `265` CI-equivalent tests, reporting QA smoke, security CI, Python compile, ROY settings JSON, deploy workflow YAML, and `git diff --check`
+  - Next exact step: publish the branch through a draft PR, merge after CI, then run the protected unpaid-cancellation deploy in dry-run mode and require the Fargate instance/IP/service/path hard gate plus localhost marker before any UI verification; do not use `execute_now=true` merely as a smoke because it would send real cancellation emails for the audited backlog
 
 - ROY individual picking-list reprint control is merged, deployed, and live (2026-07-22):
   - incident diagnosis for order `2677003601` confirmed that BizniWeb still exposed the order as paid and fulfillable, while the ROY operations state already marked it printed in batch `picking-20260720123200`; the default picking PDF therefore excluded it even though a preview PDF could still render it

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -220,6 +220,20 @@
     "age_days": 14,
     "target_status_name": "Nezaplatená - zrušená objednávka",
     "target_status_id": 74,
+    "recovery_enabled": true,
+    "recovery_source_statuses": [
+      "Stripe - expired"
+    ],
+    "recovery_target_status_name": "Odoslaná",
+    "recovery_target_status_id": 4,
+    "recovery_payment_reference_ids": [
+      "6"
+    ],
+    "recovery_payment_title_patterns": [
+      "Bankovým prevodom",
+      "Bankovní převod",
+      "Bank transfer"
+    ],
     "lang_code": "SK",
     "payment_reference_ids": [
       "6",
@@ -238,6 +252,7 @@
       "card"
     ],
     "candidate_statuses": [
+      "Čaká na vybavenie",
       "Čaká na úhradu",
       "Platba online - platnosť vypršala",
       "Platba online - platba zamietnutá",
@@ -270,7 +285,6 @@
       "Nezaplatená - zrušená objednávka",
       "Platba online - zaplatené",
       "Prijatá platba / uhradené",
-      "Čaká na vybavenie",
       "Pripravené k odberu",
       "Odoslaná",
       "Storno",

--- a/tests/test_unpaid_order_cancellation.py
+++ b/tests/test_unpaid_order_cancellation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from unpaid_order_cancellation import (
     cancellation_eligibility_reason,
+    recovery_eligibility_reason,
     resolve_unpaid_cancellation_settings,
     run_unpaid_order_cancellation,
 )
@@ -23,22 +24,56 @@ def price_element(kind: str, title: str, reference_id: str = "") -> dict:
     }
 
 
-def make_order(order_num: str, status_name: str, payment_title: str, payment_ref: str, pur_date: str) -> dict:
+def make_invoice(
+    invoice_num: str = "INV-1",
+    *,
+    created: str = "2026-05-02 10:00:00",
+    paid: bool = False,
+) -> dict:
+    return {
+        "id": invoice_num,
+        "invoice_num": invoice_num,
+        "created": created,
+        "paid": paid,
+        "pay_date": created if paid else None,
+    }
+
+
+def make_order(
+    order_num: str,
+    status_name: str,
+    payment_title: str,
+    payment_ref: str,
+    pur_date: str,
+    *,
+    last_change: str | None = None,
+    invoices: list | None = None,
+) -> dict:
     return {
         "id": order_num,
         "order_num": order_num,
         "pur_date": pur_date,
-        "last_change": pur_date,
+        "last_change": last_change or pur_date,
         "status": {"id": 1, "name": status_name},
         "price_elements": [price_element("payment", payment_title, payment_ref)],
+        "invoices": list(invoices or []),
         "sum": {"value": 100, "formatted": "100,00 EUR"},
     }
 
 
 class FakeBizniswebClient:
-    def __init__(self, pages, statuses=None):
+    def __init__(self, pages, statuses=None, detail_overrides=None, detail_sequences=None):
         self.pages = list(pages)
-        self.statuses = statuses or [{"id": 74, "name": "Nezaplaten\u00e1 - zru\u0161en\u00e1 objedn\u00e1vka"}]
+        self.statuses = statuses or [
+            {"id": 74, "name": "Nezaplaten\u00e1 - zru\u0161en\u00e1 objedn\u00e1vka"},
+            {"id": 4, "name": "Odoslan\u00e1"},
+            {"id": 1, "name": "\u010cak\u00e1 na vybavenie"},
+            {"id": 2, "name": "\u010cak\u00e1 na \u00fahradu"},
+            {"id": 68, "name": "Platba online - platnos\u0165 vypr\u0161ala"},
+            {"id": 69, "name": "Stripe - expired"},
+        ]
+        self.detail_overrides = detail_overrides or {}
+        self.detail_sequences = {key: list(value) for key, value in (detail_sequences or {}).items()}
         self.page_calls = 0
         self.mutations = []
 
@@ -54,6 +89,20 @@ class FakeBizniswebClient:
                     "status": {"id": variables["status_id"], "name": self.statuses[0]["name"]},
                 }
             }
+        if "order_num" in variables:
+            order_num = str(variables["order_num"])
+            if order_num in self.detail_sequences:
+                sequence = self.detail_sequences[order_num]
+                if len(sequence) > 1:
+                    return {"getOrder": sequence.pop(0)}
+                return {"getOrder": sequence[0]}
+            if order_num in self.detail_overrides:
+                return {"getOrder": self.detail_overrides[order_num]}
+            for page in self.pages:
+                for order in page:
+                    if str(order.get("order_num")) == order_num:
+                        return {"getOrder": order}
+            return {"getOrder": None}
         if "params" in variables:
             index = self.page_calls
             self.page_calls += 1
@@ -108,14 +157,21 @@ class UnpaidOrderCancellationTests(unittest.TestCase):
                     "enabled": True,
                     "target_status_name": "Nezaplaten\u00e1 - zru\u0161en\u00e1 objedn\u00e1vka",
                     "target_status_id": 74,
+                    "recovery_enabled": True,
+                    "recovery_target_status_name": "Odoslan\u00e1",
+                    "recovery_target_status_id": 4,
+                    "recovery_source_statuses": ["Stripe - expired"],
+                    "recovery_payment_reference_ids": ["6"],
+                    "recovery_payment_title_patterns": ["Bankov\u00fdm prevodom"],
                     "candidate_statuses": [
+                        "\u010cak\u00e1 na vybavenie",
                         "\u010cak\u00e1 na \u00fahradu",
                         "Platba online - platnos\u0165 vypr\u0161ala",
+                        "Stripe - expired",
                     ],
                     "excluded_statuses": [
                         "Nezaplaten\u00e1 - zru\u0161en\u00e1 objedn\u00e1vka",
                         "Platba online - zaplaten\u00e9",
-                        "\u010cak\u00e1 na vybavenie",
                         "Odoslan\u00e1",
                     ],
                     "payment_reference_ids": ["6", "18"],
@@ -144,7 +200,7 @@ class UnpaidOrderCancellationTests(unittest.TestCase):
             ),
             (
                 make_order("R-4", "\u010cak\u00e1 na vybavenie", "Dobierkou", "7", "2026-05-01 10:00:00"),
-                "excluded_status",
+                "payment_not_matched",
             ),
             (
                 make_order("R-5", "Platba online - zaplaten\u00e9", "Okam\u017eit\u00e1 platba online", "18", "2026-05-01 10:00:00"),
@@ -160,11 +216,101 @@ class UnpaidOrderCancellationTests(unittest.TestCase):
                 ),
                 "already_target_status",
             ),
+            (
+                make_order(
+                    "R-7",
+                    "\u010cak\u00e1 na vybavenie",
+                    "Bankov\u00fdm prevodom",
+                    "6",
+                    "2026-05-01 10:00:00",
+                ),
+                "eligible",
+            ),
+            (
+                make_order(
+                    "R-8",
+                    "Stripe - expired",
+                    "Bankov\u00fdm prevodom",
+                    "6",
+                    "2026-05-01 10:00:00",
+                    last_change="2026-05-20 10:00:00",
+                    invoices=[make_invoice()],
+                ),
+                "final_invoice_present",
+            ),
         ]
 
         for order, expected_reason in cases:
             with self.subTest(order=order["order_num"]):
                 self.assertEqual(expected_reason, cancellation_eligibility_reason(order, settings, cutoff))
+
+    def test_recovery_requires_preexisting_invoice_and_payment_resolution_evidence(self) -> None:
+        settings = self.make_settings()
+        cases = [
+            (
+                make_order(
+                    "R-1",
+                    "Stripe - expired",
+                    "Bankov\u00fdm prevodom",
+                    "6",
+                    "2026-05-01 10:00:00",
+                    last_change="2026-05-20 10:00:00",
+                    invoices=[make_invoice(created="2026-05-02 10:00:00")],
+                ),
+                "eligible",
+            ),
+            (
+                make_order(
+                    "R-2",
+                    "Stripe - expired",
+                    "Okam\u017eit\u00e1 platba online",
+                    "18",
+                    "2026-05-01 10:00:00",
+                    last_change="2026-05-20 10:00:00",
+                    invoices=[make_invoice(created="2026-05-02 10:00:00", paid=True)],
+                ),
+                "eligible",
+            ),
+            (
+                make_order(
+                    "R-3",
+                    "Stripe - expired",
+                    "Okam\u017eit\u00e1 platba online",
+                    "18",
+                    "2026-05-01 10:00:00",
+                    last_change="2026-05-20 10:00:00",
+                    invoices=[make_invoice(created="2026-05-02 10:00:00")],
+                ),
+                "missing_payment_resolution_evidence",
+            ),
+            (
+                make_order(
+                    "R-4",
+                    "Stripe - expired",
+                    "Bankov\u00fdm prevodom",
+                    "6",
+                    "2026-05-01 10:00:00",
+                    last_change="2026-05-20 10:00:00",
+                    invoices=[make_invoice(created="2026-05-21 10:00:00")],
+                ),
+                "final_invoice_not_preexisting",
+            ),
+            (
+                make_order(
+                    "R-5",
+                    "Stripe - expired",
+                    "Bankov\u00fdm prevodom",
+                    "6",
+                    "2026-05-01 10:00:00",
+                    last_change="2026-05-20 10:00:00",
+                ),
+                "missing_final_invoice",
+            ),
+        ]
+
+        for order, expected_reason in cases:
+            with self.subTest(order=order["order_num"]):
+                self.assertEqual(expected_reason, recovery_eligibility_reason(order, settings))
 
     def test_runner_dry_run_resolves_target_status_without_mutation(self) -> None:
         project_settings = {
@@ -232,6 +378,103 @@ class UnpaidOrderCancellationTests(unittest.TestCase):
         self.assertEqual(["R-1"], summary.updated_order_nums)
         self.assertEqual([("R-1", 74)], client.mutations)
 
+    def test_runner_recovers_resolved_stripe_expired_order_to_shipped(self) -> None:
+        project_settings = {
+            "unpaid_order_cancellation": {
+                "enabled": True,
+                "target_status_name": "Nezaplaten\u00e1 - zru\u0161en\u00e1 objedn\u00e1vka",
+                "target_status_id": 74,
+                "recovery_enabled": True,
+                "recovery_target_status_name": "Odoslan\u00e1",
+                "recovery_target_status_id": 4,
+                "recovery_source_statuses": ["Stripe - expired"],
+                "recovery_payment_reference_ids": ["6"],
+                "candidate_statuses": ["Stripe - expired"],
+                "payment_reference_ids": ["6", "18"],
+            }
+        }
+        order = make_order(
+            "R-RECOVER",
+            "Stripe - expired",
+            "Bankov\u00fdm prevodom",
+            "6",
+            "2026-05-01 10:00:00",
+            last_change="2026-05-20 10:00:00",
+            invoices=[make_invoice(created="2026-05-02 10:00:00")],
+        )
+        client = FakeBizniswebClient([[order]])
+
+        summary = run_unpaid_order_cancellation(
+            "roy",
+            reference_date="2026-05-27",
+            dry_run=False,
+            client=client,
+            project_settings=project_settings,
+        )
+
+        self.assertEqual(1, summary.recovery_candidates)
+        self.assertEqual(["R-RECOVER"], summary.recovery_candidate_order_nums)
+        self.assertEqual(2, summary.rechecked_orders)
+        self.assertEqual(1, summary.recovered_orders)
+        self.assertEqual(["R-RECOVER"], summary.recovered_order_nums)
+        self.assertEqual(0, summary.updated_orders)
+        self.assertEqual([("R-RECOVER", 4)], client.mutations)
+
+    def test_live_recheck_prefers_recovery_over_planned_cancellation(self) -> None:
+        project_settings = {
+            "unpaid_order_cancellation": {
+                "enabled": True,
+                "target_status_name": "Nezaplaten\u00e1 - zru\u0161en\u00e1 objedn\u00e1vka",
+                "target_status_id": 74,
+                "recovery_enabled": True,
+                "recovery_target_status_name": "Odoslan\u00e1",
+                "recovery_target_status_id": 4,
+                "recovery_source_statuses": ["Stripe - expired"],
+                "recovery_payment_reference_ids": ["6"],
+                "candidate_statuses": ["\u010cak\u00e1 na vybavenie", "Stripe - expired"],
+                "excluded_statuses": [
+                    "Nezaplaten\u00e1 - zru\u0161en\u00e1 objedn\u00e1vka",
+                    "Platba online - zaplaten\u00e9",
+                    "Odoslan\u00e1",
+                ],
+                "payment_reference_ids": ["6", "18"],
+            }
+        }
+        listed_order = make_order(
+            "R-RACE",
+            "\u010cak\u00e1 na vybavenie",
+            "Bankov\u00fdm prevodom",
+            "6",
+            "2026-05-01 10:00:00",
+        )
+        live_order = make_order(
+            "R-RACE",
+            "Stripe - expired",
+            "Bankov\u00fdm prevodom",
+            "6",
+            "2026-05-01 10:00:00",
+            last_change="2026-05-20 10:00:00",
+            invoices=[make_invoice(created="2026-05-02 10:00:00")],
+        )
+        client = FakeBizniswebClient(
+            [[listed_order]],
+            detail_sequences={"R-RACE": [listed_order, live_order]},
+        )
+
+        summary = run_unpaid_order_cancellation(
+            "roy",
+            reference_date="2026-05-27",
+            dry_run=False,
+            client=client,
+            project_settings=project_settings,
+        )
+
+        self.assertEqual(1, summary.eligible_orders)
+        self.assertEqual(0, summary.recovery_candidates)
+        self.assertEqual(0, summary.updated_orders)
+        self.assertEqual(1, summary.recovered_orders)
+        self.assertEqual([("R-RACE", 4)], client.mutations)
+
     def test_runner_uses_partial_order_pages_from_biznisweb_errors(self) -> None:
         project_settings = {
             "unpaid_order_cancellation": {
@@ -265,10 +508,17 @@ class UnpaidOrderCancellationTests(unittest.TestCase):
         self.assertTrue(settings.enabled)
         self.assertEqual(14, settings.age_days)
         self.assertEqual(74, settings.target_status_id)
+        self.assertTrue(settings.recovery_enabled)
+        self.assertEqual(4, settings.recovery_target_status_id)
+        self.assertEqual("Odoslan\u00e1", settings.recovery_target_status_name)
+        self.assertIn("Stripe - expired", settings.recovery_source_statuses)
+        self.assertIn("6", settings.recovery_payment_reference_ids)
         self.assertEqual("roy-unpaid-order-cancellation", settings.schedule_name)
         self.assertEqual("cron(10 2 * * ? *)", settings.schedule_expression)
         self.assertIn("6", settings.payment_reference_ids)
         self.assertIn("18", settings.payment_reference_ids)
+        self.assertIn("\u010cak\u00e1 na vybavenie", settings.candidate_statuses)
+        self.assertNotIn("\u010cak\u00e1 na vybavenie", settings.excluded_statuses)
 
 
 if __name__ == "__main__":

--- a/unpaid_order_cancellation.py
+++ b/unpaid_order_cancellation.py
@@ -7,7 +7,7 @@ import os
 import re
 import unicodedata
 from dataclasses import asdict, dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from gql import Client, gql
@@ -20,6 +20,7 @@ from reporting_core import BASE_DEFAULT_PROJECT, load_project_env, load_project_
 logger = get_logger("unpaid_order_cancellation")
 
 DEFAULT_TARGET_STATUS_NAME = "Nezaplaten\u00e1 - zru\u0161en\u00e1 objedn\u00e1vka"
+DEFAULT_RECOVERY_TARGET_STATUS_NAME = "Odoslan\u00e1"
 DEFAULT_AGE_DAYS = 14
 DEFAULT_SCAN_MAX_PAGES = 200
 DEFAULT_PAGE_LIMIT = 30
@@ -78,12 +79,20 @@ DEFAULT_EXCLUDED_STATUSES = (
     "Vr\u00e1ten\u00e9",
     "Dobropis",
 )
+DEFAULT_RECOVERY_SOURCE_STATUSES = ("Stripe - expired",)
+DEFAULT_RECOVERY_PAYMENT_REFERENCE_IDS = ("6",)
+DEFAULT_RECOVERY_PAYMENT_TITLE_PATTERNS = (
+    "bankovym prevodom",
+    "bankovni prevod",
+    "bankovy prevod",
+    "bank transfer",
+)
 
 
 UNPAID_ORDER_QUERY = gql(
     """
-query GetOrdersForUnpaidCancellation($params: OrderParams) {
-  getOrderList(params: $params) {
+query GetOrdersForUnpaidCancellation($status: Int, $params: OrderParams) {
+  getOrderList(status: $status, params: $params) {
     data {
       id
       order_num
@@ -113,6 +122,45 @@ query GetOrdersForUnpaidCancellation($params: OrderParams) {
       nextCursor
       pageIndex
       totalPages
+    }
+  }
+}
+"""
+)
+
+
+ORDER_RECHECK_QUERY = gql(
+    """
+query GetOrderForUnpaidCancellationRecheck($order_num: String!) {
+  getOrder(order_num: $order_num) {
+    id
+    order_num
+    pur_date
+    last_change
+    status {
+      id
+      name
+    }
+    invoices {
+      id
+      invoice_num
+      created
+      paid
+      pay_date
+    }
+    price_elements {
+      type
+      title
+      value
+      reference_id
+      price {
+        value
+        formatted
+      }
+    }
+    sum {
+      value
+      formatted
     }
   }
 }
@@ -154,6 +202,12 @@ class UnpaidCancellationSettings:
     age_days: int = DEFAULT_AGE_DAYS
     target_status_name: str = DEFAULT_TARGET_STATUS_NAME
     target_status_id: Optional[int] = None
+    recovery_enabled: bool = False
+    recovery_target_status_name: str = DEFAULT_RECOVERY_TARGET_STATUS_NAME
+    recovery_target_status_id: Optional[int] = None
+    recovery_source_statuses: Tuple[str, ...] = DEFAULT_RECOVERY_SOURCE_STATUSES
+    recovery_payment_reference_ids: Tuple[str, ...] = DEFAULT_RECOVERY_PAYMENT_REFERENCE_IDS
+    recovery_payment_title_patterns: Tuple[str, ...] = DEFAULT_RECOVERY_PAYMENT_TITLE_PATTERNS
     lang_code: str = DEFAULT_LANG_CODE
     payment_reference_ids: Tuple[str, ...] = DEFAULT_PAYMENT_REFERENCE_IDS
     payment_title_patterns: Tuple[str, ...] = DEFAULT_PAYMENT_TITLE_PATTERNS
@@ -166,12 +220,34 @@ class UnpaidCancellationSettings:
     timezone: str = "Europe/Bratislava"
     task_family: str = ""
     normalized_target_status_name: str = field(init=False)
+    normalized_recovery_target_status_name: str = field(init=False)
+    normalized_recovery_source_statuses: Tuple[str, ...] = field(init=False)
+    normalized_recovery_payment_title_patterns: Tuple[str, ...] = field(init=False)
     normalized_payment_title_patterns: Tuple[str, ...] = field(init=False)
     normalized_candidate_statuses: Tuple[str, ...] = field(init=False)
     normalized_excluded_statuses: Tuple[str, ...] = field(init=False)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "normalized_target_status_name", normalize_text(self.target_status_name))
+        object.__setattr__(
+            self,
+            "normalized_recovery_target_status_name",
+            normalize_text(self.recovery_target_status_name),
+        )
+        object.__setattr__(
+            self,
+            "normalized_recovery_source_statuses",
+            tuple(normalize_text(value) for value in self.recovery_source_statuses if normalize_text(value)),
+        )
+        object.__setattr__(
+            self,
+            "normalized_recovery_payment_title_patterns",
+            tuple(
+                normalize_text(value)
+                for value in self.recovery_payment_title_patterns
+                if normalize_text(value)
+            ),
+        )
         object.__setattr__(
             self,
             "normalized_payment_title_patterns",
@@ -198,17 +274,29 @@ class UnpaidCancellationSummary:
     cutoff_date: str
     target_status_name: str
     target_status_id: Optional[int] = None
+    recovery_enabled: bool = False
+    recovery_target_status_name: str = ""
+    recovery_target_status_id: Optional[int] = None
     total_orders_scanned: int = 0
     pages_scanned: int = 0
     eligible_orders: int = 0
     updated_orders: int = 0
+    recovery_candidates: int = 0
+    recovered_orders: int = 0
+    recovery_failed_orders: int = 0
+    rechecked_orders: int = 0
     failed_orders: int = 0
     scan_limit_reached: bool = False
     scan_stop_reason: str = ""
     oldest_order_date: str = ""
     skipped_by_reason: Dict[str, int] = field(default_factory=dict)
+    recovery_skipped_by_reason: Dict[str, int] = field(default_factory=dict)
+    recheck_skipped_by_reason: Dict[str, int] = field(default_factory=dict)
     eligible_order_nums: List[str] = field(default_factory=list)
     updated_order_nums: List[str] = field(default_factory=list)
+    recovery_candidate_order_nums: List[str] = field(default_factory=list)
+    recovered_order_nums: List[str] = field(default_factory=list)
+    recovery_failed_order_nums: List[str] = field(default_factory=list)
     failed_order_nums: List[str] = field(default_factory=list)
 
     def as_dict(self) -> Dict[str, Any]:
@@ -242,6 +330,12 @@ def resolve_unpaid_cancellation_settings(project_settings: Dict[str, Any]) -> Un
     else:
         parsed_target_status_id = int(target_status_id)
 
+    recovery_target_status_id = raw.get("recovery_target_status_id")
+    if recovery_target_status_id in ("", None):
+        parsed_recovery_target_status_id: Optional[int] = None
+    else:
+        parsed_recovery_target_status_id = int(recovery_target_status_id)
+
     age_days = max(1, int(raw.get("age_days", DEFAULT_AGE_DAYS)))
     scan_max_pages = max(1, int(raw.get("scan_max_pages", DEFAULT_SCAN_MAX_PAGES)))
     page_limit = max(1, min(DEFAULT_PAGE_LIMIT, int(raw.get("page_limit", DEFAULT_PAGE_LIMIT))))
@@ -250,6 +344,23 @@ def resolve_unpaid_cancellation_settings(project_settings: Dict[str, Any]) -> Un
         age_days=age_days,
         target_status_name=str(raw.get("target_status_name") or DEFAULT_TARGET_STATUS_NAME),
         target_status_id=parsed_target_status_id,
+        recovery_enabled=bool(raw.get("recovery_enabled", False)),
+        recovery_target_status_name=str(
+            raw.get("recovery_target_status_name") or DEFAULT_RECOVERY_TARGET_STATUS_NAME
+        ),
+        recovery_target_status_id=parsed_recovery_target_status_id,
+        recovery_source_statuses=_tuple_from_settings(
+            raw.get("recovery_source_statuses"),
+            DEFAULT_RECOVERY_SOURCE_STATUSES,
+        ),
+        recovery_payment_reference_ids=_tuple_from_settings(
+            raw.get("recovery_payment_reference_ids"),
+            DEFAULT_RECOVERY_PAYMENT_REFERENCE_IDS,
+        ),
+        recovery_payment_title_patterns=_tuple_from_settings(
+            raw.get("recovery_payment_title_patterns"),
+            DEFAULT_RECOVERY_PAYMENT_TITLE_PATTERNS,
+        ),
         lang_code=str(raw.get("lang_code") or DEFAULT_LANG_CODE),
         payment_reference_ids=_tuple_from_settings(raw.get("payment_reference_ids"), DEFAULT_PAYMENT_REFERENCE_IDS),
         payment_title_patterns=_tuple_from_settings(raw.get("payment_title_patterns"), DEFAULT_PAYMENT_TITLE_PATTERNS),
@@ -313,16 +424,89 @@ def _payment_elements(order: Dict[str, Any]) -> List[Dict[str, Any]]:
     ]
 
 
-def payment_matches(order: Dict[str, Any], settings: UnpaidCancellationSettings) -> bool:
-    configured_ids = {str(value).strip() for value in settings.payment_reference_ids if str(value).strip()}
+def _payment_matches_values(
+    order: Dict[str, Any],
+    reference_ids: Sequence[str],
+    normalized_title_patterns: Sequence[str],
+) -> bool:
+    configured_ids = {str(value).strip() for value in reference_ids if str(value).strip()}
     for element in _payment_elements(order):
         reference_id = str(element.get("reference_id") or "").strip()
         if reference_id and reference_id in configured_ids:
             return True
         normalized_title = normalize_text(element.get("title"))
-        if any(pattern and pattern in normalized_title for pattern in settings.normalized_payment_title_patterns):
+        if any(pattern and pattern in normalized_title for pattern in normalized_title_patterns):
             return True
     return False
+
+
+def payment_matches(order: Dict[str, Any], settings: UnpaidCancellationSettings) -> bool:
+    return _payment_matches_values(
+        order,
+        settings.payment_reference_ids,
+        settings.normalized_payment_title_patterns,
+    )
+
+
+def recovery_payment_matches(order: Dict[str, Any], settings: UnpaidCancellationSettings) -> bool:
+    return _payment_matches_values(
+        order,
+        settings.recovery_payment_reference_ids,
+        settings.normalized_recovery_payment_title_patterns,
+    )
+
+
+def _final_invoices(order: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [invoice for invoice in (order.get("invoices") or []) if invoice and invoice.get("id")]
+
+
+def has_final_invoice(order: Dict[str, Any]) -> bool:
+    return bool(_final_invoices(order))
+
+
+def has_paid_final_invoice(order: Dict[str, Any]) -> bool:
+    return any(invoice.get("paid") is True for invoice in _final_invoices(order))
+
+
+def _parse_api_datetime(value: Any) -> Optional[datetime]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
+
+
+def final_invoice_predates_last_change(order: Dict[str, Any]) -> bool:
+    last_change = _parse_api_datetime(order.get("last_change"))
+    if last_change is None:
+        return False
+    return any(
+        (created := _parse_api_datetime(invoice.get("created"))) is not None and created <= last_change
+        for invoice in _final_invoices(order)
+    )
+
+
+def recovery_eligibility_reason(order: Dict[str, Any], settings: UnpaidCancellationSettings) -> str:
+    if not settings.recovery_enabled:
+        return "recovery_disabled"
+
+    status = normalize_text(_status_name(order))
+    if not status:
+        return "missing_status"
+    if status not in settings.normalized_recovery_source_statuses:
+        return "not_recovery_status"
+    if not has_final_invoice(order):
+        return "missing_final_invoice"
+    if not final_invoice_predates_last_change(order):
+        return "final_invoice_not_preexisting"
+    if not (has_paid_final_invoice(order) or recovery_payment_matches(order, settings)):
+        return "missing_payment_resolution_evidence"
+    return "eligible"
 
 
 def cancellation_eligibility_reason(
@@ -343,6 +527,8 @@ def cancellation_eligibility_reason(
         return "already_target_status"
     if status in settings.normalized_excluded_statuses:
         return "excluded_status"
+    if has_final_invoice(order):
+        return "final_invoice_present"
     if settings.normalized_candidate_statuses and status not in settings.normalized_candidate_statuses:
         return "not_candidate_status"
     if not payment_matches(order, settings):
@@ -363,76 +549,135 @@ def list_order_statuses(client: Client, settings: UnpaidCancellationSettings) ->
     return [row for row in (result.get("listOrderStatuses") or []) if row]
 
 
-def resolve_target_status_id(client: Client, settings: UnpaidCancellationSettings) -> int:
-    statuses = list_order_statuses(client, settings)
-    target_norm = settings.normalized_target_status_name
+def _resolve_status_id(
+    statuses: Sequence[Dict[str, Any]],
+    target_status_name: str,
+    configured_status_id: Optional[int],
+) -> int:
+    target_norm = normalize_text(target_status_name)
     for row in statuses:
         row_id = int(row.get("id") or 0)
         row_name_norm = normalize_text(row.get("name"))
-        if settings.target_status_id and row_id == settings.target_status_id:
+        if configured_status_id and row_id == configured_status_id:
             if row_name_norm != target_norm:
                 raise RuntimeError(
-                    f"Configured target_status_id={settings.target_status_id} resolves to "
-                    f"'{row.get('name')}', expected '{settings.target_status_name}'."
+                    f"Configured status_id={configured_status_id} resolves to "
+                    f"'{row.get('name')}', expected '{target_status_name}'."
                 )
             return row_id
-        if not settings.target_status_id and row_name_norm == target_norm:
+        if not configured_status_id and row_name_norm == target_norm:
             return row_id
-    raise RuntimeError(f"Target status '{settings.target_status_name}' not found in BizniWeb.")
+    raise RuntimeError(f"Target status '{target_status_name}' not found in BizniWeb.")
+
+
+def resolve_target_status_id(client: Client, settings: UnpaidCancellationSettings) -> int:
+    return _resolve_status_id(
+        list_order_statuses(client, settings),
+        settings.target_status_name,
+        settings.target_status_id,
+    )
+
+
+def resolve_recovery_target_status_id(client: Client, settings: UnpaidCancellationSettings) -> int:
+    return _resolve_status_id(
+        list_order_statuses(client, settings),
+        settings.recovery_target_status_name,
+        settings.recovery_target_status_id,
+    )
+
+
+def resolve_candidate_status_ids(
+    statuses: Sequence[Dict[str, Any]],
+    settings: UnpaidCancellationSettings,
+) -> List[int]:
+    configured_names = set(settings.normalized_candidate_statuses)
+    if settings.recovery_enabled:
+        configured_names.update(settings.normalized_recovery_source_statuses)
+    resolved = [
+        int(row.get("id") or 0)
+        for row in statuses
+        if int(row.get("id") or 0) > 0 and normalize_text(row.get("name")) in configured_names
+    ]
+    if not resolved:
+        raise RuntimeError("No active BizniWeb order statuses match the configured cancellation candidates.")
+    return resolved
+
+
+def fetch_order_for_recheck(client: Client, order_num: str) -> Dict[str, Any]:
+    result = client.execute(
+        ORDER_RECHECK_QUERY,
+        variable_values={"order_num": str(order_num)},
+    )
+    return result.get("getOrder") or {}
 
 
 def fetch_orders_for_cancellation(
     client: Client,
     settings: UnpaidCancellationSettings,
+    status_ids: Sequence[int],
 ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     orders: List[Dict[str, Any]] = []
-    cursor: Any = None
-    has_next_page = True
     page_count = 0
     oldest_order_date = ""
     stop_reason = "api_exhausted"
 
-    while has_next_page and page_count < settings.scan_max_pages:
-        params: Dict[str, Any] = {
-            "limit": settings.page_limit,
-            "order_by": "pur_date",
-            "sort": "DESC",
-        }
-        if cursor not in ("", None):
-            params["cursor"] = cursor
+    scan_limit_reached = False
+    for status_id in status_ids:
+        cursor: Any = None
+        has_next_page = True
+        status_page_count = 0
+        while has_next_page and page_count < settings.scan_max_pages:
+            params: Dict[str, Any] = {
+                "limit": settings.page_limit,
+                "order_by": "pur_date",
+                "sort": "DESC",
+            }
+            if cursor not in ("", None):
+                params["cursor"] = cursor
 
-        try:
-            result = client.execute(UNPAID_ORDER_QUERY, variable_values={"params": params})
-        except Exception as exc:
-            partial_data = getattr(exc, "data", None)
-            if not partial_data:
-                if page_count == 0:
-                    raise
-                stop_reason = "api_error_after_partial_scan"
-                logger.warning("Stopping order-list scan after BizniWeb API error on page %s: %s", page_count + 1, exc)
+            try:
+                result = client.execute(
+                    UNPAID_ORDER_QUERY,
+                    variable_values={"status": int(status_id), "params": params},
+                )
+            except Exception as exc:
+                partial_data = getattr(exc, "data", None)
+                if not partial_data:
+                    if status_page_count == 0:
+                        raise
+                    stop_reason = "api_error_after_partial_scan"
+                    logger.warning(
+                        "Stopping order-list scan for status_id=%s after BizniWeb API error on page %s: %s",
+                        status_id,
+                        status_page_count + 1,
+                        exc,
+                    )
+                    break
+                logger.warning("Using partial order-list response after BizniWeb API error: %s", exc)
+                result = partial_data
+            payload = result.get("getOrderList") or {}
+            page_orders = [order for order in (payload.get("data") or []) if order]
+            orders.extend(page_orders)
+            page_count += 1
+            status_page_count += 1
+
+            for order in page_orders:
+                purchased_at = order_purchase_date(order)
+                if purchased_at:
+                    text = purchased_at.strftime("%Y-%m-%d")
+                    if not oldest_order_date or text < oldest_order_date:
+                        oldest_order_date = text
+
+            page_info = payload.get("pageInfo") or {}
+            has_next_page = bool(page_info.get("hasNextPage"))
+            cursor = page_info.get("nextCursor")
+            if cursor in ("", None):
                 has_next_page = False
-                break
-            logger.warning("Using partial order-list response after BizniWeb API error: %s", exc)
-            result = partial_data
-        payload = result.get("getOrderList") or {}
-        page_orders = [order for order in (payload.get("data") or []) if order]
-        orders.extend(page_orders)
-        page_count += 1
 
-        for order in page_orders:
-            purchased_at = order_purchase_date(order)
-            if purchased_at:
-                text = purchased_at.strftime("%Y-%m-%d")
-                if not oldest_order_date or text < oldest_order_date:
-                    oldest_order_date = text
+        if has_next_page and page_count >= settings.scan_max_pages:
+            scan_limit_reached = True
+            break
 
-        page_info = payload.get("pageInfo") or {}
-        has_next_page = bool(page_info.get("hasNextPage"))
-        cursor = page_info.get("nextCursor")
-        if cursor in ("", None):
-            has_next_page = False
-
-    scan_limit_reached = bool(has_next_page and page_count >= settings.scan_max_pages)
     if scan_limit_reached:
         stop_reason = "scan_max_pages"
 
@@ -477,6 +722,8 @@ def run_unpaid_order_cancellation(
         reference_date=ref_date.strftime("%Y-%m-%d"),
         cutoff_date=cutoff_date.strftime("%Y-%m-%d"),
         target_status_name=settings.target_status_name,
+        recovery_enabled=settings.recovery_enabled,
+        recovery_target_status_name=(settings.recovery_target_status_name if settings.recovery_enabled else ""),
     )
     if not settings.enabled:
         logger.info("Unpaid order cancellation disabled for project=%s", project)
@@ -487,55 +734,180 @@ def run_unpaid_order_cancellation(
             load_project_env(project, logger=logger)
         client = build_client(project, project_settings)
 
-    target_status_id = resolve_target_status_id(client, settings)
+    statuses = list_order_statuses(client, settings)
+    target_status_id = _resolve_status_id(
+        statuses,
+        settings.target_status_name,
+        settings.target_status_id,
+    )
     summary.target_status_id = target_status_id
+    recovery_target_status_id: Optional[int] = None
+    if settings.recovery_enabled:
+        recovery_target_status_id = _resolve_status_id(
+            statuses,
+            settings.recovery_target_status_name,
+            settings.recovery_target_status_id,
+        )
+        summary.recovery_target_status_id = recovery_target_status_id
 
-    orders, scan = fetch_orders_for_cancellation(client, settings)
+    candidate_status_ids = resolve_candidate_status_ids(statuses, settings)
+    orders, scan = fetch_orders_for_cancellation(client, settings, candidate_status_ids)
     summary.total_orders_scanned = len(orders)
     summary.pages_scanned = int(scan.get("pages_scanned") or 0)
     summary.scan_limit_reached = bool(scan.get("scan_limit_reached"))
     summary.scan_stop_reason = str(scan.get("scan_stop_reason") or "")
     summary.oldest_order_date = str(scan.get("oldest_order_date") or "")
 
-    eligible_orders: List[Dict[str, Any]] = []
+    def record_failure(order_num: str, recovery: bool) -> None:
+        summary.failed_orders += 1
+        summary.failed_order_nums.append(order_num)
+        if recovery:
+            summary.recovery_failed_orders += 1
+            summary.recovery_failed_order_nums.append(order_num)
+
+    provisional_orders: List[Dict[str, Any]] = []
     skipped: Dict[str, int] = {}
     for order in orders:
+        status = normalize_text(_status_name(order))
+        if settings.recovery_enabled and status in settings.normalized_recovery_source_statuses:
+            provisional_orders.append(order)
+            continue
+
         reason = cancellation_eligibility_reason(order, settings, cutoff_date)
         if reason == "eligible":
-            eligible_orders.append(order)
+            provisional_orders.append(order)
+        else:
+            skipped[reason] = skipped.get(reason, 0) + 1
+
+    recovery_candidates: List[Dict[str, Any]] = []
+    eligible_orders: List[Dict[str, Any]] = []
+    recovery_skipped: Dict[str, int] = {}
+    for order in provisional_orders:
+        order_num = str(order.get("order_num") or "").strip()
+        listed_status = normalize_text(_status_name(order))
+        if not order_num:
+            record_failure("", recovery=listed_status in settings.normalized_recovery_source_statuses)
+            continue
+        try:
+            checked_order = fetch_order_for_recheck(client, order_num)
+            summary.rechecked_orders += 1
+        except Exception as exc:  # pragma: no cover - API failure path
+            record_failure(
+                order_num,
+                recovery=listed_status in settings.normalized_recovery_source_statuses,
+            )
+            logger.error("Failed to inspect candidate order %s: %s", order_num, exc)
+            continue
+        if not checked_order:
+            record_failure(
+                order_num,
+                recovery=listed_status in settings.normalized_recovery_source_statuses,
+            )
+            logger.error("Candidate order %s was not returned by the detail recheck", order_num)
+            continue
+
+        recovery_reason = recovery_eligibility_reason(checked_order, settings)
+        checked_status = normalize_text(_status_name(checked_order))
+        if recovery_reason == "eligible":
+            recovery_candidates.append(checked_order)
+            continue
+        if settings.recovery_enabled and checked_status in settings.normalized_recovery_source_statuses:
+            recovery_skipped[recovery_reason] = recovery_skipped.get(recovery_reason, 0) + 1
+
+        reason = cancellation_eligibility_reason(checked_order, settings, cutoff_date)
+        if reason == "eligible":
+            eligible_orders.append(checked_order)
         else:
             skipped[reason] = skipped.get(reason, 0) + 1
 
     summary.eligible_orders = len(eligible_orders)
+    summary.recovery_candidates = len(recovery_candidates)
     summary.skipped_by_reason = dict(sorted(skipped.items()))
+    summary.recovery_skipped_by_reason = dict(sorted(recovery_skipped.items()))
     summary.eligible_order_nums = [str(order.get("order_num") or "") for order in eligible_orders]
+    summary.recovery_candidate_order_nums = [
+        str(order.get("order_num") or "") for order in recovery_candidates
+    ]
 
     logger.info(
-        "Unpaid order cancellation scan project=%s cutoff=%s scanned=%s eligible=%s dry_run=%s",
+        "Unpaid order cancellation scan project=%s cutoff=%s scanned=%s eligible=%s "
+        "recovery_candidates=%s dry_run=%s",
         project,
         summary.cutoff_date,
         summary.total_orders_scanned,
         summary.eligible_orders,
+        summary.recovery_candidates,
         dry_run,
     )
 
     if dry_run:
         return summary
 
-    for order in eligible_orders:
+    planned_orders = [("recover", order) for order in recovery_candidates]
+    planned_orders.extend(("cancel", order) for order in eligible_orders)
+    recheck_skipped: Dict[str, int] = {}
+
+    for planned_action, order in planned_orders:
         order_num = str(order.get("order_num") or "").strip()
         if not order_num:
-            summary.failed_orders += 1
-            summary.failed_order_nums.append("")
+            record_failure("", recovery=planned_action == "recover")
             continue
+
         try:
-            change_order_status(client, order_num, target_status_id)
-            summary.updated_orders += 1
-            summary.updated_order_nums.append(order_num)
-            logger.info("Changed order %s to status_id=%s", order_num, target_status_id)
+            live_order = fetch_order_for_recheck(client, order_num)
+            summary.rechecked_orders += 1
         except Exception as exc:  # pragma: no cover - API failure path
-            summary.failed_orders += 1
-            summary.failed_order_nums.append(order_num)
-            logger.error("Failed to change order %s: %s", order_num, exc)
+            record_failure(order_num, recovery=planned_action == "recover")
+            logger.error("Failed to re-read order %s before status change: %s", order_num, exc)
+            continue
+
+        if not live_order:
+            record_failure(order_num, recovery=planned_action == "recover")
+            logger.error("Order %s was not returned by the live pre-mutation recheck", order_num)
+            continue
+
+        live_recovery_reason = recovery_eligibility_reason(live_order, settings)
+        if live_recovery_reason == "eligible":
+            action = "recover"
+            action_status_id = recovery_target_status_id
+        elif planned_action == "recover":
+            reason = f"recovery_{live_recovery_reason}"
+            recheck_skipped[reason] = recheck_skipped.get(reason, 0) + 1
+            logger.info("Skipped recovery for order %s after live recheck: %s", order_num, live_recovery_reason)
+            continue
+        else:
+            live_cancellation_reason = cancellation_eligibility_reason(live_order, settings, cutoff_date)
+            if live_cancellation_reason != "eligible":
+                reason = f"cancellation_{live_cancellation_reason}"
+                recheck_skipped[reason] = recheck_skipped.get(reason, 0) + 1
+                logger.info(
+                    "Skipped cancellation for order %s after live recheck: %s",
+                    order_num,
+                    live_cancellation_reason,
+                )
+                continue
+            action = "cancel"
+            action_status_id = target_status_id
+
+        if action_status_id is None:
+            record_failure(order_num, recovery=action == "recover")
+            logger.error("Missing target status id for action=%s order=%s", action, order_num)
+            continue
+
+        try:
+            change_order_status(client, order_num, action_status_id)
+            if action == "recover":
+                summary.recovered_orders += 1
+                summary.recovered_order_nums.append(order_num)
+                logger.info("Recovered order %s to status_id=%s", order_num, action_status_id)
+            else:
+                summary.updated_orders += 1
+                summary.updated_order_nums.append(order_num)
+                logger.info("Cancelled unpaid order %s with status_id=%s", order_num, action_status_id)
+        except Exception as exc:  # pragma: no cover - API failure path
+            record_failure(order_num, recovery=action == "recover")
+            logger.error("Failed action=%s for order %s: %s", action, order_num, exc)
+
+    summary.recheck_skipped_by_reason = dict(sorted(recheck_skipped.items()))
 
     return summary

--- a/unpaid_order_cancellation_runner.py
+++ b/unpaid_order_cancellation_runner.py
@@ -97,6 +97,10 @@ def run_unpaid_cancellation_runner(args: argparse.Namespace) -> Dict[str, Any]:
     put_metric("UnpaidCancellationOrdersScanned", summary.total_orders_scanned, project, reporting_defaults)
     put_metric("UnpaidCancellationEligibleOrders", summary.eligible_orders, project, reporting_defaults)
     put_metric("UnpaidCancellationUpdatedOrders", summary.updated_orders, project, reporting_defaults)
+    put_metric("UnpaidCancellationRecoveryCandidates", summary.recovery_candidates, project, reporting_defaults)
+    put_metric("UnpaidCancellationRecoveredOrders", summary.recovered_orders, project, reporting_defaults)
+    put_metric("UnpaidCancellationRecoveryFailedOrders", summary.recovery_failed_orders, project, reporting_defaults)
+    put_metric("UnpaidCancellationRecheckedOrders", summary.rechecked_orders, project, reporting_defaults)
     put_metric("UnpaidCancellationFailedOrders", summary.failed_orders, project, reporting_defaults)
     put_metric("UnpaidCancellationRunSucceeded", 1, project, reporting_defaults)
 


### PR DESCRIPTION
## What changed

- Reconcile Stripe-expired orders back to `Odoslaná` when a pre-existing final invoice and payment-resolution evidence prove the order was handled.
- Treat every final invoice as a hard stop before unpaid cancellation.
- Re-read order detail immediately before every status mutation to close the scan/write race.
- Add `Čaká na vybavenie` as a guarded ROY candidate so stale bank-transfer orders can be cancelled while COD stays excluded.
- Query only configured candidate/recovery status IDs and publish recovery/recheck CloudWatch and smoke metrics.

## Why

Stripe can change an already paid and sent order back to `Stripe - expired` after an operator matched an alternative bank transfer. The old job could later treat the new current status as unpaid and cancel a fulfilled order.

Order `2677002988` demonstrated this sequence. Order `2677003434` demonstrated the separate stale bank-transfer case that should be cancelled.

## Impact and safety

Recovery requires all of the following: current `Stripe - expired` status, a final invoice predating the current last-change timestamp, and either invoice `paid=true` or the configured bank-transfer payment identity. The recovery target is ROY status ID `4` (`Odoslaná`).

The final read-only production dry-run scanned 51 candidate-status rows over 29 pages. It found 35 cancellation candidates, all with zero final invoices, and no recovery candidate because order `2677002988` had already been manually restored to `Odoslaná`.

Deployment should first use the protected dry-run smoke. Do not use `execute_now=true` merely as a smoke because the audited backlog would receive real cancellation status changes/emails.

## Validation

- 265 CI-equivalent unit tests
- reporting QA smoke
- security CI
- Python compile
- ROY settings JSON parse
- deploy workflow YAML parse
- `git diff --check`
