### PR TITLE
Handle VEVO damage compensation revenue order

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -69,6 +69,7 @@ Bootstrap entrypoints:
   - implementation merged through PR `#263` as `11a45bea4421b2d828aa7b53a074f4833bc00004`; exact image build `31712963641` published digest `sha256:865e6500725d93cc260eec9cff61a7821ba94825ae68a964c13dcf81c5e9dc11`
   - protected generation run `31713205621` stopped before localhost marker validation or any production promotion because BiznisWeb returns an internal `price_elements` error for order `2602007112`
   - read-only VEVO administration verification identified that exact order as a shipped `21.15 EUR` net damage-compensation order for Slovak Parcel Service with no delivery or payment method, so a narrow audited realized-revenue override is being added without weakening fail-closed handling for any other order
+  - override verification passes: `282` unit tests, reporting QA smoke, Python compile, both project settings JSON parses, and `git diff --check`
   - Next exact step: merge the exact override through PR, rebuild the immutable image, rerun protected VEVO generation, validate localhost marker/QA, promote the artifact and scheduler, then visually verify the live Cohort LTV matrix
 
 - ROY large bear-set product identity and missing-cost QA fix are merged, deployed, and live on `2026-08-11`:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -66,7 +66,10 @@ Bootstrap entrypoints:
   - customers whose known first purchase predates the visible report history are excluded from the matrix so rolling period slices cannot fabricate acquisition cohorts from returning customers
   - the modern customer dashboard now renders a responsive, horizontally scrollable heatmap with a sticky cohort column, `New`, `R-%`, a per-cohort trend sparkline, first-order LTV, cumulative `M0..Mn` values, explicit future-month blanks, and a customer-weighted average row
   - focused and full relevant verification passes: `96` dashboard/reporting-calculation tests, Python compile, payload null-preservation regression, and `git diff --check`
-  - Next exact step: generate a fresh full-history VEVO report, run reporting QA plus visual inspection, and record the exact artifact and cohort totals
+  - implementation merged through PR `#263` as `11a45bea4421b2d828aa7b53a074f4833bc00004`; exact image build `31712963641` published digest `sha256:865e6500725d93cc260eec9cff61a7821ba94825ae68a964c13dcf81c5e9dc11`
+  - protected generation run `31713205621` stopped before localhost marker validation or any production promotion because BiznisWeb returns an internal `price_elements` error for order `2602007112`
+  - read-only VEVO administration verification identified that exact order as a shipped `21.15 EUR` net damage-compensation order for Slovak Parcel Service with no delivery or payment method, so a narrow audited realized-revenue override is being added without weakening fail-closed handling for any other order
+  - Next exact step: merge the exact override through PR, rebuild the immutable image, rerun protected VEVO generation, validate localhost marker/QA, promote the artifact and scheduler, then visually verify the live Cohort LTV matrix
 
 - ROY large bear-set product identity and missing-cost QA fix are merged, deployed, and live on `2026-08-11`:
   - identity PR `#260` merged as `05d8a1ee69218af1d89d6b3dfb9071e5e8562c3f`; QA-input PR `#261` merged as `dbcd65bfe054cedf16c5e8dc08d2f2be4b40a2bd`

--- a/export_orders.py
+++ b/export_orders.py
@@ -3114,34 +3114,51 @@ class BizniWebExporter:
     def _is_price_elements_error(error: Exception) -> bool:
         return "price_elements" in str(error or "")
 
-    def _resolve_realized_revenue_settings(self) -> Dict[str, Any]:
-        raw = self.project_settings.get("realized_revenue") or {}
-        raw_non_realized_overrides = raw.get(
-            "missing_payment_metadata_non_realized_order_overrides",
-            {},
-        )
-        if raw_non_realized_overrides is None:
-            raw_non_realized_overrides = {}
-        if not isinstance(raw_non_realized_overrides, dict):
+    @staticmethod
+    def _resolve_exact_order_override_reasons(
+        raw_overrides: Any,
+        setting_name: str,
+    ) -> Dict[str, str]:
+        if raw_overrides is None:
+            raw_overrides = {}
+        if not isinstance(raw_overrides, dict):
             raise ValueError(
-                "realized_revenue.missing_payment_metadata_non_realized_order_overrides "
-                "must be an object mapping exact order numbers to audit reasons"
+                f"realized_revenue.{setting_name} must be an object mapping "
+                "exact order numbers to audit reasons"
             )
