### PR TITLE
Guard SES report attachment size

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -61,6 +61,15 @@ Bootstrap entrypoints:
 
 ## 5) Current Verified State
 
+- ROY daily report / live-dashboard freshness incident fix is in progress (`2026-08-15`):
+  - production incident run `31859338478` reproduced the common failure after a successful export through `2026-08-14`: SES rejected the `10,560,976` byte raw message because its hard limit is `10,485,760` bytes
+  - because the protected Fargate workflow promotes the newly generated S3 artifacts only after the runner exits successfully, the same oversized email failure left both email delivery and the live dashboard stale
+  - hard-gate identity: instance-id `N/A (scheduled ECS/Fargate task)`, private IP `172.31.37.203`, service `roy-daily-report-email`, task `5ae77222ff0d4d0a88c001af839fe196`, task definition `roy-reporting-daily:64`, runtime path `/app`, localhost marker `http://127.0.0.1:8000/marker.json`, image digest `sha256:27f2017d29454a0ed297ac3da8cbc1aa0434ed526be4e773a97691b32a1f5f8b`
+  - the email sender now preflights the exact serialized raw MIME size and transparently ZIP-compresses only the HTML attachment when the message exceeds a conservative `9 MiB` target; it fails locally before the SES API if even the compressed message exceeds the `10 MiB` hard limit
+  - focused regression coverage verifies both the large-report ZIP fallback (including archive contents and final raw size) and unchanged direct HTML delivery for small reports
+  - local verification passed: full `284`-test suite, reporting QA smoke, Python compile, and `git diff --check`
+  - Next exact step: merge through PR, build the immutable image, run the protected ROY deploy/refresh with real email delivery, verify localhost marker + SES MessageId, then verify the live dashboard generation in Chrome
+
 - VEVO monthly Cohort LTV heatmap is deployed and live (`2026-08-13`):
   - reusable cohort analytics now calculate cumulative net revenue LTV per acquired customer for calendar months `M0..Mn`, together with cohort size, observed repeat rate, first-order LTV, and customer-weighted averages
   - customers whose known first purchase predates the visible report history are excluded from the matrix so rolling period slices cannot fabricate acquisition cohorts from returning customers

--- a/daily_report_runner.py
+++ b/daily_report_runner.py
@@ -11,11 +11,13 @@ import argparse
 import calendar
 import csv
 import hashlib
+import io
 import json
 import mimetypes
 import os
 import subprocess
 import sys
+import zipfile
 from datetime import date, datetime, timedelta, timezone
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
@@ -62,6 +64,9 @@ PERIOD_LIVE_ARTIFACT_NAMES = {
     },
 }
 STRICT_LIVE_REPORT_PROJECTS = {"roy", "vevo"}
+SES_RAW_MESSAGE_LIMIT_BYTES = 10 * 1024 * 1024
+# Leave room for small header/body growth and SDK serialization differences.
+SES_RAW_MESSAGE_TARGET_BYTES = 9 * 1024 * 1024
 
 
 def bootstrap_project_from_argv(argv: List[str]) -> str:
