### PR TITLE
Merge ROY large bear-set translations

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,6 +1,6 @@
 # PROJECT_STATE
 
-Last updated: 2026-08-10
+Last updated: 2026-08-11
 Owner: Patrik
 Repository scope: BizniWeb reporting only
 Purpose: repo-scoped handoff and execution state for this codebase.
@@ -60,6 +60,15 @@ Bootstrap entrypoints:
 - `scripts/bootstrap.ps1`
 
 ## 5) Current Verified State
+
+- ROY large bear-set product identity is ready for review on `2026-08-11`:
+  - branch: `agent/roy-merge-large-bear-sets`
+  - `Velký set proti medvědům`, `Set against bears LARGE`, and `Set proti medvědům VEĽKÝ (miesto malého)` now use the existing `maco_stop_large_set` component expansion together with `Set MACO STOP VEĽKÝ`
+  - all localized parent labels are therefore excluded as standalone reporting products and their revenue, demand, and purchase cost are assigned to the same known-cost components (`14832`, `12840`, `F_482`)
+  - the live pre-change report showed the three newly covered aliases among missing-cost rows (`EUR 191.22`, `EUR 56.06`, and `EUR 29.26` net revenue respectively); they are bundle aliases, not genuine products with missing purchase prices
+  - local verification passed: JSON validation, Python compile, focused ROY product-identity/inventory/dashboard suite (`65` tests), full suite (`275` tests), reporting QA smoke, security CI, and `git diff --check`
+  - no local server, worker, watcher, or tunnel was started
+  - Next exact step: open and merge the PR, deploy the exact merge image through the protected ROY workflow, require its ECS localhost marker and App Runner gates, then verify the production report no longer lists any localized large-set parent as a missing-cost product
 
 - ROY inbound inventory valuation is merged, deployed, and live on `2026-08-10`:
   - inventory valuation PR `#257` merged as `6079020cd25ea2df851c339c160c41effd956033`; deploy-gate fix PR `#258` merged as `c2b996a161c41a9f524b6a14b16c92496a0b4355`

--- a/projects/roy/settings.json
+++ b/projects/roy/settings.json
@@ -30,7 +30,10 @@
       "bundle_patterns": [
         "Set MACO STOP VEĽKÝ",
         "Set proti medveďom VEĽKÝ",
-        "Set proti medveďom veľký (miesto malého)"
+        "Set proti medveďom veľký (miesto malého)",
+        "Velký set proti medvědům",
+        "Set against bears LARGE",
+        "Set proti medvědům VEĽKÝ (miesto malého)"
       ],
       "components": [
         {
@@ -468,7 +471,10 @@
           "set proti medvedom velky",
           "set proti medvedom",
           "set sprej na medveda 300ml s kapsickou",
-          "set proti medvedom velky (miesto maleho)"
+          "set proti medvedom velky (miesto maleho)",
+          "velky set proti medvedum",
+          "set against bears large",
+          "set proti medvedum velky (miesto maleho)"
         ],
         "exclude_bundle_from_alerts": true,
         "components": [

--- a/tests/test_reporting_product_identity.py
+++ b/tests/test_reporting_product_identity.py
@@ -183,23 +183,63 @@ class ReportingProductIdentityTests(unittest.TestCase):
                     120.0,
                     quantity=2,
                 ),
+                reporting_item(
+                    "R-MACO-CZ",
+                    "H-906556E0",
+                    "Velký set proti medvědům",
+                    "",
+                    60.0,
+                ),
+                reporting_item(
+                    "R-MACO-EN",
+                    "H-FED33077",
+                    "Set against bears LARGE",
+                    "",
+                    60.0,
+                ),
+                reporting_item(
+                    "R-MACO-CZ-SUB",
+                    "13365",
+                    "Set proti medvědům VEĽKÝ (miesto malého)",
+                    "",
+                    60.0,
+                ),
             ]
         )
 
         canonical_df = exporter.add_reporting_product_identity_columns(item_df)
 