-        non_realized_overrides: Dict[str, str] = {}
-        for raw_order_num, raw_reason in raw_non_realized_overrides.items():
+
+        overrides: Dict[str, str] = {}
+        for raw_order_num, raw_reason in raw_overrides.items():
             order_num = str(raw_order_num or "").strip()
             reason = str(raw_reason or "").strip()
             if not order_num or not reason:
                 raise ValueError(
-                    "realized_revenue.missing_payment_metadata_non_realized_order_overrides "
-                    "requires non-empty exact order numbers and audit reasons"
+                    f"realized_revenue.{setting_name} requires non-empty exact "
+                    "order numbers and audit reasons"
                 )
             if any(character in order_num for character in "*?[]{}"):
                 raise ValueError(
-                    "realized_revenue.missing_payment_metadata_non_realized_order_overrides "
-                    "does not allow wildcard order numbers"
+                    f"realized_revenue.{setting_name} does not allow wildcard order numbers"
                 )
-            non_realized_overrides[order_num] = reason
+            overrides[order_num] = reason
+        return overrides
+
+    def _resolve_realized_revenue_settings(self) -> Dict[str, Any]:
+        raw = self.project_settings.get("realized_revenue") or {}
+        non_realized_overrides = self._resolve_exact_order_override_reasons(
+            raw.get("missing_payment_metadata_non_realized_order_overrides", {}),
+            "missing_payment_metadata_non_realized_order_overrides",
+        )
+        realized_overrides = self._resolve_exact_order_override_reasons(
+            raw.get("missing_payment_metadata_realized_order_overrides", {}),
+            "missing_payment_metadata_realized_order_overrides",
+        )
+        conflicting_order_nums = set(non_realized_overrides).intersection(realized_overrides)
+        if conflicting_order_nums:
+            raise ValueError(
+                "realized_revenue missing-payment overrides conflict for exact order numbers: "
+                + ", ".join(sorted(conflicting_order_nums))
+            )
         paid_statuses = self._as_config_list(
             raw.get("paid_statuses"),
             DEFAULT_REALIZED_REVENUE_PAID_STATUSES,
@@ -3197,6 +3214,8 @@ class BizniWebExporter:
             "prepaid_payment_ids": {str(value).strip() for value in prepaid_payment_ids if str(value).strip()},
             "missing_payment_metadata_non_realized_order_overrides": non_realized_overrides,
             "missing_payment_metadata_non_realized_order_nums": set(non_realized_overrides),
+            "missing_payment_metadata_realized_order_overrides": realized_overrides,
+            "missing_payment_metadata_realized_order_nums": set(realized_overrides),
         }
 
     def _is_cod_payment(self, order: Dict[str, Any]) -> bool:
@@ -3229,8 +3248,19 @@ class BizniWebExporter:
             return True, "paid_status"
 
         order_num = str((order or {}).get("order_num") or "").strip()
+        missing_price_elements = not self._has_loaded_price_elements(order)
+        metadata_dependent_status = (
+            status_norm in settings["prepaid_fulfilled_statuses_normalized"]
+            or status_norm in settings["cod_statuses_normalized"]
+        )
         if (
-            not self._has_loaded_price_elements(order)
+            missing_price_elements
+            and metadata_dependent_status
+            and order_num in settings["missing_payment_metadata_realized_order_nums"]
+        ):
+            return True, "configured_missing_payment_metadata_realized"
+        if (
+            missing_price_elements
             and order_num in settings["missing_payment_metadata_non_realized_order_nums"]
         ):
             return False, "configured_missing_payment_metadata_non_realized"

--- a/projects/vevo/settings.json
+++ b/projects/vevo/settings.json
@@ -163,7 +163,10 @@
       "17",
       "18",
       "20"
