### PR TITLE
Fix scheduler PassRole deployment gate

### DIFF
--- a/.github/workflows/deploy-live-dashboard-apprunner.yml
+++ b/.github/workflows/deploy-live-dashboard-apprunner.yml
@@ -1281,12 +1281,14 @@ jobs:
                 --resource-arns "${PROJECT_TASK_ROLE_ARN}" "${PROJECT_EXECUTION_ROLE_ARN}" \
                 --context-entries ContextKeyName=iam:PassedToService,ContextKeyValues=ecs-tasks.amazonaws.com,ContextKeyType=string \
                 --output json > reporting-scheduler-passrole-simulation.json \
-                && python - <<'PY'
+                && python - "${PROJECT_TASK_ROLE_ARN}" "${PROJECT_EXECUTION_ROLE_ARN}" <<'PY'
           import json
+          import sys
 
-          results = json.load(open("reporting-scheduler-passrole-simulation.json", encoding="utf-8")).get("EvaluationResults") or []
-          if len(results) != 2 or any(result.get("EvalDecision") != "allowed" for result in results):
-              raise SystemExit(1)
+          from scripts.reporting_scheduler_passrole import validate_passrole_simulation
+
+          simulation = json.load(open("reporting-scheduler-passrole-simulation.json", encoding="utf-8"))
+          validate_passrole_simulation(simulation, sys.argv[1:])
           PY
               then
                 PASSROLE_SIMULATION_READY=true

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,15 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY inbound inventory valuation deploy follow-up is in progress on `2026-08-10`:
+  - branch: `codex/fix-scheduler-passrole-gate`
+  - inventory valuation PR `#257` merged as `6079020cd25ea2df851c339c160c41effd956033`; exact ECR build `31410114494` succeeded with digest `sha256:c896fc3c9993218326c6d3f2fa3fbf620a1482e6543fded142f59faae518188a`
+  - full deploy `31410363837` completed the Fargate artifact refresh and published source timestamp `2026-08-10T17:12:56Z`, but the workflow later failed before App Runner promotion
+  - skip-refresh deploy `31413627782` proved the exact candidate image directly in Fargate (`a2716936951646f4b9448100d51ad4f3`, private IP `172.31.41.195`, service `roy-daily-report-email`, localhost marker `LIVE_ARTIFACT_MARKER_OK`) and then reproduced the blocker
+  - root cause: IAM correctly returns one top-level result per simulated action with the two role decisions nested under `ResourceSpecificResults`; the deploy gate incorrectly required two top-level results and rejected an otherwise fully `allowed` response
+  - fix: validate exactly one `iam:PassRole` action plus the exact expected task/execution role ARN set, while continuing to fail closed on a missing, duplicate, extra, or non-allowed resource decision
+  - Next exact step: pass focused/full validation, merge through PR, build the exact image, rerun the protected skip-refresh deploy, verify the Fargate localhost marker and App Runner host markers, then verify the combined inbound valuation in the production Chrome UI
+
 - ROY inbound inventory valuation is implemented locally on `2026-08-10`:
   - branch: `codex/roy-inbound-inventory-value`
   - root cause: the operations dashboard used only the current on-hand purchase-cost total; manually recorded inbound units affected stock-risk coverage but contributed no value to the inventory KPI

