### PR TITLE
Include inbound stock in ROY inventory value

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,17 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY inbound inventory valuation is implemented locally on `2026-08-10`:
+  - branch: `codex/roy-inbound-inventory-value`
+  - root cause: the operations dashboard used only the current on-hand purchase-cost total; manually recorded inbound units affected stock-risk coverage but contributed no value to the inventory KPI
+  - the reporting inventory model now preserves a known mapped purchase cost and retail unit price even when the product currently has zero stock, while conflicting or missing unit values remain unpriced instead of being guessed
+  - the live operations snapshot now exposes on-hand value, inbound value, and the combined owned-inventory value separately; inbound rows include unit cost, extended cost, retail value, and an explicit `costed` / `missing_cost` status
+  - the ROY UI now shows `Hodnota skladu` and both detailed valuation cards as `skladom + na ceste`; each inbound row shows its purchase value, and products without a mapped purchase cost are visibly marked `chýba nákupná cena`
+  - local verification passed: Python compile; focused ROY inventory/operations suite (`61` tests); live auth/mobile/modern dashboard suite (`21` tests); full suite (`273` tests); reporting QA smoke; security CI; generated ROY inline JavaScript syntax; and `git diff --check`
+  - local `scripts/check_env.ps1` was not applicable in the isolated clean worktree because `.env` is intentionally absent and secrets were not copied
+  - Known issue: the change is not deployed yet; existing production artifacts do not contain the zero-stock unit-value fields required to value every current inbound product
+  - Next exact step: commit and push the branch, merge through PR, build the exact image, deploy ROY with an artifact refresh, verify the Fargate localhost marker and combined inbound valuation fields, and only then verify the production dashboard UI
+
 - ROY unpaid-order Stripe-expiry reconciliation is merged, deployed, and live (2026-08-10):
   - root cause: Stripe can overwrite an already fulfilled order back to `Stripe - expired` after an operator has matched an alternative bank transfer, issued the final invoice, and moved the order through the paid/sent states; the existing cancellation job inspected only the current status/payment and could later cancel that genuinely paid order
   - every prospective cancellation now loads the current order detail before planning and again immediately before mutation; any final invoice is a hard cancellation stop, so the job fails safe if invoice evidence appears between the scan and write

--- a/export_orders.py
+++ b/export_orders.py
@@ -12243,6 +12243,8 @@ class BizniWebExporter:
             "inventory_cost_value",
             "inventory_retail_value",
             "mapped_inventory_retail_value",
+            "known_cost_per_unit",
+            "known_retail_unit_price",
             "history_only_inventory_flag",
         ]
 
@@ -12280,6 +12282,33 @@ class BizniWebExporter:
                     inventory_frame["mapped_available_quantity"],
                     errors="coerce",
                 ).fillna(0.0)
+                if "cost_per_unit" not in inventory_frame.columns:
+                    inventory_frame["cost_per_unit"] = np.where(
+                        inventory_frame["mapped_available_quantity"] > 0,
+                        inventory_frame["inventory_cost_value"] / inventory_frame["mapped_available_quantity"],
+                        np.nan,
+                    )
+                else:
+                    inventory_frame["cost_per_unit"] = pd.to_numeric(
+                        inventory_frame["cost_per_unit"],
+                        errors="coerce",
+                    )
+                if "retail_unit_price_eur" not in inventory_frame.columns:
+                    inventory_frame["retail_unit_price_eur"] = np.where(
+                        inventory_frame["available_quantity"] > 0,
+                        inventory_frame["inventory_retail_value"] / inventory_frame["available_quantity"],
+                        0.0,
+                    )
+                else:
+                    inventory_frame["retail_unit_price_eur"] = pd.to_numeric(
+                        inventory_frame["retail_unit_price_eur"],
+                        errors="coerce",
+                    ).fillna(0.0)
+
+                def _single_known_unit_value(values: pd.Series) -> float:
+                    numeric = pd.to_numeric(values, errors="coerce")
+                    finite_values = numeric.loc[np.isfinite(numeric)].unique()
+                    return float(finite_values[0]) if len(finite_values) == 1 else np.nan
 
                 inventory_products_df = (
                     inventory_frame.groupby("reporting_sku")
@@ -12295,6 +12324,8 @@ class BizniWebExporter:
                         inventory_cost_value=("inventory_cost_value", "sum"),
                         inventory_retail_value=("inventory_retail_value", "sum"),
                         mapped_inventory_retail_value=("mapped_inventory_retail_value", "sum"),
+                        known_cost_per_unit=("cost_per_unit", _single_known_unit_value),
+                        known_retail_unit_price=("retail_unit_price_eur", _single_known_unit_value),
                     )
                     .reset_index()
                     .rename(columns={"reporting_sku": "sku"})