-        self.assertNotIn("H-226DA29F", set(canonical_df["product_sku"]))
-        self.assertNotIn("Set MACO STOP VEĽKÝ", set(canonical_df["item_label"]))
+        self.assertTrue(
+            {"H-226DA29F", "H-906556E0", "H-FED33077", "13365"}.isdisjoint(
+                set(canonical_df["product_sku"])
+            )
+        )
+        self.assertTrue(
+            {
+                "Set MACO STOP VEĽKÝ",
+                "Velký set proti medvědům",
+                "Set against bears LARGE",
+                "Set proti medvědům VEĽKÝ (miesto malého)",
+            }.isdisjoint(set(canonical_df["item_label"]))
+        )
         self.assertEqual({"14832", "12840", "F_482"}, set(canonical_df["product_sku"]))
         self.assertTrue(canonical_df["bundle_component_flag"].all())
-        self.assertEqual({"Set MACO STOP VEĽKÝ"}, set(canonical_df["bundle_parent_item_label"]))
-        self.assertAlmostEqual(120.0, float(canonical_df["item_total_without_tax"].sum()), places=2)
-        self.assertAlmostEqual(52.02, float(canonical_df["total_expense"].sum()), places=2)
+        self.assertEqual(
+            {
+                "Set MACO STOP VEĽKÝ",
+                "Velký set proti medvědům",
+                "Set against bears LARGE",
+                "Set proti medvědům VEĽKÝ (miesto malého)",
+            },
+            set(canonical_df["bundle_parent_item_label"]),
+        )
+        self.assertAlmostEqual(300.0, float(canonical_df["item_total_without_tax"].sum()), places=2)
+        self.assertAlmostEqual(130.05, float(canonical_df["total_expense"].sum()), places=2)
 
-        quantity_by_sku = canonical_df.set_index("product_sku")["item_quantity"].to_dict()
-        self.assertEqual(2, int(quantity_by_sku["14832"]))
-        self.assertEqual(2, int(quantity_by_sku["12840"]))
-        self.assertEqual(2, int(quantity_by_sku["F_482"]))
+        quantity_by_sku = canonical_df.groupby("product_sku")["item_quantity"].sum().to_dict()
+        self.assertEqual(5, int(quantity_by_sku["14832"]))
+        self.assertEqual(5, int(quantity_by_sku["12840"]))
+        self.assertEqual(5, int(quantity_by_sku["F_482"]))
 
         _, _, items_agg, _, _ = exporter.create_aggregated_reports(
             canonical_df,
@@ -209,7 +249,7 @@ class ReportingProductIdentityTests(unittest.TestCase):
             google_ads_daily_spend={},
         )
         self.assertEqual({"14832", "12840", "F_482"}, set(items_agg["product_sku"]))
-        self.assertAlmostEqual(120.0, float(items_agg["total_revenue"].sum()), places=2)
+        self.assertAlmostEqual(300.0, float(items_agg["total_revenue"].sum()), places=2)
 
     def test_roy_reporting_expands_wachman_rio_solar_to_components(self) -> None:
         exporter = ReportingIdentityExporter("roy")


### PR DESCRIPTION
## Summary

- Treat the Czech `Velký set proti medvědům`, English `Set against bears LARGE`, and Czech substitute label as the existing `Set MACO STOP VEĽKÝ` bundle.
- Expand every localized parent into the same known-cost components for reporting and inventory demand.
- Add regression coverage for all observed labels and preserve parent labels only as audit metadata.

## Verification

- `python -m unittest tests.test_reporting_product_identity tests.test_roy_inventory_model tests.test_roy_operations_dashboard` (65 tests)
- `python -m unittest discover -s tests` (275 tests)
- `python scripts/reporting_qa_smoke.py`
- `python scripts/security_ci.py`
- JSON validation, Python compile, and `git diff --check`

## Production note

The live pre-change report listed the three newly covered bundle aliases as missing-cost products with EUR 191.22, EUR 56.06, and EUR 29.26 net revenue. After artifact refresh, those parent aliases should disappear and feed SKUs `14832`, `12840`, and `F_482` instead.