@@ -1385,34 +1390,62 @@ def send_email_ses(
     if not destinations:
         raise ValueError("REPORT_EMAIL_TO has no valid recipients")
 
-    msg = MIMEMultipart("mixed")
-    msg["Subject"] = subject
-    msg["From"] = source
-    msg["To"] = ", ".join(destinations)
-    msg["Date"] = formatdate(localtime=True)
-    msg["Message-ID"] = make_msgid(domain="amazonses.com")
-    msg["Reply-To"] = source
+    def build_message(*, compress_html: bool) -> MIMEMultipart:
+        msg = MIMEMultipart("mixed")
+        msg["Subject"] = subject
+        msg["From"] = source
+        msg["To"] = ", ".join(destinations)
+        msg["Date"] = formatdate(localtime=True)
+        msg["Message-ID"] = make_msgid(domain="amazonses.com")
+        msg["Reply-To"] = source
 
-    # Keep a short non-empty body to reduce spam score.
-    msg.attach(MIMEText(body_text, "plain", "utf-8"))
+        # Keep a short non-empty body to reduce spam score.
+        msg.attach(MIMEText(body_text, "plain", "utf-8"))
 
-    def attach_file(path: Path) -> None:
+        attach_file(msg, file_paths["report_html"], compress_html=compress_html)
+        for extra in extra_attachments or []:
+            attach_file(msg, extra, compress_html=False)
+        return msg
+
+    def attach_file(msg: MIMEMultipart, path: Path, *, compress_html: bool) -> None:
         if path.suffix.lower() in {".html", ".htm"}:
-            text = path.read_text(encoding="utf-8", errors="replace")
-            part = MIMEText(text, "html", "utf-8")
+            if compress_html:
+                archive = io.BytesIO()
+                with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as output_zip:
+                    output_zip.writestr(path.name, path.read_bytes())
+                attachment_name = f"{path.name}.zip"
+                part = MIMEApplication(archive.getvalue(), _subtype="zip", Name=attachment_name)
+            else:
+                text = path.read_text(encoding="utf-8", errors="replace")
+                attachment_name = path.name
+                part = MIMEText(text, "html", "utf-8")
         else:
             with path.open("rb") as f:
                 part = MIMEApplication(f.read(), Name=path.name)
-        part["Content-Disposition"] = f'attachment; filename="{path.name}"'
+            attachment_name = path.name
+        part["Content-Disposition"] = f'attachment; filename="{attachment_name}"'
         msg.attach(part)
 
     if not file_paths["report_html"].exists():
         raise FileNotFoundError(f"Missing HTML report attachment: {file_paths['report_html']}")
-    attach_file(file_paths["report_html"])
     for extra in extra_attachments or []:
         if not extra.exists():
             raise FileNotFoundError(f"Missing extra attachment: {extra}")
-        attach_file(extra)
+
+    msg = build_message(compress_html=False)
+    raw_message = msg.as_bytes()
+    if len(raw_message) > SES_RAW_MESSAGE_TARGET_BYTES:
+        msg = build_message(compress_html=True)
+        raw_message = msg.as_bytes()
+        print(
+            "SES email HTML attachment compressed to stay within the raw-message limit: "
+            f"bytes={len(raw_message)} limit={SES_RAW_MESSAGE_LIMIT_BYTES}"
+        )
+    if len(raw_message) > SES_RAW_MESSAGE_LIMIT_BYTES:
+        raise ValueError(
+            "SES raw email remains too large after HTML compression: "
+            f"{len(raw_message)} > {SES_RAW_MESSAGE_LIMIT_BYTES} bytes"
+        )
 
     try:
         import boto3  # type: ignore
@@ -1425,7 +1458,7 @@ def send_email_ses(
         send_args: Dict[str, Any] = {
             "Source": source,
             "Destinations": destinations,
-            "RawMessage": {"Data": msg.as_string()},
+            "RawMessage": {"Data": raw_message},
         }
         if configuration_set:
             send_args["ConfigurationSetName"] = configuration_set

--- a/tests/test_daily_report_email.py
+++ b/tests/test_daily_report_email.py
@@ -1,0 +1,98 @@
+import email
+import os
+import sys
+import tempfile
+import types
+import unittest
+import zipfile
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import daily_report_runner as runner
+
+
+class DailyReportEmailTests(unittest.TestCase):
+    def test_large_html_is_zipped_before_ses_send(self) -> None:
+        sent = {}
+
+        class FakeSes:
+            def send_raw_email(self, **kwargs):
+                sent.update(kwargs)
+                return {"MessageId": "test-message"}
+
+        boto3 = types.ModuleType("boto3")
+        boto3.client = lambda *_args, **_kwargs: FakeSes()
+        botocore = types.ModuleType("botocore")
+        botocore_exceptions = types.ModuleType("botocore.exceptions")
+        botocore_exceptions.BotoCoreError = RuntimeError
+        botocore_exceptions.ClientError = RuntimeError
+        botocore.exceptions = botocore_exceptions
+
+        with tempfile.TemporaryDirectory() as tmp:
+            report = Path(tmp) / "report_latest.html"
+            report.write_text("<html>" + ("report-row" * 900_000) + "</html>", encoding="utf-8")
+            modules = {
+                "boto3": boto3,
+                "botocore": botocore,
+                "botocore.exceptions": botocore_exceptions,
+            }
+            env = {"REPORT_EMAIL_FROM": "reports@example.test", "REPORT_EMAIL_TO": "owner@example.test"}
+            with patch.dict(sys.modules, modules), patch.dict(os.environ, env, clear=False):
+                message_id = runner.send_email_ses(
+                    subject="Daily report",
+                    body_text="Attached report",
+                    file_paths={"report_html": report},
+                    reporting_defaults={"ses_configuration_set": ""},
+                )
+
+        self.assertEqual(message_id, "test-message")
+        raw = sent["RawMessage"]["Data"]
+        self.assertLessEqual(len(raw), runner.SES_RAW_MESSAGE_LIMIT_BYTES)
+        message = email.message_from_bytes(raw)
+        attachments = [part for part in message.walk() if part.get_filename()]
+        self.assertEqual([part.get_filename() for part in attachments], ["report_latest.html.zip"])
+        with zipfile.ZipFile(BytesIO(attachments[0].get_payload(decode=True))) as archive:
+            self.assertEqual(archive.namelist(), ["report_latest.html"])
+            self.assertTrue(archive.read("report_latest.html").startswith(b"<html>"))
+
+    def test_small_html_remains_direct_attachment(self) -> None:
+        sent = {}
+
+        class FakeSes:
+            def send_raw_email(self, **kwargs):
+                sent.update(kwargs)
+                return {"MessageId": "small-message"}
+
+        boto3 = types.ModuleType("boto3")
+        boto3.client = lambda *_args, **_kwargs: FakeSes()
+        botocore = types.ModuleType("botocore")
+        botocore_exceptions = types.ModuleType("botocore.exceptions")
+        botocore_exceptions.BotoCoreError = RuntimeError
+        botocore_exceptions.ClientError = RuntimeError
+        botocore.exceptions = botocore_exceptions
+
+        with tempfile.TemporaryDirectory() as tmp:
+            report = Path(tmp) / "report_latest.html"
+            report.write_text("<html>small</html>", encoding="utf-8")
+            modules = {
+                "boto3": boto3,
+                "botocore": botocore,
+                "botocore.exceptions": botocore_exceptions,
+            }
+            env = {"REPORT_EMAIL_FROM": "reports@example.test", "REPORT_EMAIL_TO": "owner@example.test"}
+            with patch.dict(sys.modules, modules), patch.dict(os.environ, env, clear=False):
+                runner.send_email_ses(
+                    subject="Daily report",
+                    body_text="Attached report",
+                    file_paths={"report_html": report},
+                    reporting_defaults={"ses_configuration_set": ""},
+                )
+
+        message = email.message_from_bytes(sent["RawMessage"]["Data"])
+        attachments = [part for part in message.walk() if part.get_filename()]
+        self.assertEqual([part.get_filename() for part in attachments], ["report_latest.html"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## What changed
- preflight the exact serialized MIME size before calling SES
- ZIP only the HTML attachment when the raw message exceeds a conservative 9 MiB target
- fail locally with an explicit error if the compressed message can still exceed the 10 MiB SES limit
- add regression coverage for both large and small reports
- record the production incident and hard-gate identity in PROJECT_STATE.md

## Root cause
ROY's growing full-history HTML made the raw email 10,560,976 bytes. SES rejects messages above 10,485,760 bytes. The protected reporting pipeline therefore exited before promotion, leaving both the email and live dashboard stale.

## Validation
- `python -m unittest discover -s tests` (284 tests)
- `python scripts/reporting_qa_smoke.py`
- `python -m py_compile daily_report_runner.py`
- `git diff --check`