-    ]
+    ],
+    "missing_payment_metadata_realized_order_overrides": {
+      "2602007112": "Verified in VEVO administration on 2026-08-13: shipped damage-compensation order for Slovak Parcel Service, 21.15 EUR net, intentionally has no delivery or payment method."
+    }
   },
   "excluded_order_statuses": [
     "madfrog stara odoslana"

--- a/tests/test_reporting_calculation_fixes.py
+++ b/tests/test_reporting_calculation_fixes.py
@@ -3022,6 +3022,68 @@ class ReportingCalculationFixTests(unittest.TestCase):
 
         self.assertTrue(exporter._needs_payment_metadata_for_realized_revenue(order))
 
+    def test_vevo_realized_override_is_exact_audited_and_status_bounded(self) -> None:
+        exporter = make_exporter("vevo")
+        fulfilled_status = exporter.realized_revenue_settings["prepaid_fulfilled_statuses"][0]
+        overridden = {
+            "order_num": "2602007112",
+            "status": {"name": fulfilled_status},
+        }
+        another_missing = {
+            "order_num": "2602007113",
+            "status": {"name": fulfilled_status},
+        }
+
+        self.assertEqual(
+            (True, "configured_missing_payment_metadata_realized"),
+            exporter._realized_revenue_decision(overridden),
+        )
+        self.assertFalse(exporter._needs_payment_metadata_for_realized_revenue(overridden))
+        self.assertEqual([overridden], exporter._filter_by_status([overridden], track_excluded=False))
+        self.assertTrue(exporter._needs_payment_metadata_for_realized_revenue(another_missing))
+
+        overridden["status"] = {"name": "Storno"}
+        self.assertEqual(
+            (False, "non_realized_status"),
+            exporter._realized_revenue_decision(overridden),
+        )
+
+        overridden["status"] = {"name": fulfilled_status}
+        overridden["price_elements"] = [price_element("payment", "Dobierkou", "7")]
+        self.assertEqual(
+            (True, "cod_status_and_payment"),
+            exporter._realized_revenue_decision(overridden),
+        )
+
+    def test_vevo_realized_override_skips_only_the_exact_enrichment_candidate(self) -> None:
+        exporter = make_exporter("vevo")
+        fulfilled_status = exporter.realized_revenue_settings["prepaid_fulfilled_statuses"][0]
+        orders = [
+            {
+                "id": "DAMAGE-COMPENSATION",
+                "order_num": "2602007112",
+                "status": {"name": fulfilled_status},
+            },
+            {
+                "id": "OTHER-MISSING",
+                "order_num": "OTHER-MISSING",
+                "status": {"name": fulfilled_status},
+            },
+        ]
+        attempted_order_nums = []
+
+        def fetch_metadata(order):
+            attempted_order_nums.append(order["order_num"])
+            order["price_elements"] = [price_element("payment", "Bankovym prevodom", "6")]
+            return True
+
+        with patch.object(exporter, "_fetch_order_payment_metadata", side_effect=fetch_metadata):
+            exporter._enrich_payment_metadata_for_realized_revenue(orders)
+
+        self.assertEqual(["OTHER-MISSING"], attempted_order_nums)
+        self.assertNotIn("price_elements", orders[0])
+        self.assertIn("price_elements", orders[1])
+
     def test_non_realized_override_configuration_fails_closed(self) -> None:
         invalid_values = [
             [],
@@ -3041,6 +3103,43 @@ class ReportingCalculationFixTests(unittest.TestCase):
                     self.assertRaises(ValueError),
                 ):
                     make_exporter("roy")
+
+    def test_realized_override_configuration_fails_closed(self) -> None:
+        invalid_values = [
+            [],
+            {"": "audit reason"},
+            {"ORDER-1": ""},
+            {"*": "wildcard must not be accepted"},
+        ]
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=invalid_value):
+                settings = {
+                    "realized_revenue": {
+                        "missing_payment_metadata_realized_order_overrides": invalid_value,
+                    }
+                }
+                with (
+                    patch("export_orders.load_project_settings", return_value=settings),
+                    self.assertRaises(ValueError),
+                ):
+                    make_exporter("vevo")
+
+    def test_conflicting_missing_metadata_overrides_fail_closed(self) -> None:
+        settings = {
+            "realized_revenue": {
+                "missing_payment_metadata_realized_order_overrides": {
+                    "ORDER-1": "verified realized",
+                },
+                "missing_payment_metadata_non_realized_order_overrides": {
+                    "ORDER-1": "verified non-realized",
+                },
+            }
+        }
+        with (
+            patch("export_orders.load_project_settings", return_value=settings),
+            self.assertRaisesRegex(ValueError, "conflict.*ORDER-1"),
+        ):
+            make_exporter("vevo")
 
     def test_roy_non_realized_override_skips_only_the_exact_enrichment_candidate(self) -> None:
         exporter = make_exporter("roy")


### PR DESCRIPTION
## Summary

- add a fail-closed, exact-order realized-revenue override with mandatory audit reasons
- classify VEVO order `2602007112` as realized revenue after read-only admin verification identified it as a shipped damage-compensation order with no payment method by design
- preserve payment-metadata enrichment and final guards for every other metadata-dependent order

## Verification

- `python -m unittest` — 282 tests passed
- `python scripts/reporting_qa_smoke.py`
- `python -m py_compile export_orders.py dashboard_modern.py`
- both VEVO and ROY settings parse as JSON
- `git diff --check`

## Operational context

Protected generation run `31713205621` failed before localhost marker validation and before any production promotion because BiznisWeb's `price_elements` resolver fails for this exact legacy compensation order. Production remained unchanged.
