### PR TITLE
Add VEVO monthly Cohort LTV heatmap

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -64,8 +64,9 @@ Bootstrap entrypoints:
 - VEVO monthly Cohort LTV heatmap implementation is in progress on `codex/vevo-cohort-ltv-heatmap` (`2026-08-13`):
   - reusable cohort analytics now calculate cumulative net revenue LTV per acquired customer for calendar months `M0..Mn`, together with cohort size, observed repeat rate, first-order LTV, and customer-weighted averages
   - customers whose known first purchase predates the visible report history are excluded from the matrix so rolling period slices cannot fabricate acquisition cohorts from returning customers
-  - focused regression tests pass for cumulative monthly values, weighted averages, and the prior-history exclusion guard; Python compile and `git diff --check` pass
-  - Next exact step: render the matrix as a responsive heatmap in the modern customer dashboard, add payload/render regressions, and generate a fresh full-history VEVO report
+  - the modern customer dashboard now renders a responsive, horizontally scrollable heatmap with a sticky cohort column, `New`, `R-%`, a per-cohort trend sparkline, first-order LTV, cumulative `M0..Mn` values, explicit future-month blanks, and a customer-weighted average row
+  - focused and full relevant verification passes: `96` dashboard/reporting-calculation tests, Python compile, payload null-preservation regression, and `git diff --check`
+  - Next exact step: generate a fresh full-history VEVO report, run reporting QA plus visual inspection, and record the exact artifact and cohort totals
 
 - ROY large bear-set product identity and missing-cost QA fix are merged, deployed, and live on `2026-08-11`:
   - identity PR `#260` merged as `05d8a1ee69218af1d89d6b3dfb9071e5e8562c3f`; QA-input PR `#261` merged as `dbcd65bfe054cedf16c5e8dc08d2f2be4b40a2bd`

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,12 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- VEVO monthly Cohort LTV heatmap implementation is in progress on `codex/vevo-cohort-ltv-heatmap` (`2026-08-13`):
+  - reusable cohort analytics now calculate cumulative net revenue LTV per acquired customer for calendar months `M0..Mn`, together with cohort size, observed repeat rate, first-order LTV, and customer-weighted averages
+  - customers whose known first purchase predates the visible report history are excluded from the matrix so rolling period slices cannot fabricate acquisition cohorts from returning customers
+  - focused regression tests pass for cumulative monthly values, weighted averages, and the prior-history exclusion guard; Python compile and `git diff --check` pass
+  - Next exact step: render the matrix as a responsive heatmap in the modern customer dashboard, add payload/render regressions, and generate a fresh full-history VEVO report
+
 - ROY large bear-set product identity and missing-cost QA fix are merged, deployed, and live on `2026-08-11`:
   - identity PR `#260` merged as `05d8a1ee69218af1d89d6b3dfb9071e5e8562c3f`; QA-input PR `#261` merged as `dbcd65bfe054cedf16c5e8dc08d2f2be4b40a2bd`
   - `Velký set proti medvědům`, `Set against bears LARGE`, and `Set proti medvědům VEĽKÝ (miesto malého)` now use the existing `maco_stop_large_set` expansion together with `Set MACO STOP VEĽKÝ`; revenue, demand, and purchase cost are assigned to known-cost components `14832`, `12840`, and `F_482`

--- a/dashboard_modern.py
+++ b/dashboard_modern.py
@@ -949,6 +949,31 @@ def generate_modern_dashboard(
         ["cohort", "cohort_age_days", "retention_2nd_pct", "retention_3rd_pct", "retention_4th_pct", "retention_5th_pct"],
         limit=12,
     )
+    cohort_ltv_source = (cohort_analysis or {}).get("cohort_ltv") or {}
+    cohort_ltv_month_columns = [
+        str(column)
+        for column in list(cohort_ltv_source.get("month_columns") or [])
+        if re.fullmatch(r"M\d+", str(column))
+    ]
+    cohort_ltv_row_columns = [
+        "cohort",
+        "new_customers",
+        "repeat_customers",
+        "repeat_rate_pct",
+        "first_order_ltv",
+        "observed_months",
+        *cohort_ltv_month_columns,
+    ]
+    cohort_ltv_rows = _frame_rows(
+        cohort_ltv_source.get("rows"),
+        cohort_ltv_row_columns,
+        limit=60,
+    )
+    cohort_ltv_average = {
+        key: _json_safe(value)
+        for key, value in dict(cohort_ltv_source.get("average") or {}).items()
+        if key in cohort_ltv_row_columns
+    }
 
     customer_daily = (new_vs_returning_revenue or {}).get("daily")
     if customer_daily is not None and not getattr(customer_daily, "empty", True):