@@ -12329,6 +12360,8 @@ class BizniWebExporter:
                                 "inventory_cost_value": 0.0,
                                 "inventory_retail_value": 0.0,
                                 "mapped_inventory_retail_value": 0.0,
+                                "known_cost_per_unit": np.nan,
+                                "known_retail_unit_price": 0.0,
                                 "history_only_inventory_flag": True,
                             }
                         )
@@ -12347,16 +12380,26 @@ class BizniWebExporter:
                 "inventory_cost_value",
                 "inventory_retail_value",
                 "mapped_inventory_retail_value",
+                "known_retail_unit_price",
             ):
                 inventory_products_df[column] = pd.to_numeric(
                     inventory_products_df[column],
                     errors="coerce",
                 ).fillna(0.0)
+            inventory_products_df["known_cost_per_unit"] = pd.to_numeric(
+                inventory_products_df["known_cost_per_unit"],
+                errors="coerce",
+            )
 
             inventory_products_df["cost_per_unit"] = np.where(
                 inventory_products_df["mapped_available_quantity"] > 0,
                 inventory_products_df["inventory_cost_value"] / inventory_products_df["mapped_available_quantity"],
-                np.nan,
+                inventory_products_df["known_cost_per_unit"],
+            )
+            inventory_products_df["retail_unit_price"] = np.where(
+                inventory_products_df["available_quantity"] > 0,
+                inventory_products_df["inventory_retail_value"] / inventory_products_df["available_quantity"],
+                inventory_products_df["known_retail_unit_price"],
             )
             inventory_products_df["cost_coverage_pct"] = np.where(
                 inventory_products_df["available_quantity"] > 0,

--- a/live_dashboard_server.py
+++ b/live_dashboard_server.py
@@ -1469,7 +1469,7 @@ def build_roy_operations_dashboard_html(
           <div class="alert-grid" id="inventorySummaryGrid"></div>
           <div class="table-wrap">
             <table>
-              <thead><tr><th>Objednaný produkt</th><th>Objednané kusy</th><th>ETA</th><th>Sklad pri zadaní</th><th>Aktuálny sklad</th><th>Akcia</th></tr></thead>
+              <thead><tr><th>Objednaný produkt</th><th>Objednané kusy</th><th>Nákupná hodnota</th><th>ETA</th><th>Sklad pri zadaní</th><th>Aktuálny sklad</th><th>Akcia</th></tr></thead>
               <tbody id="inboundRowsBody"></tbody>
             </table>
           </div>
@@ -1903,7 +1903,11 @@ def build_roy_operations_dashboard_html(
         metric('Kritický sklad', fmtInt(inv.stock_risk_critical_count), `${fmtInt(inv.stock_risk_30d_count)} položiek v 30d riziku`),
         metric('Objednať teraz', fmtInt(inv.alert_reorder_now_count), `${fmtInt(inv.alert_prepare_po_count)} pripraviť PO`),
         metric('Objednané na ceste', fmtQty(inv.inbound_ordered_units), `${fmtInt(inv.inbound_order_count)} položiek · ETA ${text(inv.inbound_next_arrival_date)}`),
-        metric('Hodnota skladu', fmtMoney(inv.inventory_cost_value), `predajná ${fmtMoney(inv.inventory_retail_value)}`),
+        metric(
+          'Hodnota skladu',
+          fmtMoney(inv.inventory_cost_value_including_inbound ?? inv.inventory_cost_value),
+          `${fmtMoney(inv.inventory_cost_value)} skladom + ${fmtMoney(inv.inbound_cost_value)} na ceste${Number(inv.inbound_unpriced_order_count || 0) ? ` · ${fmtInt(inv.inbound_unpriced_order_count)} bez ceny` : ''}`,
+        ),
       ].join('');
     }
     function orderItemsHtml(order) {
@@ -2132,8 +2136,16 @@ def build_roy_operations_dashboard_html(
       el('demandAnomalyRowsBody').innerHTML = anomalies.length ? anomalies.map(demandAnomalyRow).join('') : '<tr><td colspan="7" class="muted">Bez neobvykle veľkých jednorazových objednávok.</td></tr>';
       el('inventoryMeta').textContent = `${fmtInt(summary.inventory_products_with_stock)} produktov so skladom · coverage ${fmtPct(summary.inventory_cost_coverage_units_pct)} · ${text(summary.demand_model_version, 'legacy')}`;
       el('inventorySummaryGrid').innerHTML = [
-        metric('Nákupná hodnota bez DPH', fmtMoney(summary.inventory_cost_value), `${fmtQty(summary.inventory_available_units)} ks skladom`),
-        metric('Predajná hodnota bez DPH', fmtMoney(summary.inventory_retail_value), `coverage ${fmtPct(summary.inventory_cost_coverage_retail_pct)}`),
+        metric(
+          'Nákupná hodnota bez DPH',
+          fmtMoney(summary.inventory_cost_value_including_inbound ?? summary.inventory_cost_value),
+          `${fmtMoney(summary.inventory_cost_value)} skladom + ${fmtMoney(summary.inbound_cost_value)} na ceste${Number(summary.inbound_unpriced_order_count || 0) ? ` · ${fmtInt(summary.inbound_unpriced_order_count)} bez ceny` : ''}`,
+        ),
+        metric(
+          'Predajná hodnota bez DPH',
+          fmtMoney(summary.inventory_retail_value_including_inbound ?? summary.inventory_retail_value),
+          `${fmtMoney(summary.inventory_retail_value)} skladom + ${fmtMoney(summary.inbound_retail_value)} na ceste`,
+        ),
         metric('45d watchlist', fmtInt(summary.stock_risk_45d_count), `${fmtInt(summary.out_of_stock_recent_demand_count)} vypredané s dopytom`),
         metric('Dead stock', fmtMoney(summary.dead_stock_cost_value), `${fmtInt(summary.dead_stock_count)} položiek`),
         metric('Tržby v riziku', fmtMoney(summary.revenue_at_risk_30d), `zisk ${fmtMoney(summary.profit_at_risk_30d)}`),
@@ -2143,11 +2155,12 @@ def build_roy_operations_dashboard_html(
       el('inboundRowsBody').innerHTML = inboundRows.length ? inboundRows.map((row) => `<tr>
         <td><strong>${safe(row.product)}</strong><div class="muted mono">${safe(row.sku)}</div></td>
         <td>${fmtQty(row.ordered_units)} ks</td>
+        <td>${row.inbound_cost_value === null || row.inbound_cost_value === undefined ? '<span class="muted">chýba nákupná cena</span>' : `<strong>${fmtMoney(row.inbound_cost_value)}</strong><div class="muted">${fmtMoney(row.cost_per_unit)} / ks</div>`}</td>
         <td>${safe(row.expected_arrival_date)}</td>
         <td>${fmtQty(row.baseline_available_quantity)} ks</td>
         <td>${fmtQty(row.current_available_quantity)} ks</td>
         <td><button type="button" data-clear-inbound="${safe(row.sku)}">Zrušiť</button></td>
-      </tr>`).join('') : '<tr><td colspan="6" class="muted">Žiadne ručne zadané inbound objednávky.</td></tr>';
+      </tr>`).join('') : '<tr><td colspan="7" class="muted">Žiadne ručne zadané inbound objednávky.</td></tr>';
       el('inventoryRowsBody').innerHTML = inventoryRows.length ? inventoryRows.slice(0, visibleInventoryLimit).map((row) => `<tr>
         <td><strong>${safe(row.product)}</strong><div class="muted mono">${safe(row.sku)}</div></td>
         <td>${fmtQty(row.available_quantity)} ks</td>

--- a/roy_operations_dashboard.py
+++ b/roy_operations_dashboard.py
@@ -1799,6 +1799,46 @@ def _current_availability_by_sku(inventory: Dict[str, Any]) -> Dict[str, float]:
     return availability
 
 
+def _finite_nonnegative_float(value: Any) -> Optional[float]:
+    parsed = _optional_float(value)
+    if parsed is None or not math.isfinite(parsed) or parsed < 0:
+        return None
+    return parsed
+
+
+def _inventory_unit_values_by_sku(inventory: Dict[str, Any]) -> Dict[str, Dict[str, Optional[float]]]:
+    values_by_sku: Dict[str, Dict[str, Optional[float]]] = {}
+    for _, rows in _inventory_row_collections(inventory):
+        for row in rows:
+            sku = str(row.get("sku") or "").strip()
+            if not sku:
+                continue
+
+            cost_per_unit = _finite_nonnegative_float(row.get("cost_per_unit"))
+            if cost_per_unit is None:
+                mapped_units = _finite_nonnegative_float(row.get("mapped_available_quantity"))
+                cost_value = _finite_nonnegative_float(row.get("inventory_cost_value"))
+                if mapped_units and cost_value is not None:
+                    cost_per_unit = cost_value / mapped_units
+
+            retail_per_unit = _finite_nonnegative_float(row.get("retail_unit_price"))
+            if retail_per_unit is None:
+                available_units = _finite_nonnegative_float(row.get("available_quantity"))
+                retail_value = _finite_nonnegative_float(row.get("inventory_retail_value"))
+                if available_units and retail_value is not None:
+                    retail_per_unit = retail_value / available_units
+
+            current = values_by_sku.setdefault(
+                sku,
+                {"cost_per_unit": None, "retail_per_unit": None},
+            )
+            if current["cost_per_unit"] is None and cost_per_unit is not None:
+                current["cost_per_unit"] = cost_per_unit
+            if current["retail_per_unit"] is None and retail_per_unit is not None:
+                current["retail_per_unit"] = retail_per_unit
+    return values_by_sku
+
+
 def _stock_risk_sets() -> Tuple[set[str], set[str]]:
     risk_30d = {"Negative stock", "Out of stock", "Critical", "Low", "Lead time risk"}
     risk_45d = {"Negative stock", "Out of stock", "Critical", "Low", "Lead time risk", "Watch"}
@@ -2521,9 +2561,26 @@ def _auto_clear_restocked_inbound_orders(state: Dict[str, Any], inventory: Dict[
 
 def _apply_inbound_to_inventory(inventory: Dict[str, Any], state: Dict[str, Any], project_settings: Dict[str, Any]) -> None:
     inbound = state.get("inbound_orders") if isinstance(state.get("inbound_orders"), dict) else {}
+    summary = inventory.setdefault("summary", {})
+    inventory_cost_value = _to_float(summary.get("inventory_cost_value"))
+    inventory_retail_value = _to_float(summary.get("inventory_retail_value"))
+    inventory_available_units = _to_float(summary.get("inventory_available_units"))
+    unit_values_by_sku = _inventory_unit_values_by_sku(inventory)
     if not inbound:
-        inventory.setdefault("summary", {})["inbound_order_count"] = 0
-        inventory.setdefault("summary", {})["inbound_ordered_units"] = 0.0
+        summary.update(
+            {
+                "inbound_order_count": 0,
+                "inbound_ordered_units": 0.0,
+                "inbound_costed_order_count": 0,
+                "inbound_unpriced_order_count": 0,
+                "inbound_costed_units": 0.0,
+                "inbound_cost_value": 0.0,
+                "inbound_retail_value": 0.0,
+                "inventory_cost_value_including_inbound": round(inventory_cost_value, 2),
+                "inventory_retail_value_including_inbound": round(inventory_retail_value, 2),
+                "inventory_units_including_inbound": round(inventory_available_units, 1),
+            }
+        )
         inventory["inbound_order_rows"] = []
         _finalize_inventory_alert_rows(inventory)
         return
@@ -2599,9 +2656,17 @@ def _apply_inbound_to_inventory(inventory: Dict[str, Any], state: Dict[str, Any]
 
         expected_arrival_date = str(record.get("expected_arrival_date") or "").strip()
         inbound_covers = bool(ordered_units > 0 and (suggested <= 0 or current_risk not in risk_30d))
+        unit_values = unit_values_by_sku.get(sku) or {}
+        cost_per_unit = unit_values.get("cost_per_unit")
+        retail_per_unit = unit_values.get("retail_per_unit")
         row.update(
             {
                 "inbound_ordered_units": round(ordered_units, 2),
+                "inbound_cost_per_unit": round(cost_per_unit, 4) if cost_per_unit is not None else None,
+                "inbound_retail_per_unit": round(retail_per_unit, 4) if retail_per_unit is not None else None,
+                "inbound_cost_value": round(ordered_units * cost_per_unit, 2) if cost_per_unit is not None else None,
+                "inbound_retail_value": round(ordered_units * retail_per_unit, 2) if retail_per_unit is not None else None,
+                "inbound_valuation_status": "costed" if cost_per_unit is not None else "missing_cost",
                 "inbound_expected_arrival_date": expected_arrival_date,
                 "inbound_created_at": record.get("created_at"),
                 "inbound_updated_at": record.get("updated_at"),
@@ -2645,26 +2710,50 @@ def _apply_inbound_to_inventory(inventory: Dict[str, Any], state: Dict[str, Any]
     inventory["revenue_at_risk_rows"] = [row for row in inventory.get("revenue_at_risk_rows", []) if keep_45d(row)]
     inventory["stock_risk_rows"] = [row for row in inventory.get("stock_risk_rows", []) if keep_45d(row)]
 
-    summary = inventory.setdefault("summary", {})
-    active_inbound = [record for record in inbound.values() if _to_float(record.get("ordered_units")) > 0]
-    next_eta = min((str(record.get("expected_arrival_date")) for record in active_inbound if record.get("expected_arrival_date")), default=None)
     availability = _current_availability_by_sku(inventory)
-    inventory["inbound_order_rows"] = sorted(
-        [
+    active_inbound_rows: List[Dict[str, Any]] = []
+    for stored_sku, record in inbound.items():
+        ordered_units = _to_float(record.get("ordered_units"))
+        if ordered_units <= 0:
+            continue
+        sku = str(record.get("sku") or stored_sku)
+        unit_values = unit_values_by_sku.get(sku) or {}
+        cost_per_unit = unit_values.get("cost_per_unit")
+        retail_per_unit = unit_values.get("retail_per_unit")
+        active_inbound_rows.append(
             {
-                "sku": str(record.get("sku") or sku),
+                "sku": sku,
                 "product": str(record.get("product") or ""),
-                "ordered_units": round(_to_float(record.get("ordered_units")), 2),
+                "ordered_units": round(ordered_units, 2),
                 "expected_arrival_date": record.get("expected_arrival_date"),
                 "baseline_available_quantity": _to_float(record.get("baseline_available_quantity")),
-                "current_available_quantity": round(availability.get(str(sku), _to_float(record.get("baseline_available_quantity"))), 2),
+                "current_available_quantity": round(
+                    availability.get(sku, _to_float(record.get("baseline_available_quantity"))),
+                    2,
+                ),
+                "cost_per_unit": round(cost_per_unit, 4) if cost_per_unit is not None else None,
+                "retail_per_unit": round(retail_per_unit, 4) if retail_per_unit is not None else None,
+                "inbound_cost_value": round(ordered_units * cost_per_unit, 2) if cost_per_unit is not None else None,
+                "inbound_retail_value": round(ordered_units * retail_per_unit, 2) if retail_per_unit is not None else None,
+                "valuation_status": "costed" if cost_per_unit is not None else "missing_cost",
                 "created_at": record.get("created_at"),
                 "updated_at": record.get("updated_at"),
             }
-            for sku, record in inbound.items()
-            if _to_float(record.get("ordered_units")) > 0
-        ],
+        )
+    inventory["inbound_order_rows"] = sorted(
+        active_inbound_rows,
         key=lambda row: (str(row.get("expected_arrival_date") or "9999-99-99"), str(row.get("sku") or "")),
+    )
+    active_inbound = inventory["inbound_order_rows"]
+    next_eta = min(
+        (str(row.get("expected_arrival_date")) for row in active_inbound if row.get("expected_arrival_date")),
+        default=None,
+    )
+    costed_inbound = [row for row in active_inbound if row.get("inbound_cost_value") is not None]
+    inbound_cost_value = round(sum(_to_float(row.get("inbound_cost_value")) for row in costed_inbound), 2)
+    inbound_retail_value = round(
+        sum(_to_float(row.get("inbound_retail_value")) for row in active_inbound if row.get("inbound_retail_value") is not None),
+        2,
     )
     alert_rows = inventory.get("alert_rows", [])
     restock_rows = inventory.get("restock_priority_rows", [])
@@ -2673,8 +2762,19 @@ def _apply_inbound_to_inventory(inventory: Dict[str, Any], state: Dict[str, Any]
     summary.update(
         {
             "inbound_order_count": len(active_inbound),
-            "inbound_ordered_units": round(sum(_to_float(record.get("ordered_units")) for record in active_inbound), 1),
+            "inbound_ordered_units": round(sum(_to_float(row.get("ordered_units")) for row in active_inbound), 1),
             "inbound_next_arrival_date": next_eta,
+            "inbound_costed_order_count": len(costed_inbound),
+            "inbound_unpriced_order_count": len(active_inbound) - len(costed_inbound),
+            "inbound_costed_units": round(sum(_to_float(row.get("ordered_units")) for row in costed_inbound), 1),
+            "inbound_cost_value": inbound_cost_value,
+            "inbound_retail_value": inbound_retail_value,
+            "inventory_cost_value_including_inbound": round(inventory_cost_value + inbound_cost_value, 2),
+            "inventory_retail_value_including_inbound": round(inventory_retail_value + inbound_retail_value, 2),
+            "inventory_units_including_inbound": round(
+                inventory_available_units + sum(_to_float(row.get("ordered_units")) for row in active_inbound),
+                1,
+            ),
             "alert_delivery_count": len(alert_rows),
             "alert_reorder_now_count": sum(1 for row in alert_rows if str(row.get("reorder_action_label") or "") == "Order now"),
             "alert_prepare_po_count": sum(1 for row in alert_rows if str(row.get("reorder_action_label") or "") == "Prepare PO"),

--- a/tests/test_roy_inventory_model.py
+++ b/tests/test_roy_inventory_model.py
@@ -64,7 +64,13 @@ def inventory_row(
     available_quantity: float = 0.0,
     inventory_cost_value: float = 0.0,
     inventory_retail_value: float = 0.0,
+    cost_per_unit: float | None = None,
+    retail_unit_price: float | None = None,
 ) -> dict:
+    if cost_per_unit is None and available_quantity > 0 and inventory_cost_value:
+        cost_per_unit = inventory_cost_value / available_quantity
+    if retail_unit_price is None and available_quantity > 0:
+        retail_unit_price = inventory_retail_value / available_quantity
     return {
         "reporting_sku": sku,
         "reporting_product": product,
@@ -77,6 +83,8 @@ def inventory_row(
         "inventory_cost_value": inventory_cost_value,
         "inventory_retail_value": inventory_retail_value,
         "mapped_inventory_retail_value": inventory_retail_value if inventory_cost_value else 0.0,
+        "cost_per_unit": cost_per_unit,
+        "retail_unit_price_eur": retail_unit_price or 0.0,
     }
 
 
@@ -181,6 +189,32 @@ class RoyInventoryModelTests(unittest.TestCase):
         self.assertEqual("Out of stock", row["stock_risk_level"])
         self.assertEqual("low_stock_after_large_order", row["alert_reason_code"])
         self.assertLess(float(row["alert_30d_units"]), 5.0)
+
+    def test_zero_stock_row_keeps_known_unit_values_for_inbound_valuation(self) -> None:
+        exporter = RoyInventoryModelExporter(
+            inventory_snapshot=pd.DataFrame(
+                [
+                    inventory_row(
+                        "SPIKE-SKU",
+                        "Slow Product",
+                        cost_per_unit=2.5,
+                        retail_unit_price=10.0,
+                    )
+                ]
+            )
+        )
+
+        result = exporter.analyze_roy_product_demand_analytics(
+            df=pd.DataFrame(),
+            orders_df=pd.DataFrame(),
+            item_df=self._one_off_spike_rows(),
+        )
+
+        row = result["stock_risk_rows"].loc[
+            result["stock_risk_rows"]["sku"] == "SPIKE-SKU"
+        ].iloc[0]
+        self.assertEqual(2.5, float(row["cost_per_unit"]))
+        self.assertEqual(10.0, float(row["retail_unit_price"]))
 
     def test_short_history_keeps_legacy_demand_floor(self) -> None:
         exporter = RoyInventoryModelExporter(

--- a/tests/test_roy_operations_dashboard.py
+++ b/tests/test_roy_operations_dashboard.py
@@ -715,6 +715,9 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertIn("Hrubý zisk/strata", html)
         self.assertNotIn("Zisk s fixom", html)
         self.assertIn("data-save-inbound", html)
+        self.assertIn("inventory_cost_value_including_inbound", html)
+        self.assertIn("inbound_cost_value", html)
+        self.assertIn("chýba nákupná cena", html)
         self.assertIn("soundToggleBtn", html)
         self.assertIn("playNewOrderSound", html)
         self.assertIn("loud-two-tone-v2", html)
@@ -844,6 +847,9 @@ class RoyOperationsDashboardTests(unittest.TestCase):
                     "summary": {
                         "alert_delivery_count": 1,
                         "stock_risk_30d_count": 1,
+                        "inventory_available_units": 10,
+                        "inventory_cost_value": 100,
+                        "inventory_retail_value": 250,
                     },
                     "alert_rows": [
                         {
@@ -871,6 +877,8 @@ class RoyOperationsDashboardTests(unittest.TestCase):
                             "suggested_reorder_units": 8,
                             "stock_risk_level": "Out of stock",
                             "reorder_action_label": "Order now",
+                            "cost_per_unit": 4,
+                            "retail_unit_price": 10,
                         }
                     ],
                     "restock_priority_rows": [
@@ -931,7 +939,63 @@ class RoyOperationsDashboardTests(unittest.TestCase):
         self.assertEqual([], inventory["restock_priority_rows"])
         self.assertEqual(1, inventory["summary"]["inbound_order_count"])
         self.assertEqual(20, inventory["inbound_order_rows"][0]["ordered_units"])
+        self.assertEqual(80, inventory["summary"]["inbound_cost_value"])
+        self.assertEqual(180, inventory["summary"]["inventory_cost_value_including_inbound"])
+        self.assertEqual(200, inventory["summary"]["inbound_retail_value"])
+        self.assertEqual(450, inventory["summary"]["inventory_retail_value_including_inbound"])
+        self.assertEqual(30, inventory["summary"]["inventory_units_including_inbound"])
+        self.assertEqual(4, inventory["inbound_order_rows"][0]["cost_per_unit"])
+        self.assertEqual(80, inventory["inbound_order_rows"][0]["inbound_cost_value"])
         self.assertEqual("Inbound ordered", inventory["inventory_rows"][0]["reorder_action_label"])
+
+    def test_inbound_inventory_value_reports_missing_purchase_cost_without_guessing(self) -> None:
+        payload = {
+            "dashboard": {
+                "roy_product_demand": {
+                    "summary": {
+                        "inventory_available_units": 5,
+                        "inventory_cost_value": 50,
+                        "inventory_retail_value": 100,
+                    },
+                    "inventory_rows": [
+                        {
+                            "sku": "NO-COST",
+                            "product": "Unpriced inbound product",
+                            "available_quantity": 0,
+                            "stock_risk_level": "Out of stock",
+                        }
+                    ],
+                }
+            }
+        }
+        state = {
+            "version": 1,
+            "loss_acknowledgements": {},
+            "inbound_orders": {
+                "NO-COST": {
+                    "sku": "NO-COST",
+                    "product": "Unpriced inbound product",
+                    "ordered_units": 7,
+                    "expected_arrival_date": "2026-08-20",
+                    "baseline_available_quantity": 0,
+                }
+            },
+            "auto_cleared_inbound_orders": [],
+        }
+
+        inventory, state_changed = build_inventory_snapshot(
+            payload,
+            state=state,
+            project_settings={"inventory_model": {}},
+        )
+
+        self.assertFalse(state_changed)
+        self.assertEqual(0, inventory["summary"]["inbound_cost_value"])
+        self.assertEqual(50, inventory["summary"]["inventory_cost_value_including_inbound"])
+        self.assertEqual(0, inventory["summary"]["inbound_costed_order_count"])
+        self.assertEqual(1, inventory["summary"]["inbound_unpriced_order_count"])
+        self.assertIsNone(inventory["inbound_order_rows"][0]["inbound_cost_value"])
+        self.assertEqual("missing_cost", inventory["inbound_order_rows"][0]["valuation_status"])
 
     def test_stock_alerts_are_ranked_by_expected_cm2_loss_before_severity(self) -> None:
         high_impact = {


### PR DESCRIPTION
## What changed

- preserve mapped unit cost and retail price for zero-stock products
- calculate inbound purchase/retail value and combined owned-inventory totals
- show `skladom + na ceste` in the ROY operations dashboard
- flag inbound products with missing purchase cost instead of estimating silently
- add regression coverage and update `PROJECT_STATE.md`

## Why

The ROY inventory KPI counted only units physically on hand. Products already ordered and paid for affected stock-risk coverage but were omitted from inventory value.

## Validation

- Python compile
- 273 unit tests
- reporting QA smoke
- security CI
- generated inline JavaScript syntax
- `git diff --check`