--- a/scripts/reporting_scheduler_passrole.py
+++ b/scripts/reporting_scheduler_passrole.py
@@ -13,7 +13,7 @@ import argparse
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
 
 ROLE_ARN_RE = re.compile(
@@ -44,6 +44,61 @@ def validate_role_arn(role_arn: str, account_id: str) -> Tuple[str, str]:
     if "*" in role_path or role_path.endswith("/"):
         raise ValueError(f"IAM role ARN must identify one exact role: {role_arn!r}")
     return match.group("partition"), role_path.rsplit("/", 1)[-1]
+
+
+def validate_passrole_simulation(
+    simulation: Dict[str, Any], expected_resource_arns: Iterable[str]
+) -> None:
+    """Require an allowed ``iam:PassRole`` result for every exact role ARN.
+
+    IAM returns one top-level evaluation per simulated action. When multiple
+    resources are supplied for that action, their decisions live in
+    ``ResourceSpecificResults`` rather than separate top-level results.
+    """
+
+    expected_resources = list(dict.fromkeys(expected_resource_arns))
+    if not expected_resources:
+        raise ValueError("PassRole simulation needs at least one expected resource")
+
+    results = simulation.get("EvaluationResults")
+    if not isinstance(results, list) or len(results) != 1:
+        raise ValueError("PassRole simulation must contain one action result")
+    action_result = results[0]
+    if not isinstance(action_result, dict):
+        raise ValueError("PassRole action result is invalid")
+    if action_result.get("EvalActionName") != "iam:PassRole":
+        raise ValueError("PassRole simulation returned an unexpected action")
+    if action_result.get("EvalDecision") != "allowed":
+        raise ValueError("PassRole action is not allowed")
+
+    resource_results = action_result.get("ResourceSpecificResults")
+    if not isinstance(resource_results, list):
+        raise ValueError("PassRole resource-specific results are missing")
+    decisions: Dict[str, str] = {}
+    for resource_result in resource_results:
+        if not isinstance(resource_result, dict):
+            raise ValueError("PassRole resource result is invalid")
+        resource_arn = str(resource_result.get("EvalResourceName") or "")
+        if not resource_arn or resource_arn in decisions:
+            raise ValueError(
+                "PassRole resource results contain a missing or duplicate ARN"
+            )
+        decisions[resource_arn] = str(
+            resource_result.get("EvalResourceDecision") or ""
+        )
+
+    if set(decisions) != set(expected_resources):
+        raise ValueError("PassRole simulation resources do not match the expected roles")
+    denied_resources = sorted(
+        resource_arn
+        for resource_arn, decision in decisions.items()
+        if decision != "allowed"
+    )
+    if denied_resources:
+        raise ValueError(
+            "PassRole is not allowed for expected roles: "
+            + ", ".join(denied_resources)
+        )
 
 
 def build_passrole_documents(

--- a/tests/test_live_dashboard_refresh_gate.py
+++ b/tests/test_live_dashboard_refresh_gate.py
@@ -88,6 +88,9 @@ class LiveDashboardRefreshGateTests(unittest.TestCase):
         self.assertIn("aws iam put-role-policy", workflow)
         self.assertIn("aws iam get-role-policy", workflow)
         self.assertIn("aws iam simulate-principal-policy", workflow)
+        self.assertIn(
+            "validate_passrole_simulation(simulation, sys.argv[1:])", workflow
+        )
         self.assertIn("role drifted from", workflow)
         self.assertIn("changed during deployment", workflow)
         unconditional_verify = "schedule-passrole-verified.json"

--- a/tests/test_reporting_scheduler_passrole.py
+++ b/tests/test_reporting_scheduler_passrole.py
@@ -3,6 +3,7 @@ import unittest
 
 from scripts.reporting_scheduler_passrole import (
     build_passrole_documents,
+    validate_passrole_simulation,
     validate_role_arn,
 )
 
@@ -33,6 +34,62 @@ SCHEDULER_ROLE_DOCUMENT = {
 
 
 class ReportingSchedulerPassRoleTests(unittest.TestCase):
+    def test_accepts_one_action_with_two_allowed_resource_results(self) -> None:
+        simulation = {
+            "EvaluationResults": [
+                {
+                    "EvalActionName": "iam:PassRole",
+                    "EvalResourceName": "arn:aws:iam::${Account}:role/${RoleName}",
+                    "EvalDecision": "allowed",
+                    "ResourceSpecificResults": [
+                        {
+                            "EvalResourceName": TASK_ROLE_ARN,
+                            "EvalResourceDecision": "allowed",
+                        },
+                        {
+                            "EvalResourceName": EXECUTION_ROLE_ARN,
+                            "EvalResourceDecision": "allowed",
+                        },
+                    ],
+                }
+            ]
+        }
+
+        validate_passrole_simulation(
+            simulation, [TASK_ROLE_ARN, EXECUTION_ROLE_ARN]
+        )
+
+    def test_rejects_denied_or_missing_passrole_resource(self) -> None:
+        denied = {
+            "EvaluationResults": [
+                {
+                    "EvalActionName": "iam:PassRole",
+                    "EvalDecision": "allowed",
+                    "ResourceSpecificResults": [
+                        {
+                            "EvalResourceName": TASK_ROLE_ARN,
+                            "EvalResourceDecision": "allowed",
+                        },
+                        {
+                            "EvalResourceName": EXECUTION_ROLE_ARN,
+                            "EvalResourceDecision": "implicitDeny",
+                        },
+                    ],
+                }
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, "not allowed for expected roles"):
+            validate_passrole_simulation(
+                denied, [TASK_ROLE_ARN, EXECUTION_ROLE_ARN]
+            )
+
+        missing = json.loads(json.dumps(denied))
+        missing["EvaluationResults"][0]["ResourceSpecificResults"].pop()
+        with self.assertRaisesRegex(ValueError, "do not match"):
+            validate_passrole_simulation(
+                missing, [TASK_ROLE_ARN, EXECUTION_ROLE_ARN]
+            )
+
     def test_builds_exact_account_local_ecs_passrole_policy(self) -> None:
         schedule = {"Target": {"RoleArn": SCHEDULER_ROLE_ARN}}
         task_definition = {


### PR DESCRIPTION
## Summary
- validate the real AWS IAM simulation shape: one iam:PassRole action with per-role ResourceSpecificResults
- require the exact task-role and execution-role ARN set and fail closed on denied, missing, duplicate, or extra results
- add production-shaped regression coverage and record the deploy incident in PROJECT_STATE.md

## Verification
- 275 unit tests
- reporting QA smoke
- security CI
- workflow YAML parse
- external environment contract
- git diff --check

## Incident evidence
Deploy 31413627782 proved the candidate Fargate localhost marker, then rejected an AWS response where both exact role decisions were allowed because the old gate expected two top-level action results.