@@ -2323,6 +2348,15 @@ def generate_modern_dashboard(
         "cohort_time_to_nth_rows": cohort_time_to_nth_rows,
         "cohort_revenue_by_order_rows": cohort_revenue_by_order_rows,
         "mature_cohort_rows": mature_cohort_rows,
+        "cohort_ltv": {
+            "available": bool(cohort_ltv_source.get("available") and cohort_ltv_rows),
+            "revenue_basis": str(cohort_ltv_source.get("revenue_basis") or ""),
+            "analysis_end_month": _json_safe(cohort_ltv_source.get("analysis_end_month")),
+            "excluded_prior_customers": int(_num(cohort_ltv_source.get("excluded_prior_customers"))),
+            "month_columns": cohort_ltv_month_columns,
+            "rows": cohort_ltv_rows,
+            "average": cohort_ltv_average,
+        },
         "refund_rate": _maybe_num(refund_summary.get("refund_rate_pct")),
         "returning_customers": returning_payload,
         "clv": clv_payload,
@@ -3539,6 +3573,121 @@ def generate_modern_dashboard(
     ) or '<tr><td colspan="5"><span class="lang-en">No cohort retention data available.</span><span class="lang-sk hidden">Kohortná retencia nie je dostupná.</span></td></tr>'
 
 
+    def _cohort_ltv_sparkline(values: List[Any]) -> str:
+        numbers = [number for number in (_maybe_num(value) for value in values) if number is not None]
+        if not numbers:
+            return '<span class="cohort-ltv-empty-mark">&mdash;</span>'
+        width = 88.0
+        height = 28.0
+        padding = 2.0
+        minimum = min(numbers)
+        maximum = max(numbers)
+        spread = maximum - minimum
+        points = []
+        for index, number in enumerate(numbers):
+            x = padding if len(numbers) == 1 else padding + index * (width - 2 * padding) / (len(numbers) - 1)
+            y = height / 2 if spread <= 0 else height - padding - ((number - minimum) / spread) * (height - 2 * padding)
+            points.append((x, y))
+        point_text = " ".join(f"{x:.1f},{y:.1f}" for x, y in points)
+        last_x, last_y = points[-1]
+        return (
+            f'<svg class="cohort-ltv-sparkline" viewBox="0 0 {width:.0f} {height:.0f}" '
+            f'preserveAspectRatio="none" aria-hidden="true"><polyline points="{point_text}" />'
+            f'<circle cx="{last_x:.1f}" cy="{last_y:.1f}" r="2.4" /></svg>'
+        )
+
+    def _cohort_month_label(value: Any) -> str:
+        match = re.fullmatch(r"(\d{4})-(\d{2})", str(value or ""))
+        if not match:
+            return escape(str(value or "-"))
+        month_names = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+        year = int(match.group(1))
+        month = int(match.group(2))
+        if month < 1 or month > 12:
+            return escape(str(value or "-"))
+        return f"{month_names[month - 1]} {year % 100:02d}"
+
+    cohort_ltv_max_value = max(
+        (
+            number
+            for row in cohort_ltv_rows
+            for number in (_maybe_num(row.get(column)) for column in cohort_ltv_month_columns)
+            if number is not None
+        ),
+        default=0.0,
+    )
+
+    def _cohort_ltv_value_cell(value: Any) -> str:
+        number = _maybe_num(value)
+        if number is None:
+            return '<td class="cohort-ltv-empty"><span aria-label="not observed">&mdash;</span></td>'
+        ratio = max(0.0, min(number / cohort_ltv_max_value, 1.0)) if cohort_ltv_max_value > 0 else 0.0
+        alpha = 0.08 + ratio * 0.78
+        text_color = "#ffffff" if ratio >= 0.54 else "#241f19"
+        return (
+            f'<td class="cohort-ltv-value" style="background:rgba(71,102,255,{alpha:.3f});color:{text_color}">'
+            f'&euro;{number:,.2f}</td>'
+        )
+
+    def _cohort_ltv_row_html(row: Dict[str, Any], *, average: bool = False) -> str:
+        trend_values = [row.get(column) for column in cohort_ltv_month_columns]
+        cohort_label = (
+            '<span class="lang-en">Average</span><span class="lang-sk hidden">Priemer</span>'
+            if average
+            else _cohort_month_label(row.get("cohort"))
+        )
+        cells = "".join(_cohort_ltv_value_cell(row.get(column)) for column in cohort_ltv_month_columns)
+        row_class = ' class="cohort-ltv-average"' if average else ""
+        return (
+            f"<tr{row_class}>"
+            f'<td class="cohort-ltv-cohort">{cohort_label}</td>'
+            f'<td class="number">{int(round(_num(row.get("new_customers")))):,}</td>'
+            f'<td class="number">{_num(row.get("repeat_rate_pct")):.1f}%</td>'
+            f'<td class="cohort-ltv-trend">{_cohort_ltv_sparkline(trend_values)}</td>'
+            f'<td class="cohort-ltv-first">&euro;{_num(row.get("first_order_ltv")):,.2f}</td>'
+            f"{cells}</tr>"
+        )
+
+    cohort_ltv_header_cells_html = "".join(
+        f'<th class="number">{escape(column)}</th>' for column in cohort_ltv_month_columns
+    )
+    cohort_ltv_rows_html = "".join(_cohort_ltv_row_html(row) for row in cohort_ltv_rows)
+    if cohort_ltv_average:
+        cohort_ltv_rows_html += _cohort_ltv_row_html(cohort_ltv_average, average=True)
+    cohort_ltv_exclusion_note_html = ""
+    if int(_num(cohort_ltv_source.get("excluded_prior_customers"))) > 0:
+        excluded_prior_customers = int(_num(cohort_ltv_source.get("excluded_prior_customers")))
+        cohort_ltv_exclusion_note_html = (
+            f'<p class="muted-note"><span class="lang-en">Excluded {excluded_prior_customers:,} customers acquired before this report history.</span>'
+            f'<span class="lang-sk hidden">Vylucenych {excluded_prior_customers:,} zakaznikov ziskanych pred historiou tohto reportu.</span></p>'
+        )
+    cohort_ltv_section_html = ""
+    if cohort_ltv_rows and cohort_ltv_month_columns:
+        cohort_ltv_section_html = f"""
+                    <div class="panel table-card cohort-ltv-card" style="margin-top:18px;">
+                        <div class="card-head">
+                            <div>
+                                <h3><span class="lang-en">Cohort LTV</span><span class="lang-sk hidden">Kohortne LTV</span></h3>
+                                <p><span class="lang-en">Cumulative net revenue per acquired customer. M0 is the acquisition calendar month; R-% is the observed repeat-purchase rate.</span><span class="lang-sk hidden">Kumulativna cista trzba na ziskaneho zakaznika. M0 je kalendarny mesiac akvizicie; R-% je pozorovana miera opakovaneho nakupu.</span></p>
+                            </div>
+                        </div>
+                        {cohort_ltv_exclusion_note_html}
+                        <div class="cohort-ltv-scroll" role="region" aria-label="Cohort lifetime value matrix" tabindex="0">
+                            <table class="cohort-ltv-table">
+                                <thead><tr>
+                                    <th><span class="lang-en">Cohort</span><span class="lang-sk hidden">Kohorta</span></th>
+                                    <th class="number"><span class="lang-en">New</span><span class="lang-sk hidden">Novi</span></th>
+                                    <th class="number">R-%</th>
+                                    <th><span class="lang-en">Trend</span><span class="lang-sk hidden">Trend</span></th>
+                                    <th class="number"><span class="lang-en">First order</span><span class="lang-sk hidden">Prva objednavka</span></th>
+                                    {cohort_ltv_header_cells_html}
+                                </tr></thead>
+                                <tbody>{cohort_ltv_rows_html}</tbody>
+                            </table>
+                        </div>
+                    </div>
+        """
+
     order_frequency_rows_html = "".join(
         f"<tr><td>{escape(str(row.get('frequency') or '-'))}</td><td>{int(round(_num(row.get('customer_count'))))}</td><td>{int(round(_num(row.get('total_orders'))))}</td><td>{_num(row.get('customer_pct')):.1f}%</td><td>{_num(row.get('orders_pct')):.1f}%</td></tr>"
         for row in cohort_order_frequency_rows
@@ -3977,6 +4126,24 @@ def generate_modern_dashboard(
         .kpi-sparkline svg {{ display:block; width: 100%; height: 44px; overflow: visible; }}
         .chart-card, .table-card, .health-card {{ padding: 20px; }}
         .table-card {{ overflow-x:auto; }}
+        .cohort-ltv-card {{ overflow:hidden; }}
+        .cohort-ltv-scroll {{ width:100%; overflow:auto; border:1px solid var(--line); border-radius:18px; background:#fff; }}
+        .cohort-ltv-scroll:focus {{ outline:3px solid rgba(71,102,255,.22); outline-offset:2px; }}
+        .cohort-ltv-table {{ width:max-content; min-width:100%; font-variant-numeric:tabular-nums; }}
+        .cohort-ltv-table th, .cohort-ltv-table td {{ min-width:82px; padding:12px 10px; text-align:center; white-space:nowrap; }}
+        .cohort-ltv-table th {{ background:#fffdfa; }}
+        .cohort-ltv-table th:first-child, .cohort-ltv-table td:first-child {{ position:sticky; left:0; min-width:92px; text-align:left; z-index:2; background:#fff; box-shadow:8px 0 16px rgba(36,31,25,.05); }}
+        .cohort-ltv-table thead th:first-child {{ z-index:3; background:#fffdfa; }}
+        .cohort-ltv-table .cohort-ltv-trend {{ min-width:108px; }}
+        .cohort-ltv-table .cohort-ltv-first {{ min-width:108px; font-weight:800; }}
+        .cohort-ltv-value {{ border:2px solid #fff; font-weight:850; }}
+        .cohort-ltv-empty {{ color:#b8afa5; background:repeating-linear-gradient(135deg, #fbf8f3, #fbf8f3 6px, #f5f0e9 6px, #f5f0e9 12px); }}
+        .cohort-ltv-average td {{ border-top:2px solid rgba(71,102,255,.32); font-weight:900; }}
+        .cohort-ltv-average td:first-child {{ background:#f3f5ff; }}
+        .cohort-ltv-sparkline {{ display:block; width:88px; height:28px; margin:0 auto; overflow:visible; }}
+        .cohort-ltv-sparkline polyline {{ fill:none; stroke:#4766ff; stroke-width:2.6; stroke-linecap:round; stroke-linejoin:round; }}
+        .cohort-ltv-sparkline circle {{ fill:#4766ff; }}
+        .cohort-ltv-empty-mark {{ color:#b8afa5; }}
         .card-head {{ display:flex; justify-content:space-between; gap:12px; align-items:start; margin-bottom: 16px; }}
         .card-head h3 {{ margin:0; font-size:18px; }}
         .card-head p {{ margin: 6px 0 0; color: var(--muted); font-size: 13px; line-height: 1.5; }}
@@ -4511,6 +4678,7 @@ def generate_modern_dashboard(
                         </div>
                     </div>
                     {sample_funnel_section_html}
+                    {cohort_ltv_section_html}
                     <div class="grid-2">
                         <div class="panel chart-card">
                             <div class="card-head"><div><h3><span class="lang-en">Refill cohort timing</span><span class="lang-sk hidden">Casovanie refill kohort</span></h3><p><span class="lang-en">Second-order refill speed by first-order entry bucket so refill timing is measured by cohort, not only global repeat rate.</span><span class="lang-sk hidden">Rychlost druhej objednavky podla vstupneho bucketu prvej objednavky, aby sa refill meral kohortne a nie len globalnym repeat rate.</span></p></div></div>

--- a/export_orders.py
+++ b/export_orders.py
@@ -7658,6 +7658,164 @@ class BizniWebExporter:
         )
         return result
 
+    def _build_monthly_cohort_ltv(self, df: pd.DataFrame, revenue_col: str) -> dict:
+        """Build cumulative monthly revenue LTV for acquisition cohorts.
+
+        M0 is the acquisition calendar month, M1 the following calendar month,
+        and so on. Values are cumulative net revenue divided by the original
+        number of customers in the cohort. Customers whose known first purchase
+        predates the visible dataframe are excluded because their earlier
+        revenue is unavailable in the current report slice.
+        """
+        base_columns = [
+            "cohort",
+            "new_customers",
+            "repeat_customers",
+            "repeat_rate_pct",
+            "first_order_ltv",
+            "observed_months",
+        ]
+        empty_result = {
+            "available": False,
+            "revenue_basis": revenue_col,
+            "month_columns": [],
+            "rows": pd.DataFrame(columns=base_columns),
+            "average": {},
+            "analysis_end_month": None,
+            "excluded_prior_customers": 0,
+        }
+        required_columns = {"order_num", "customer_email", "purchase_date", revenue_col}
+        if df.empty or not required_columns.issubset(df.columns):
+            return empty_result
+
+        selected_columns = ["order_num", "customer_email", "purchase_date", revenue_col]
+        if "customer_first_purchase_date" in df.columns:
+            selected_columns.append("customer_first_purchase_date")
+
+        orders = df[selected_columns].drop_duplicates(subset=["order_num"]).copy()
+        orders["customer_email"] = orders["customer_email"].fillna("").astype(str).str.strip().str.lower()
+        orders["purchase_datetime"] = pd.to_datetime(orders["purchase_date"], errors="coerce")
+        orders["order_revenue"] = pd.to_numeric(orders[revenue_col], errors="coerce").fillna(0.0)
+        orders = orders[
+            orders["customer_email"].ne("")
+            & orders["customer_email"].ne("nan")
+            & orders["purchase_datetime"].notna()
+        ].copy()
+        if orders.empty:
+            return empty_result
+
+        orders = orders.sort_values(["customer_email", "purchase_datetime", "order_num"]).reset_index(drop=True)
+        visible_first = orders.groupby("customer_email")["purchase_datetime"].transform("min")
+        if "customer_first_purchase_date" in orders.columns:
+            known_first = pd.to_datetime(orders["customer_first_purchase_date"], errors="coerce")
+            known_first = known_first.fillna(visible_first)
+        else:
+            known_first = visible_first
+        orders["first_order_datetime"] = known_first
+
+        customer_start = orders.groupby("customer_email", as_index=False).agg(
+            visible_first=("purchase_datetime", "min"),
+            known_first=("first_order_datetime", "min"),
+        )
+        customer_start["eligible"] = customer_start["visible_first"].eq(customer_start["known_first"])
+        eligible_customers = customer_start.loc[customer_start["eligible"], "customer_email"]
+        excluded_prior_customers = int((~customer_start["eligible"]).sum())
+        orders = orders[orders["customer_email"].isin(eligible_customers)].copy()
+        if orders.empty:
+            result = dict(empty_result)
+            result["excluded_prior_customers"] = excluded_prior_customers
+            return result
+
+        orders["customer_order_num"] = orders.groupby("customer_email").cumcount() + 1
+        orders["cohort_period"] = orders["first_order_datetime"].dt.to_period("M")
+        orders["order_period"] = orders["purchase_datetime"].dt.to_period("M")
+        orders["month_index"] = orders["order_period"].map(lambda value: value.ordinal) - orders[
+            "cohort_period"
+        ].map(lambda value: value.ordinal)
+        orders = orders[orders["month_index"] >= 0].copy()
+        if orders.empty:
+            result = dict(empty_result)
+            result["excluded_prior_customers"] = excluded_prior_customers
+            return result
+
+        analysis_end_period = orders["order_period"].max()
+        cohort_rows = []
+        max_observed_month = 0
+        for cohort_period, cohort_orders in orders.groupby("cohort_period", sort=True):
+            cohort_customers = int(cohort_orders["customer_email"].nunique())
+            if cohort_customers <= 0:
+                continue
+
+            customer_order_counts = cohort_orders.groupby("customer_email").size()
+            repeat_customers = int((customer_order_counts >= 2).sum())
+            observed_months = int(analysis_end_period.ordinal - cohort_period.ordinal)
+            max_observed_month = max(max_observed_month, observed_months)
+
+            first_order_revenue = float(
+                cohort_orders.loc[cohort_orders["customer_order_num"] == 1, "order_revenue"].sum()
+            )
+            revenue_by_month = cohort_orders.groupby("month_index")["order_revenue"].sum().to_dict()
+            row = {
+                "cohort": str(cohort_period),
+                "new_customers": cohort_customers,
+                "repeat_customers": repeat_customers,
+                "repeat_rate_pct": round(repeat_customers / cohort_customers * 100, 1),
+                "first_order_ltv": round(first_order_revenue / cohort_customers, 2),
+                "observed_months": observed_months,
+            }
+            cumulative_revenue = 0.0
+            for month_index in range(observed_months + 1):
+                cumulative_revenue += float(revenue_by_month.get(month_index, 0.0))
+                row[f"M{month_index}"] = round(cumulative_revenue / cohort_customers, 2)
+            cohort_rows.append(row)
+
+        if not cohort_rows:
+            result = dict(empty_result)
+            result["excluded_prior_customers"] = excluded_prior_customers
+            return result
+
+        month_columns = [f"M{month_index}" for month_index in range(max_observed_month + 1)]
+        cohort_frame = pd.DataFrame(cohort_rows)
+        for month_column in month_columns:
+            if month_column not in cohort_frame.columns:
+                cohort_frame[month_column] = np.nan
+        cohort_frame = cohort_frame[base_columns + month_columns]
+
+        total_customers = int(cohort_frame["new_customers"].sum())
+        average_row = {
+            "cohort": "Average",
+            "new_customers": int(round(float(cohort_frame["new_customers"].mean()))),
+            "repeat_customers": int(cohort_frame["repeat_customers"].sum()),
+            "repeat_rate_pct": round(
+                float(cohort_frame["repeat_customers"].sum()) / total_customers * 100,
+                1,
+            ) if total_customers > 0 else 0.0,
+            "first_order_ltv": round(
+                float((cohort_frame["first_order_ltv"] * cohort_frame["new_customers"]).sum())
+                / total_customers,
+                2,
+            ) if total_customers > 0 else 0.0,
+            "observed_months": max_observed_month,
+        }
+        for month_column in month_columns:
+            mature_rows = cohort_frame[cohort_frame[month_column].notna()]
+            mature_customers = int(mature_rows["new_customers"].sum())
+            average_row[month_column] = round(
+                float((mature_rows[month_column] * mature_rows["new_customers"]).sum())
+                / mature_customers,
+                2,
+            ) if mature_customers > 0 else np.nan
+
+        return {
+            "available": True,
+            "revenue_basis": revenue_col,
+            "month_columns": month_columns,
+            "rows": cohort_frame,
+            "average": average_row,
+            "analysis_end_month": str(analysis_end_period),
+            "excluded_prior_customers": excluded_prior_customers,
+        }
+
     def analyze_repeat_purchase_cohorts(self, df: pd.DataFrame) -> dict:
         """
         Analyze repeat purchase cohorts with detailed metrics:
@@ -7703,6 +7861,10 @@ class BizniWebExporter:
         orders_df['days_since_prev_order'] = (orders_df['purchase_datetime'] - orders_df['prev_order_date']).dt.days
 
         result = {}
+
+        # === MONTHLY CUMULATIVE COHORT LTV ===
+        print("  Calculating monthly cumulative cohort LTV...")
+        result["cohort_ltv"] = self._build_monthly_cohort_ltv(df, revenue_col)
 
         # === 1. TIME TO NTH ORDER ANALYSIS ===
         print("  Calculating time to nth order...")
@@ -7969,6 +8131,14 @@ class BizniWebExporter:
         if not result['cohort_retention'].empty:
             result['cohort_retention'].to_csv(cohort_filename, index=False, encoding='utf-8-sig')
             print(f"Cohort analysis saved: {cohort_filename}")
+
+        cohort_ltv_rows = result.get("cohort_ltv", {}).get("rows")
+        if isinstance(cohort_ltv_rows, pd.DataFrame) and not cohort_ltv_rows.empty:
+            cohort_ltv_filename = self.output_path(
+                f"cohort_ltv_{df['purchase_datetime'].min().strftime('%Y%m%d')}-{df['purchase_datetime'].max().strftime('%Y%m%d')}.csv"
+            )
+            cohort_ltv_rows.to_csv(cohort_ltv_filename, index=False, encoding="utf-8-sig")
+            print(f"Cohort LTV saved: {cohort_ltv_filename}")
 
         print(f"  Cohort analysis complete:")
         print(f"    - Total customers: {result['summary']['total_customers']}")

--- a/tests/test_dashboard_modern.py
+++ b/tests/test_dashboard_modern.py
@@ -38,6 +38,94 @@ class DashboardModernTests(unittest.TestCase):
         self.assertEqual([80.0, 0.0, 120.0, 0.0], payload["clicks"])
         self.assertEqual([3924.0, 0.0, 5630.0, 0.0], payload["impressions"])
 
+    def test_cohort_ltv_heatmap_is_visible_and_preserves_null_future_months(self) -> None:
+        date_agg = pd.DataFrame(
+            [
+                {
+                    "date": pd.Timestamp("2026-02-28"),
+                    "total_revenue": 300.0,
+                    "net_profit": 80.0,
+                    "contribution_profit": 100.0,
+                    "unique_orders": 3,
+                    "fb_ads_spend": 20.0,
+                    "google_ads_spend": 5.0,
+                    "total_items": 3,
+                    "product_expense": 120.0,
+                    "total_cost": 220.0,
+                    "pre_ad_contribution_profit": 125.0,
+                }
+            ]
+        )
+        items_agg = pd.DataFrame(
+            [{"item_label": "Test", "total_quantity": 3, "total_revenue": 300.0}]
+        )
+        cohort_rows = pd.DataFrame(
+            [
+                {
+                    "cohort": "2026-01",
+                    "new_customers": 2,
+                    "repeat_customers": 1,
+                    "repeat_rate_pct": 50.0,
+                    "first_order_ltv": 75.0,
+                    "observed_months": 1,
+                    "M0": 85.0,
+                    "M1": 100.0,
+                },
+                {
+                    "cohort": "2026-02",
+                    "new_customers": 1,
+                    "repeat_customers": 0,
+                    "repeat_rate_pct": 0.0,
+                    "first_order_ltv": 80.0,
+                    "observed_months": 0,
+                    "M0": 80.0,
+                    "M1": None,
+                },
+            ]
+        )
+        cohort_average = {
+            "cohort": "Average",
+            "new_customers": 2,
+            "repeat_customers": 1,
+            "repeat_rate_pct": 33.3,
+            "first_order_ltv": 76.67,
+            "observed_months": 1,
+            "M0": 83.33,
+            "M1": 100.0,
+        }
+
+        html = generate_modern_dashboard(
+            date_agg,
+            items_agg,
+            datetime(2026, 1, 1),
+            datetime(2026, 2, 28),
+            report_title="VEVO cohort test",
+            cohort_analysis={
+                "summary": {"total_customers": 3, "repeat_customers": 1, "repeat_rate_pct": 33.3},
+                "cohort_ltv": {
+                    "available": True,
+                    "revenue_basis": "order_revenue_net",
+                    "analysis_end_month": "2026-02",
+                    "excluded_prior_customers": 4,
+                    "month_columns": ["M0", "M1"],
+                    "rows": cohort_rows,
+                    "average": cohort_average,
+                },
+            },
+            source_health={"project": "vevo"},
+        )
+
+        self.assertIn("Cohort LTV", html)
+        self.assertIn("Cumulative net revenue per acquired customer", html)
+        self.assertIn('class="cohort-ltv-value"', html)
+        self.assertIn('class="cohort-ltv-average"', html)
+        self.assertIn("Excluded 4 customers acquired before this report history", html)
+        payload = extract_embedded_dashboard_payload(html)["cohort_ltv"]
+        self.assertEqual(["M0", "M1"], payload["month_columns"])
+        self.assertEqual(100.0, payload["rows"][0]["M1"])
+        self.assertIsNone(payload["rows"][1]["M1"])
+        self.assertEqual(83.33, payload["average"]["M0"])
+
     def test_frame_rows_serializes_nested_country_top_products(self) -> None:
         rows = _frame_rows(
             pd.DataFrame(

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -1859,6 +1859,110 @@ class ReportingCalculationFixTests(unittest.TestCase):
         self.assertTrue(pd.isna(weekly.iloc[0]["cumulative_avg_cac"]))
         self.assertEqual(16.0, weekly.iloc[1]["cumulative_avg_cac"])
 
+    def test_monthly_cohort_ltv_is_cumulative_and_customer_weighted(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        frame = pd.DataFrame(
+            [
+                {
+                    "order_num": "A-1",
+                    "customer_email": "a@example.com",
+                    "purchase_date": "2026-01-05 10:00:00",
+                    "customer_first_purchase_date": "2026-01-05 10:00:00",
+                    "order_revenue_net": 100.0,
+                },
+                {
+                    "order_num": "A-2",
+                    "customer_email": "a@example.com",
+                    "purchase_date": "2026-01-20 10:00:00",
+                    "customer_first_purchase_date": "2026-01-05 10:00:00",
+                    "order_revenue_net": 20.0,
+                },
+                {
+                    "order_num": "A-3",
+                    "customer_email": "a@example.com",
+                    "purchase_date": "2026-02-05 10:00:00",
+                    "customer_first_purchase_date": "2026-01-05 10:00:00",
+                    "order_revenue_net": 30.0,
+                },
+                {
+                    "order_num": "B-1",
+                    "customer_email": "b@example.com",
+                    "purchase_date": "2026-01-10 10:00:00",
+                    "customer_first_purchase_date": "2026-01-10 10:00:00",
+                    "order_revenue_net": 50.0,
+                },
+                {
+                    "order_num": "B-2",
+                    "customer_email": "b@example.com",
+                    "purchase_date": "2026-03-01 10:00:00",
+                    "customer_first_purchase_date": "2026-01-10 10:00:00",
+                    "order_revenue_net": 50.0,
+                },
+                {
+                    "order_num": "C-1",
+                    "customer_email": "c@example.com",
+                    "purchase_date": "2026-02-02 10:00:00",
+                    "customer_first_purchase_date": "2026-02-02 10:00:00",
+                    "order_revenue_net": 80.0,
+                },
+                {
+                    "order_num": "C-2",
+                    "customer_email": "c@example.com",
+                    "purchase_date": "2026-03-02 10:00:00",
+                    "customer_first_purchase_date": "2026-02-02 10:00:00",
+                    "order_revenue_net": 20.0,
+                },
+            ]
+        )
+
+        result = exporter._build_monthly_cohort_ltv(frame, "order_revenue_net")
+
+        self.assertTrue(result["available"])
+        self.assertEqual(["M0", "M1", "M2"], result["month_columns"])
+        january = result["rows"].iloc[0]
+        february = result["rows"].iloc[1]
+        self.assertEqual(2, january["new_customers"])
+        self.assertEqual(100.0, january["repeat_rate_pct"])
+        self.assertEqual(75.0, january["first_order_ltv"])
+        self.assertEqual(85.0, january["M0"])
+        self.assertEqual(100.0, january["M1"])
+        self.assertEqual(125.0, january["M2"])
+        self.assertEqual(100.0, february["M1"])
+        self.assertTrue(pd.isna(february["M2"]))
+        self.assertEqual(76.67, result["average"]["first_order_ltv"])
+        self.assertEqual(83.33, result["average"]["M0"])
+        self.assertEqual(100.0, result["average"]["M1"])
+        self.assertEqual(125.0, result["average"]["M2"])
+
+    def test_monthly_cohort_ltv_excludes_customers_acquired_before_visible_history(self) -> None:
+        exporter = make_exporter(project_name="vevo")
+        frame = pd.DataFrame(
+            [
+                {
+                    "order_num": "OLD-2",
+                    "customer_email": "old@example.com",
+                    "purchase_date": "2026-01-12 10:00:00",
+                    "customer_first_purchase_date": "2025-12-01 10:00:00",
+                    "order_revenue_net": 90.0,
+                },
+                {
+                    "order_num": "NEW-1",
+                    "customer_email": "new@example.com",
+                    "purchase_date": "2026-01-15 10:00:00",
+                    "customer_first_purchase_date": "2026-01-15 10:00:00",
+                    "order_revenue_net": 70.0,
+                },
+            ]
+        )
+
+        result = exporter._build_monthly_cohort_ltv(frame, "order_revenue_net")
+
+        self.assertTrue(result["available"])
+        self.assertEqual(1, result["excluded_prior_customers"])
+        self.assertEqual(1, len(result["rows"]))
+        self.assertEqual(1, result["rows"].iloc[0]["new_customers"])
+        self.assertEqual(70.0, result["rows"].iloc[0]["M0"])
+
     def test_advanced_cohort_cac_uses_full_fb_google_calendars(self) -> None:
         exporter = make_exporter(project_name="vevo")
         frame = pd.DataFrame(


### PR DESCRIPTION
## What changed

- calculates cumulative monthly net-revenue LTV per acquired customer for M0–Mn
- adds cohort size, observed repeat rate, first-order LTV, trend sparklines, and customer-weighted averages
- excludes customers acquired before the visible history so rolling reports cannot create false acquisition cohorts
- renders a responsive heatmap in the modern Customers dashboard and preserves future unobserved months as blank
- records the implementation state and next release step in `PROJECT_STATE.md`

## Why

VEVO reporting already had customer identity, first-purchase dates, repeat behavior, and cohort unit economics, but it did not expose the month-by-month cumulative Cohort LTV matrix shown in the requested reference.

## Validation

- `python scripts/reporting_qa_smoke.py`
- CI-equivalent local unit suite: 271 tests passed
- focused Cohort LTV calculation and dashboard payload/render regressions
- `python -m py_compile dashboard_modern.py export_orders.py`
- `git diff --check`

## Release plan

After merge, wait for the exact ECR image build, confirm the VEVO Fargate hard-gate identity and localhost marker, run a no-email full-history production reporting smoke, and visually verify the generated report.
